### PR TITLE
nix: init at 1.1.1-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Torlink is a torrent finder that lives in your terminal, with zero setup and nothing to configure.";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+
+    let
+      systems = [
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.callPackage ./nix/package.nix { };
+        }
+      );
+      overlays.default = final: prev: {
+        torlink = final.callPackage ./nix/package.nix { };
+      };
+
+    };
+
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,42 @@
+# Flake install
+Add this repo to your ```flake.nix```. The package is built using the unstable channel. You can overwrite this by setting ```inputs.nixpkgs.follows = "nixpkgs"``` (if your default is 26.05).
+
+**The binary is executed as ```torlnk```.**
+
+```nix
+inputs = {
+  ...
+  torlink.url = "github:baairon/torlink";
+  ...
+}
+```
+
+You can install the package in either home.nix or your configuration.nix depending on your preference.
+
+**User**
+```nix
+# home.nix
+{ pkgs, inputs, ... }: 
+
+{
+  home.packages = with pkgs; [
+    ...
+    inputs.torlink.packages.${pkgs.system}.default
+    ...
+  ];
+}
+```
+
+**System**
+```nix
+# configuration.nix
+{ pkgs, inputs, ... }: 
+
+{
+  environment.systemPackages = with pkgs; [
+    ...
+    inputs.torlink.packages.${pkgs.system}.default
+    ...
+  ];
+}
+```

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -5,23 +5,25 @@
   # dependencies
   fetchurl,
   nodejs_22,
+  wl-clipboard,
+  xclip,
 }:
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
-  version = "1.0.0-unstable";
+  version = "1.1.1-unstable";
   __structedAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "baairon";
     repo = "torlink";
-    rev = "69027331b2c8edc77e517034775fae7972b446a0";
-    hash = "sha256-siDwO3KpwPP82/ufGgZxcvkImKezLVKnLpOjPb5XpxM=";
+    rev = "3c5b5597d9ad212b6dab50af5a6e614cdfb82743";
+    hash = "sha256-f4olyyE2QqvVyakV5LvQq2Rm01fNeVox1Mk0VOat/nk=";
   };
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-MjkkbcYLRY2Zc1je7ArVJ1ccSm5KtV95T758H2w6YKo=";
+  npmDepsHash = "sha256-7CCecywWleUE7wobdzwWb4Rff0LmrlHcON1iPeiiFnw=";
   npmFlags = [ "--ignore-scripts" ]; # ignore scripts for ip-set broken pre-install
 
   # node-datachannel binary tarball
@@ -30,10 +32,24 @@ buildNpmPackage (finalAttrs: {
     sha256 = "4092afc9cd594a3326eb1bd823da452b227b742ea8222689b2cea6f7344cf67a";
   };
 
+  # replicate postbuild from package.json
+  postBuild = ''
+    cp scripts/cli-entry.cjs dist/cli.cjs
+    chmod +x dist/cli.cjs
+  '';
+
   # extract node-datachannel tarball
   postInstall = ''
     tar -xzf ${finalAttrs.nodeDatachannelPrebuilt} \
       -C $out/lib/node_modules/torlnk/node_modules/node-datachannel
+      # add wl-copy and xclip to nix readeable path
+      wrapProgram $out/bin/torlnk \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            wl-clipboard
+            xclip
+          ]
+        }
   '';
 
   meta = {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  # dependencies
+  fetchurl,
+  nodejs_22,
+}:
+
+buildNpmPackage (finalAttrs: {
+  pname = "torlink";
+  version = "1.0.0-unstable";
+  __structedAttrs = true;
+  strictDeps = true;
+
+  src = fetchFromGitHub {
+    owner = "baairon";
+    repo = "torlink";
+    rev = "69027331b2c8edc77e517034775fae7972b446a0";
+    hash = "sha256-siDwO3KpwPP82/ufGgZxcvkImKezLVKnLpOjPb5XpxM=";
+  };
+
+  nodejs = nodejs_22;
+  npmDepsHash = "sha256-MjkkbcYLRY2Zc1je7ArVJ1ccSm5KtV95T758H2w6YKo=";
+  npmFlags = [ "--ignore-scripts" ]; # ignore scripts for ip-set broken pre-install
+
+  # node-datachannel binary tarball
+  nodeDatachannelPrebuilt = fetchurl {
+    url = "https://github.com/murat-dogan/node-datachannel/releases/download/v0.32.3/node-datachannel-v0.32.3-napi-v8-linux-x64.tar.gz";
+    sha256 = "4092afc9cd594a3326eb1bd823da452b227b742ea8222689b2cea6f7344cf67a";
+  };
+
+  # extract node-datachannel tarball
+  postInstall = ''
+    tar -xzf ${finalAttrs.nodeDatachannelPrebuilt} \
+      -C $out/lib/node_modules/torlnk/node_modules/node-datachannel
+  '';
+
+  meta = {
+    description = "Torlink is a torrent finder that lives in your terminal, with zero setup and nothing to configure.";
+    homepage = "https://github.com/baairon/torlink";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ ghastrum ];
+    mainProgram = "torlnk";
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
In-app testing:
- Searches
- Downloads
- Seeds
- Creates ~/Downloads/torlink directory
- c114c32 Selecting a new download folder works
- 05236fe All navigation and keys works (couldn't test retry failed)

Nix:
- Ignore scripts flag for broken ip-set preinstall
- Download and extract nodeDatachannel to circumvent sandboxed build environment
- Replicated postbuild from package.json so npm install can execute the index.js
- Wrapped wl-clipboard and xclip so nix has a readeable path