### PR TITLE
fix: show clear error when Node.js is too old instead of a parse crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "torlink",
+  "name": "torlnk",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "torlink",
+      "name": "torlnk",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -16,7 +16,7 @@
         "webtorrent": "^2.4.1"
       },
       "bin": {
-        "torlink": "dist/index.js"
+        "torlnk": "dist/cli.cjs"
       },
       "devDependencies": {
         "@types/node": "^25.9.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A sleek, zero-setup torrent finder and downloader that lives right in your terminal.",
   "type": "module",
   "bin": {
-    "torlnk": "./dist/index.js"
+    "torlnk": "./dist/cli.cjs"
   },
   "files": [
     "dist",
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "tsx src/index.tsx",
     "build": "tsup",
+    "postbuild": "cp scripts/cli-entry.cjs dist/cli.cjs && chmod +x dist/cli.cjs",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/cli-entry.cjs
+++ b/scripts/cli-entry.cjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict';
+
+var major = parseInt(process.versions.node.split('.')[0], 10);
+if (major < 22) {
+  process.stderr.write(
+    '\ntorlnk requires Node.js v22 or later.\n' +
+    'You are running v' + process.versions.node + '.\n\n' +
+    'Upgrade:  https://nodejs.org\n' +
+    'With nvm: nvm install 22 && nvm use 22\n\n'
+  );
+  process.exit(1);
+}
+
+import('./index.js').catch(function (err) {
+  process.stderr.write(String((err && err.message) || err) + '\n');
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

When users run `npx torlnk` on Node.js older than v22, npm installs the package (with `EBADENGINE` warnings) but then crashes with a cryptic `SyntaxError: Unexpected token '.'`. This happens because the bundled ESM file uses optional chaining (`?.`) and other modern syntax that Node 12/14/16 cannot even *parse* — so any runtime version check inside the bundle is unreachable.

## Fix

Added a tiny CommonJS wrapper (`dist/cli.cjs`) as the new `bin` entry point. It uses only ES5-compatible syntax, checks the Node version, and exits with a clear message before the main bundle is ever loaded:

```
torlnk requires Node.js v22 or later.
You are running v12.22.9.

Upgrade:  https://nodejs.org
With nvm: nvm install 22 && nvm use 22
```

If the version is satisfied, it `import()`s `./index.js` normally (dynamic `import()` works in CJS files from Node 12 onward).

## Changes

- `scripts/cli-entry.cjs` — new CJS version-gate wrapper
- `package.json` — `bin.torlnk` now points to `./dist/cli.cjs`; `postbuild` copies the wrapper into `dist/` after each build

All 37 existing tests pass.