### PR TITLE
fix: show sort param during search phase

### DIFF
--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -250,10 +250,12 @@ export function Results() {
     return codes.length ? ` (${codes.join(", ")})` : "";
   };
 
+  const sortNote = sort === "none" ? "" : `  ${ICON.dot} sort: ${sortLabel(sort)}`;
+
   const status = () => {
     if (search.loading) {
       if (results.length > 0)
-        return <Text dimColor>{`searching… ${search.done}/${search.total} sources`}</Text>;
+        return <Text dimColor>{`searching… ${search.done}/${search.total} sources${sortNote}`}</Text>;
       return (
         <Spinner label={`${browsing ? "Loading" : "Searching"} ${search.done}/${search.total} sources`} />
       );
@@ -288,7 +290,6 @@ export function Results() {
     const head = browsing
       ? "newest across all sources"
       : `${results.length} result${results.length === 1 ? "" : "s"}`;
-    const sortNote = sort === "none" ? "" : `  ${ICON.dot} sort: ${sortLabel(sort)}`;
     return <Text dimColor>{`${head}${note}${sortNote}`}</Text>;
   };
 


### PR DESCRIPTION
## Summary

When a torrent search is still in its searching phase, you can already apply a sort to the partial results — but the status line only showed `searching… X/Y sources` and dropped the active sort parameter. Once the search finished, the sort note reappeared, which made it look like the sort had been lost mid-search.

This appends the existing `sortNote` to the searching-phase status line so the active sort stays visible throughout.

## Changes

- Hoisted `sortNote` above `status()` in `Results.tsx` so it can be reused.
- Appended `sortNote` to the `searching… X/Y sources` status string.

## Testing

- `tsc --noEmit` passes with no errors.