### PR TITLE
fix: make postbuild cross-platform so the CLI builds on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "tsx src/index.tsx",
     "build": "tsup",
-    "postbuild": "cp scripts/cli-entry.cjs dist/cli.cjs && chmod +x dist/cli.cjs",
+    "postbuild": "node scripts/postbuild.cjs",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/postbuild.cjs
+++ b/scripts/postbuild.cjs
@@ -1,0 +1,20 @@
+'use strict';
+
+const { chmodSync, copyFileSync } = require('node:fs');
+const { resolve } = require('node:path');
+
+const root = resolve(__dirname, '..');
+const src = resolve(root, 'scripts/cli-entry.cjs');
+const dest = resolve(root, 'dist/cli.cjs');
+
+copyFileSync(src, dest);
+
+// On Windows chmod is effectively a no-op, and npm re-applies bin permissions on install anyway, so a failure
+// here shouldn't fail the build, but warn rather than swallow the error.
+try {
+  chmodSync(dest, 0o755);
+} catch (err) {
+  console.warn('postbuild: could not set executable bit on dist/cli.cjs:', err.message);
+}
+
+console.log('postbuild: wrote dist/cli.cjs');


### PR DESCRIPTION
## What and why

`npm run build` was failing on windows before it could make the CLI binary.
The old postbuild script relied on cp and chmod, meaning that after tsup finished it would error out with "cp is not recognized as an internal or external command". This resulted in `dist/cli.js` never getting created, and 'npx torlnk`  couldn't find anything to run.

This replaces the shell one liner for `scripts/postbuild.cjs` a cross-platform node script that does the same copy and sets the executable bit. Producing the exact same result cross platform (windows,macos and linux)

It follows the same pattern previously used in `scripts/cli-entry.cjs`, but now properly handling OS differences instead of assuming that the Unix shell is always there.

## Checklist
- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [ ] New logic has a test (vitest; mock node built-ins for platform code) - I haven't added tests as it's a postbuild script and not runtime code
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a, no key added
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a, no Store field
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`fix:`)