### PR TITLE
[fix] Fix pequeño

### DIFF
--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -70,7 +70,7 @@ export class TorrentEngine {
     try {
       torrent = client.add(source, opts);
     } catch (e) {
-      handlers.onError?.(message(e));
+      handlers.onError?.(message(e) + ' - Failed to add the torrent source. Please check the source URL or format.');
       return;
     }
     this.torrents.set(id, torrent);


### PR DESCRIPTION
Se corrige un mensaje de error que no proporciona información útil al usuario en caso de fallo al añadir un torrent.

---
_Generado con GitHub Trending Agent para baairon/torlink._