### PR TITLE
feat(download): implement selective file download for multi-file torrents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 dist/
 .DS_Store
 package-lock.json
+bun.lock
+.bun/

--- a/preview/browse.svg
+++ b/preview/browse.svg
@@ -4,122 +4,122 @@
   <rect x="0.5" y="0.5" width="831" height="539" rx="14" fill="none" stroke="#2d2b31" stroke-width="1"/>
   <text x="416" y="23" text-anchor="middle" font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="13" fill="#8a8a8a">torlink</text>
   <g font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="16" fill="#ddd8ea">
-    <text x="99.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#5ae87a" font-weight="600">𐓏</text>
-    <rect x="51.2" y="90" width="9.6" height="11" fill="#faf5ff"/>
-    <rect x="60.8" y="90" width="9.6" height="22" fill="#f5ecff"/>
-    <rect x="70.4" y="90" width="9.6" height="11" fill="#f0e2ff"/>
-    <rect x="89.6" y="90" width="9.6" height="22" fill="#e6cffe"/>
-    <rect x="99.2" y="90" width="9.6" height="11" fill="#e1c5fe"/>
-    <rect x="108.8" y="90" width="9.6" height="22" fill="#dcbcfe"/>
-    <rect x="128" y="90" width="9.6" height="22" fill="#d3b0fe"/>
-    <rect x="137.6" y="90" width="9.6" height="11" fill="#d0adfd"/>
-    <rect x="147.2" y="90" width="9.6" height="22" fill="#ccaafd"/>
-    <rect x="166.4" y="90" width="9.6" height="22" fill="#c4a4fc"/>
-    <rect x="204.8" y="90" width="9.6" height="22" fill="#b597fb"/>
-    <rect x="224" y="90" width="9.6" height="22" fill="#ae91fb"/>
-    <rect x="233.6" y="101" width="9.6" height="11" fill="#aa8efa"/>
-    <rect x="252.8" y="90" width="9.6" height="22" fill="#a487f7"/>
-    <rect x="272" y="90" width="9.6" height="22" fill="#9e81f3"/>
-    <rect x="281.6" y="101" width="9.6" height="11" fill="#9b7ef0"/>
-    <rect x="291.2" y="90" width="9.6" height="11" fill="#997bee"/>
-    <rect x="60.8" y="112" width="9.6" height="22" fill="#9375e9"/>
-    <rect x="89.6" y="112" width="9.6" height="22" fill="#8b6ce2"/>
-    <rect x="99.2" y="123" width="9.6" height="11" fill="#8869e0"/>
-    <rect x="108.8" y="112" width="9.6" height="22" fill="#8566de"/>
-    <rect x="128" y="112" width="9.6" height="22" fill="#8060d9"/>
-    <rect x="137.6" y="112" width="9.6" height="11" fill="#7d5dd7"/>
-    <rect x="147.2" y="123" width="9.6" height="11" fill="#7a5bd3"/>
-    <rect x="166.4" y="112" width="9.6" height="22" fill="#7456c9"/>
-    <rect x="176" y="123" width="9.6" height="11" fill="#7154c4"/>
-    <rect x="185.6" y="123" width="9.6" height="11" fill="#6e52c0"/>
-    <rect x="204.8" y="112" width="9.6" height="22" fill="#684eb6"/>
-    <rect x="224" y="112" width="9.6" height="22" fill="#6249ac"/>
-    <rect x="243.2" y="112" width="9.6" height="11" fill="#5b45a2"/>
-    <rect x="252.8" y="112" width="9.6" height="22" fill="#58439d"/>
-    <rect x="272" y="112" width="9.6" height="22" fill="#523e94"/>
-    <rect x="291.2" y="112" width="9.6" height="22" fill="#4c3a8a"/>
-    <text x="41.6" y="150" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577">──────────────────────────────────────────────────────────────────────────────</text>
-    <rect x="41.6" y="178" width="4.8" height="22" fill="#6b6577"/>
-    <text x="60.8" y="194" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">All</text>
-    <text x="204.8" y="194" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577">╭─</text>
-    <text x="233.6" y="194" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577" font-weight="600">Search</text>
-    <text x="300.8" y="194" textLength="489.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577">──────────────────────────────────────────────────╮</text>
+    <text x="99.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#87ff87" font-weight="600">𐓏</text>
+    <rect x="51.2" y="90" width="9.6" height="11" fill="#ffffff"/>
+    <rect x="60.8" y="90" width="9.6" height="22" fill="#ffffff"/>
+    <rect x="70.4" y="90" width="9.6" height="11" fill="#ffd7ff"/>
+    <rect x="89.6" y="90" width="9.6" height="22" fill="#ffd7ff"/>
+    <rect x="99.2" y="90" width="9.6" height="11" fill="#d7d7ff"/>
+    <rect x="108.8" y="90" width="9.6" height="22" fill="#d7d7ff"/>
+    <rect x="128" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="137.6" y="90" width="9.6" height="11" fill="#d7afff"/>
+    <rect x="147.2" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="166.4" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="204.8" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="224" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="233.6" y="101" width="9.6" height="11" fill="#afafff"/>
+    <rect x="252.8" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="272" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="281.6" y="101" width="9.6" height="11" fill="#af87ff"/>
+    <rect x="291.2" y="90" width="9.6" height="11" fill="#af87ff"/>
+    <rect x="60.8" y="112" width="9.6" height="22" fill="#af87ff"/>
+    <rect x="89.6" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="99.2" y="123" width="9.6" height="11" fill="#af87d7"/>
+    <rect x="108.8" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="128" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="137.6" y="112" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="147.2" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="166.4" y="112" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="176" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="185.6" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="204.8" y="112" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="224" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="243.2" y="112" width="9.6" height="11" fill="#875faf"/>
+    <rect x="252.8" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="272" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="291.2" y="112" width="9.6" height="22" fill="#5f5faf"/>
+    <text x="41.6" y="150" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787">──────────────────────────────────────────────────────────────────────────────</text>
+    <rect x="41.6" y="178" width="4.8" height="22" fill="#878787"/>
+    <text x="60.8" y="194" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">All</text>
+    <text x="204.8" y="194" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787">╭─</text>
+    <text x="233.6" y="194" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787" font-weight="600">Search</text>
+    <text x="300.8" y="194" textLength="489.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787">──────────────────────────────────────────────────╮</text>
     <text x="60.8" y="216" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Games</text>
-    <rect x="208.9" y="200" width="1.4" height="22" fill="#6b6577"/>
-    <text x="224" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">❯</text>
+    <rect x="208.9" y="200" width="1.4" height="22" fill="#878787"/>
+    <text x="224" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">❯</text>
     <text x="243.2" y="216" textLength="288" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search or paste a magnet link…</text>
-    <rect x="784.9" y="200" width="1.4" height="22" fill="#6b6577"/>
+    <rect x="784.9" y="200" width="1.4" height="22" fill="#878787"/>
     <text x="60.8" y="238" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Movies</text>
-    <text x="204.8" y="238" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577">╰───────────────────────────────────────────────────────────╯</text>
+    <text x="204.8" y="238" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787">╰───────────────────────────────────────────────────────────╯</text>
     <text x="60.8" y="260" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">TV</text>
     <text x="60.8" y="282" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Anime</text>
-    <text x="204.8" y="282" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╭─</text>
-    <text x="233.6" y="282" textLength="96" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Latest (5)</text>
-    <text x="339.2" y="282" textLength="451.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">──────────────────────────────────────────────╮</text>
-    <rect x="208.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="204.8" y="282" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╭─</text>
+    <text x="233.6" y="282" textLength="96" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" font-weight="600">Latest (5)</text>
+    <text x="339.2" y="282" textLength="451.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">──────────────────────────────────────────────╮</text>
+    <rect x="208.9" y="288" width="1.4" height="22" fill="#afafff"/>
     <text x="224" y="304" textLength="240" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">newest across all sources</text>
-    <rect x="784.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
+    <rect x="784.9" y="288" width="1.4" height="22" fill="#afafff"/>
     <text x="60.8" y="326" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Downloads</text>
-    <rect x="208.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="784.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
+    <rect x="208.9" y="310" width="1.4" height="22" fill="#afafff"/>
+    <rect x="784.9" y="310" width="1.4" height="22" fill="#afafff"/>
     <text x="60.8" y="348" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Seeding</text>
-    <rect x="208.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
+    <rect x="208.9" y="332" width="1.4" height="22" fill="#afafff"/>
     <text x="252.8" y="348" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">#</text>
     <text x="272" y="348" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Name</text>
     <text x="588.8" y="348" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Size</text>
     <text x="646.4" y="348" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Seed:Lch</text>
     <text x="742.4" y="348" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Src</text>
-    <rect x="784.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="224" y="370" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">❯</text>
+    <rect x="784.9" y="332" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="354" width="1.4" height="22" fill="#afafff"/>
+    <text x="224" y="370" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">❯</text>
     <text x="252.8" y="370" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1</text>
-    <text x="272" y="370" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Oppenheimer (2023) [1080p…</text>
+    <text x="272" y="370" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" font-weight="600">Oppenheimer (2023) [1080p…</text>
     <text x="560" y="370" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1.96 GB</text>
-    <text x="656" y="370" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">1240:88</text>
-    <text x="742.4" y="370" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">YTS</text>
-    <rect x="784.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="376" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="656" y="370" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">1240:88</text>
+    <text x="742.4" y="370" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">YTS</text>
+    <rect x="784.9" y="354" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="376" width="1.4" height="22" fill="#afafff"/>
     <text x="252.8" y="392" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">2</text>
     <text x="272" y="392" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Dune: Part Two (2024) [21…</text>
     <text x="560" y="392" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">7.82 GB</text>
-    <text x="665.6" y="392" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">910:41</text>
-    <text x="742.4" y="392" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2" fill-opacity="0.55">YTS</text>
-    <rect x="784.9" y="376" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="398" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="665.6" y="392" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">910:41</text>
+    <text x="742.4" y="392" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af" fill-opacity="0.55">YTS</text>
+    <rect x="784.9" y="376" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="398" width="1.4" height="22" fill="#afafff"/>
     <text x="252.8" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">3</text>
     <text x="272" y="414" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Breaking Bad S05E14 1080p…</text>
     <text x="560" y="414" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1.49 GB</text>
-    <text x="665.6" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">540:31</text>
-    <text x="732.8" y="414" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#f0c560" fill-opacity="0.55">EZTV</text>
-    <rect x="784.9" y="398" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="420" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="665.6" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">540:31</text>
+    <text x="732.8" y="414" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#ffd787" fill-opacity="0.55">EZTV</text>
+    <rect x="784.9" y="398" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="420" width="1.4" height="22" fill="#afafff"/>
     <text x="252.8" y="436" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">4</text>
     <text x="272" y="436" textLength="249.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">[Erai-raws] Jujutsu Kaise…</text>
     <text x="560" y="436" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1.21 GB</text>
-    <text x="665.6" y="436" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">320:12</text>
-    <text x="732.8" y="436" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d8b4fe" fill-opacity="0.55">NYAA</text>
-    <rect x="784.9" y="420" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="442" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="665.6" y="436" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">320:12</text>
+    <text x="732.8" y="436" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7d7ff" fill-opacity="0.55">NYAA</text>
+    <rect x="784.9" y="420" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="442" width="1.4" height="22" fill="#afafff"/>
     <text x="252.8" y="458" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">5</text>
     <text x="272" y="458" textLength="192" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Frieren - 28 [1080p]</text>
     <text x="560" y="458" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1.30 GB</text>
     <text x="713.6" y="458" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">-</text>
-    <text x="742.4" y="458" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6" fill-opacity="0.55">SUB</text>
-    <rect x="784.9" y="442" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="204.8" y="480" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╰───────────────────────────────────────────────────────────╯</text>
-    <text x="41.6" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↑↓←→</text>
+    <text x="742.4" y="458" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff" fill-opacity="0.55">SUB</text>
+    <rect x="784.9" y="442" width="1.4" height="22" fill="#afafff"/>
+    <text x="204.8" y="480" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╰───────────────────────────────────────────────────────────╯</text>
+    <text x="41.6" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↑↓←→</text>
     <text x="89.6" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Move</text>
-    <text x="156.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">d</text>
+    <text x="156.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">d</text>
     <text x="176" y="502" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Download</text>
-    <text x="281.6" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">y</text>
+    <text x="281.6" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">y</text>
     <text x="300.8" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Copy</text>
-    <text x="368" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
+    <text x="368" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">s</text>
     <text x="387.2" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Sort</text>
-    <text x="454.4" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">/</text>
+    <text x="454.4" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">/</text>
     <text x="473.6" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search</text>
-    <text x="560" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
+    <text x="560" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">tab</text>
     <text x="598.4" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
-    <text x="684.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
+    <text x="684.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">?</text>
     <text x="704" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
   </g>
 </svg>

--- a/preview/downloads.svg
+++ b/preview/downloads.svg
@@ -4,151 +4,151 @@
   <rect x="0.5" y="0.5" width="831" height="451" rx="14" fill="none" stroke="#2d2b31" stroke-width="1"/>
   <text x="416" y="23" text-anchor="middle" font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="13" fill="#8a8a8a">torlink</text>
   <g font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="16" fill="#ddd8ea">
-    <text x="99.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#5ae87a" font-weight="600">𐓏</text>
-    <rect x="51.2" y="90" width="9.6" height="11" fill="#faf5ff"/>
-    <rect x="60.8" y="90" width="9.6" height="22" fill="#f5ecff"/>
-    <rect x="70.4" y="90" width="9.6" height="11" fill="#f0e2ff"/>
-    <rect x="89.6" y="90" width="9.6" height="22" fill="#e6cffe"/>
-    <rect x="99.2" y="90" width="9.6" height="11" fill="#e1c5fe"/>
-    <rect x="108.8" y="90" width="9.6" height="22" fill="#dcbcfe"/>
-    <rect x="128" y="90" width="9.6" height="22" fill="#d3b0fe"/>
-    <rect x="137.6" y="90" width="9.6" height="11" fill="#d0adfd"/>
-    <rect x="147.2" y="90" width="9.6" height="22" fill="#ccaafd"/>
-    <rect x="166.4" y="90" width="9.6" height="22" fill="#c4a4fc"/>
-    <rect x="204.8" y="90" width="9.6" height="22" fill="#b597fb"/>
-    <rect x="224" y="90" width="9.6" height="22" fill="#ae91fb"/>
-    <rect x="233.6" y="101" width="9.6" height="11" fill="#aa8efa"/>
-    <rect x="252.8" y="90" width="9.6" height="22" fill="#a487f7"/>
-    <rect x="272" y="90" width="9.6" height="22" fill="#9e81f3"/>
-    <rect x="281.6" y="101" width="9.6" height="11" fill="#9b7ef0"/>
-    <rect x="291.2" y="90" width="9.6" height="11" fill="#997bee"/>
-    <rect x="60.8" y="112" width="9.6" height="22" fill="#9375e9"/>
-    <rect x="89.6" y="112" width="9.6" height="22" fill="#8b6ce2"/>
-    <rect x="99.2" y="123" width="9.6" height="11" fill="#8869e0"/>
-    <rect x="108.8" y="112" width="9.6" height="22" fill="#8566de"/>
-    <rect x="128" y="112" width="9.6" height="22" fill="#8060d9"/>
-    <rect x="137.6" y="112" width="9.6" height="11" fill="#7d5dd7"/>
-    <rect x="147.2" y="123" width="9.6" height="11" fill="#7a5bd3"/>
-    <rect x="166.4" y="112" width="9.6" height="22" fill="#7456c9"/>
-    <rect x="176" y="123" width="9.6" height="11" fill="#7154c4"/>
-    <rect x="185.6" y="123" width="9.6" height="11" fill="#6e52c0"/>
-    <rect x="204.8" y="112" width="9.6" height="22" fill="#684eb6"/>
-    <rect x="224" y="112" width="9.6" height="22" fill="#6249ac"/>
-    <rect x="243.2" y="112" width="9.6" height="11" fill="#5b45a2"/>
-    <rect x="252.8" y="112" width="9.6" height="22" fill="#58439d"/>
-    <rect x="272" y="112" width="9.6" height="22" fill="#523e94"/>
-    <rect x="291.2" y="112" width="9.6" height="22" fill="#4c3a8a"/>
-    <text x="41.6" y="150" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577">──────────────────────────────────────────────────────────────────────────────</text>
+    <text x="99.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#87ff87" font-weight="600">𐓏</text>
+    <rect x="51.2" y="90" width="9.6" height="11" fill="#ffffff"/>
+    <rect x="60.8" y="90" width="9.6" height="22" fill="#ffffff"/>
+    <rect x="70.4" y="90" width="9.6" height="11" fill="#ffd7ff"/>
+    <rect x="89.6" y="90" width="9.6" height="22" fill="#ffd7ff"/>
+    <rect x="99.2" y="90" width="9.6" height="11" fill="#d7d7ff"/>
+    <rect x="108.8" y="90" width="9.6" height="22" fill="#d7d7ff"/>
+    <rect x="128" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="137.6" y="90" width="9.6" height="11" fill="#d7afff"/>
+    <rect x="147.2" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="166.4" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="204.8" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="224" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="233.6" y="101" width="9.6" height="11" fill="#afafff"/>
+    <rect x="252.8" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="272" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="281.6" y="101" width="9.6" height="11" fill="#af87ff"/>
+    <rect x="291.2" y="90" width="9.6" height="11" fill="#af87ff"/>
+    <rect x="60.8" y="112" width="9.6" height="22" fill="#af87ff"/>
+    <rect x="89.6" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="99.2" y="123" width="9.6" height="11" fill="#af87d7"/>
+    <rect x="108.8" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="128" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="137.6" y="112" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="147.2" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="166.4" y="112" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="176" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="185.6" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="204.8" y="112" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="224" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="243.2" y="112" width="9.6" height="11" fill="#875faf"/>
+    <rect x="252.8" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="272" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="291.2" y="112" width="9.6" height="22" fill="#5f5faf"/>
+    <text x="41.6" y="150" textLength="748.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787">──────────────────────────────────────────────────────────────────────────────</text>
     <text x="60.8" y="194" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">All</text>
-    <text x="204.8" y="194" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╭─</text>
-    <text x="233.6" y="194" textLength="124.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Downloads (1)</text>
-    <text x="368" y="194" textLength="422.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">───────────────────────────────────────────╮</text>
+    <text x="204.8" y="194" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╭─</text>
+    <text x="233.6" y="194" textLength="124.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" font-weight="600">Downloads (1)</text>
+    <text x="368" y="194" textLength="422.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">───────────────────────────────────────────╮</text>
     <text x="60.8" y="216" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Games</text>
-    <rect x="208.9" y="200" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="224" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">❯</text>
-    <text x="243.2" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">↓</text>
-    <text x="262.4" y="216" textLength="345.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Dune: Part Two (2024) [2160p BluRay]</text>
+    <rect x="208.9" y="200" width="1.4" height="22" fill="#afafff"/>
+    <text x="224" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" font-weight="600">❯</text>
+    <text x="243.2" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">↓</text>
+    <text x="262.4" y="216" textLength="345.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" font-weight="600">Dune: Part Two (2024) [2160p BluRay]</text>
     <text x="656" y="216" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">7.82 GB</text>
-    <text x="742.4" y="216" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">YTS</text>
-    <rect x="784.9" y="200" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="742.4" y="216" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af">YTS</text>
+    <rect x="784.9" y="200" width="1.4" height="22" fill="#afafff"/>
     <text x="60.8" y="238" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Movies</text>
-    <rect x="208.9" y="222" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="262.4" y="222" width="9.6" height="22" fill="#7c5cd6"/>
-    <rect x="272" y="222" width="9.6" height="22" fill="#8060d9"/>
-    <rect x="281.6" y="222" width="9.6" height="22" fill="#8465dd"/>
-    <rect x="291.2" y="222" width="9.6" height="22" fill="#8869e0"/>
-    <rect x="300.8" y="222" width="9.6" height="22" fill="#8c6ee4"/>
-    <rect x="310.4" y="222" width="9.6" height="22" fill="#9072e7"/>
-    <rect x="320" y="222" width="9.6" height="22" fill="#9577eb"/>
-    <rect x="329.6" y="222" width="9.6" height="22" fill="#997bee"/>
-    <rect x="339.2" y="222" width="9.6" height="22" fill="#9d80f1"/>
-    <rect x="348.8" y="222" width="9.6" height="22" fill="#a184f5"/>
-    <rect x="358.4" y="222" width="9.6" height="22" fill="#a589f8"/>
-    <rect x="368" y="222" width="9.6" height="22" fill="#a98dfa"/>
-    <rect x="377.6" y="222" width="9.6" height="22" fill="#ae91fb"/>
-    <rect x="387.2" y="222" width="9.6" height="22" fill="#b395fb"/>
-    <text x="396.8" y="238" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#6b6577">░░░░░░░░</text>
+    <rect x="208.9" y="222" width="1.4" height="22" fill="#afafff"/>
+    <rect x="262.4" y="222" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="272" y="222" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="281.6" y="222" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="291.2" y="222" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="300.8" y="222" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="310.4" y="222" width="9.6" height="22" fill="#af87ff"/>
+    <rect x="320" y="222" width="9.6" height="22" fill="#af87ff"/>
+    <rect x="329.6" y="222" width="9.6" height="22" fill="#af87ff"/>
+    <rect x="339.2" y="222" width="9.6" height="22" fill="#afafff"/>
+    <rect x="348.8" y="222" width="9.6" height="22" fill="#afafff"/>
+    <rect x="358.4" y="222" width="9.6" height="22" fill="#afafff"/>
+    <rect x="368" y="222" width="9.6" height="22" fill="#afafff"/>
+    <rect x="377.6" y="222" width="9.6" height="22" fill="#afafff"/>
+    <rect x="387.2" y="222" width="9.6" height="22" fill="#d7afff"/>
+    <text x="396.8" y="238" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#878787">░░░░░░░░</text>
     <text x="492.8" y="238" textLength="211.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">64%  7.7 MB/s  •41  6m</text>
-    <rect x="784.9" y="222" width="1.4" height="22" fill="#a78bfa"/>
+    <rect x="784.9" y="222" width="1.4" height="22" fill="#afafff"/>
     <text x="60.8" y="260" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">TV</text>
-    <rect x="208.9" y="244" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="784.9" y="244" width="1.4" height="22" fill="#a78bfa"/>
+    <rect x="208.9" y="244" width="1.4" height="22" fill="#afafff"/>
+    <rect x="784.9" y="244" width="1.4" height="22" fill="#afafff"/>
     <text x="60.8" y="282" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Anime</text>
-    <rect x="208.9" y="266" width="1.4" height="22" fill="#a78bfa"/>
+    <rect x="208.9" y="266" width="1.4" height="22" fill="#afafff"/>
     <text x="224" y="282" textLength="230.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Recently downloaded  (2)</text>
-    <rect x="784.9" y="266" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="243.2" y="304" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2" fill-opacity="0.55">✓</text>
+    <rect x="784.9" y="266" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="288" width="1.4" height="22" fill="#afafff"/>
+    <text x="243.2" y="304" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af" fill-opacity="0.55">✓</text>
     <text x="262.4" y="304" textLength="230.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Elden Ring: Shadow of t…</text>
     <text x="521.6" y="304" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">50.29 GB</text>
     <text x="656" y="304" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1hr ago</text>
-    <text x="752" y="304" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" fill-opacity="0.55">FG</text>
-    <rect x="784.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="41.6" y="310" width="4.8" height="22" fill="#6b6577"/>
-    <text x="60.8" y="326" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">Downloads</text>
+    <text x="752" y="304" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" fill-opacity="0.55">FG</text>
+    <rect x="784.9" y="288" width="1.4" height="22" fill="#afafff"/>
+    <rect x="41.6" y="310" width="4.8" height="22" fill="#878787"/>
+    <text x="60.8" y="326" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">Downloads</text>
     <text x="156.8" y="326" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">(1)</text>
-    <rect x="208.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="243.2" y="326" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2" fill-opacity="0.55">✓</text>
+    <rect x="208.9" y="310" width="1.4" height="22" fill="#afafff"/>
+    <text x="243.2" y="326" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afd7af" fill-opacity="0.55">✓</text>
     <text x="262.4" y="326" textLength="230.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Breaking Bad S05E14 108…</text>
     <text x="531.2" y="326" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1.49 GB</text>
     <text x="627.2" y="326" textLength="96" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1d 1hr ago</text>
-    <text x="732.8" y="326" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#f0c560" fill-opacity="0.55">EZTV</text>
-    <rect x="784.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="732.8" y="326" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#ffd787" fill-opacity="0.55">EZTV</text>
+    <rect x="784.9" y="310" width="1.4" height="22" fill="#afafff"/>
     <text x="60.8" y="348" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Seeding</text>
-    <rect x="208.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="784.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="208.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="784.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="204.8" y="392" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╰───────────────────────────────────────────────────────────╯</text>
-    <text x="41.6" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">p</text>
+    <rect x="208.9" y="332" width="1.4" height="22" fill="#afafff"/>
+    <rect x="784.9" y="332" width="1.4" height="22" fill="#afafff"/>
+    <rect x="208.9" y="354" width="1.4" height="22" fill="#afafff"/>
+    <rect x="784.9" y="354" width="1.4" height="22" fill="#afafff"/>
+    <text x="204.8" y="392" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╰───────────────────────────────────────────────────────────╯</text>
+    <text x="41.6" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">p</text>
     <text x="60.8" y="414" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Pause</text>
-    <text x="137.6" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">c</text>
+    <text x="137.6" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">c</text>
     <text x="156.8" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cancel</text>
-    <text x="243.2" y="414" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
+    <text x="243.2" y="414" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">tab</text>
     <text x="281.6" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
-    <text x="368" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
+    <text x="368" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">?</text>
     <text x="387.2" y="414" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
   </g>
-  <rect x="262.4" y="222" width="9.6" height="22" fill="#7c5cd6">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#7c5cd6;#7f5fd7;#8669da;#9277de;#a18ae3;#b29ee8;#c3b3ee;#d2c5f3;#ded4f7;#e5ddfa;#e8e0fb;#e5ddfa;#ded4f7;#d2c5f3;#c3b3ee;#b29ee8;#a18ae3;#9277de;#8669da;#7f5fd7;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6" repeatCount="indefinite"/>
+  <rect x="262.4" y="222" width="9.6" height="22" fill="#8787d7">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#8787d7;#8989d8;#9090da;#9b9ade;#a9a7e3;#b8b6e9;#c7c4ef;#d5d1f4;#e0dcf8;#e7e2fa;#e9e5fb;#e7e2fa;#e0dcf8;#d5d1f4;#c7c4ef;#b8b6e9;#a9a7e3;#9b9ade;#9090da;#8989d8;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7;#8787d7" repeatCount="indefinite"/>
   </rect>
-  <rect x="272" y="222" width="9.6" height="22" fill="#8060d9">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#8060d9;#8060d9;#8060d9;#8262da;#886adc;#9377df;#a188e4;#b19ce9;#c1b0ee;#d0c2f3;#dcd2f7;#e5dcfa;#e8e1fb;#e7dffb;#e0d7f9;#d6caf5;#c8b8f1;#b8a5eb;#a891e6;#997ee1;#8c6fdd;#8465da;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9;#8060d9" repeatCount="indefinite"/>
+  <rect x="272" y="222" width="9.6" height="22" fill="#af87d7">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87d7;#af87d7;#af87d7;#b088d8;#b48eda;#ba98dd;#c2a4e2;#ccb3e8;#d6c1ed;#dfcff3;#e6daf7;#ebe1fa;#ede4fb;#ece3fa;#e8ddf8;#e2d4f5;#dac7f0;#d0b9ea;#c7aae5;#be9ddf;#b692db;#b18ad8;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7" repeatCount="indefinite"/>
   </rect>
-  <rect x="281.6" y="222" width="9.6" height="22" fill="#8465dd">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8566dd;#8a6cdf;#9378e2;#a088e6;#af9aea;#bfaeef;#cec0f3;#dbd0f7;#e4dbfa;#e8e1fb;#e8e0fb;#e3dafa;#d9cef7;#ccbef3;#bdacee;#ae98ea;#9f86e5;#9276e1;#896bdf;#8466dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd;#8465dd" repeatCount="indefinite"/>
+  <rect x="281.6" y="222" width="9.6" height="22" fill="#af87d7">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af88d7;#b38cd9;#b895dc;#c0a1e1;#caafe6;#d3beec;#ddccf1;#e4d7f6;#eae0f9;#ede4fb;#ede4fb;#e9dff9;#e4d6f6;#dccaf1;#d2bcec;#c9aee6;#bfa0e1;#b894dc;#b28cd9;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7" repeatCount="indefinite"/>
   </rect>
-  <rect x="291.2" y="222" width="9.6" height="22" fill="#8869e0">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8c6ee1;#9478e4;#a087e7;#ae99eb;#beacef;#ccbef4;#d9cef7;#e3dafa;#e8e0fc;#e9e1fc;#e5dcfb;#ddd2f8;#d1c3f5;#c3b2f1;#b49fec;#a58de8;#987de5;#8f71e2;#896ae0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0;#8869e0" repeatCount="indefinite"/>
+  <rect x="291.2" y="222" width="9.6" height="22" fill="#af87d7">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#b28bd9;#b793dc;#bf9ee0;#c8ace5;#d1bbeb;#dbc9f0;#e3d5f5;#e9def9;#ece4fb;#ede4fb;#eae1f9;#e5d9f6;#decdf2;#d5c0ed;#cbb1e7;#c1a3e2;#b996dd;#b38dd9;#b088d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7" repeatCount="indefinite"/>
   </rect>
-  <rect x="300.8" y="222" width="9.6" height="22" fill="#8c6ee4">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8f72e5;#967ae7;#a188e9;#ae98ed;#bcaaf1;#cbbcf4;#d8ccf8;#e2d8fa;#e8e0fc;#eae2fc;#e7dffc;#e0d6fa;#d5c9f7;#c8b8f3;#b9a6f0;#ab94ec;#9e84e9;#9478e6;#8e70e4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4;#8c6ee4" repeatCount="indefinite"/>
+  <rect x="300.8" y="222" width="9.6" height="22" fill="#af87d7">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#b18ad8;#b691db;#bd9cdf;#c5a9e4;#cfb7ea;#d9c6ef;#e1d3f4;#e8ddf8;#ece3fa;#ede5fb;#ebe2fa;#e7dbf7;#dfd0f3;#d7c3ee;#cdb4e8;#c3a6e3;#bb99de;#b48fda;#b089d8;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7;#af87d7" repeatCount="indefinite"/>
   </rect>
-  <rect x="310.4" y="222" width="9.6" height="22" fill="#9072e7">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9274e7;#987ce9;#a188eb;#ae97ee;#bba8f1;#c9baf5;#d6caf8;#e0d7fa;#e7dffc;#eae2fd;#e8e0fc;#e2d9fb;#d9cdf8;#ccbdf5;#bfacf2;#b19bef;#a48bec;#9a7ee9;#9375e8;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7;#9072e7" repeatCount="indefinite"/>
+  <rect x="310.4" y="222" width="9.6" height="22" fill="#af87ff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#b089ff;#b48fff;#bb99ff;#c3a6ff;#cdb4ff;#d7c3ff;#dfd0ff;#e7dbff;#ebe2ff;#ede5ff;#ece3ff;#e8ddff;#e1d3ff;#d9c6ff;#cfb7ff;#c5a9ff;#bd9cff;#b691ff;#b18aff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff" repeatCount="indefinite"/>
   </rect>
-  <rect x="320" y="222" width="9.6" height="22" fill="#9577eb">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9678eb;#9b7eec;#a389ee;#ae97f0;#bba7f3;#c9b8f6;#d5c8f9;#e0d5fb;#e7defc;#eae3fd;#eae2fd;#e5dcfc;#dcd1fa;#d1c3f8;#c4b3f5;#b7a2f2;#aa92f0;#a085ed;#997cec;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb;#9577eb" repeatCount="indefinite"/>
+  <rect x="320" y="222" width="9.6" height="22" fill="#af87ff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#b088ff;#b38dff;#b996ff;#c1a3ff;#cbb1ff;#d5c0ff;#decdff;#e5d9ff;#eae1ff;#ede4ff;#ece4ff;#e9deff;#e3d5ff;#dbc9ff;#d1bbff;#c8acff;#bf9eff;#b793ff;#b28bff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff" repeatCount="indefinite"/>
   </rect>
-  <rect x="329.6" y="222" width="9.6" height="22" fill="#997bee">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997cee;#9d80ef;#a48af0;#af97f2;#bba6f4;#c8b6f7;#d4c6f9;#ded3fb;#e6ddfc;#eae3fd;#ebe3fd;#e7defd;#dfd5fb;#d5c8f9;#c9b8f7;#bca8f5;#b098f2;#a68bf0;#9e81ef;#9a7cee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee;#997bee" repeatCount="indefinite"/>
+  <rect x="329.6" y="222" width="9.6" height="22" fill="#af87ff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#b28cff;#b894ff;#bfa0ff;#c9aeff;#d2bcff;#dccaff;#e4d6ff;#e9dfff;#ede4ff;#ede4ff;#eae0ff;#e4d7ff;#ddccff;#d3beff;#caafff;#c0a1ff;#b895ff;#b38cff;#af88ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff;#af87ff" repeatCount="indefinite"/>
   </rect>
-  <rect x="339.2" y="222" width="9.6" height="22" fill="#9d80f1">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#a084f1;#a68cf2;#af97f4;#bba6f6;#c7b5f8;#d3c5fa;#ddd2fb;#e5dcfd;#eae2fd;#ebe4fe;#e8e0fd;#e2d8fc;#d9ccfb;#cebef9;#c1aef7;#b59ff5;#ab92f3;#a388f2;#9e81f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1;#9d80f1" repeatCount="indefinite"/>
+  <rect x="339.2" y="222" width="9.6" height="22" fill="#afafff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#b1b1ff;#b6b6ff;#bebdff;#c7c5ff;#d0ceff;#dad7ff;#e2deff;#e8e4ff;#ece8ff;#ede9ff;#ebe7ff;#e6e2ff;#dfdbff;#d6d3ff;#cccaff;#c2c1ff;#bab9ff;#b4b3ff;#b0b0ff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff" repeatCount="indefinite"/>
   </rect>
-  <rect x="348.8" y="222" width="9.6" height="22" fill="#a184f5">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a386f5;#a88df6;#b098f7;#bba5f8;#c6b4fa;#d2c3fb;#dcd0fc;#e5dbfd;#eae2fe;#ece4fe;#eae2fe;#e5dbfd;#dcd0fc;#d2c3fb;#c6b4fa;#bba5f8;#b098f7;#a88df6;#a386f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5;#a184f5" repeatCount="indefinite"/>
+  <rect x="348.8" y="222" width="9.6" height="22" fill="#afafff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#b1b0ff;#b5b5ff;#bcbbff;#c4c3ff;#ceccff;#d8d5ff;#e0ddff;#e7e3ff;#ece7ff;#ede9ff;#ece7ff;#e7e3ff;#e0ddff;#d8d5ff;#ceccff;#c4c3ff;#bcbbff;#b5b5ff;#b1b0ff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff" repeatCount="indefinite"/>
   </rect>
-  <rect x="358.4" y="222" width="9.6" height="22" fill="#a589f8">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a68af8;#aa90f8;#b299f9;#bba6fa;#c6b4fb;#d1c2fc;#dbcffd;#e4dafe;#eae1fe;#ece5fe;#ebe3fe;#e7defe;#dfd4fd;#d6c8fc;#cbbafb;#c0acfa;#b69ff9;#ad94f9;#a88cf8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8;#a589f8" repeatCount="indefinite"/>
+  <rect x="358.4" y="222" width="9.6" height="22" fill="#afafff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#b0b0ff;#b4b3ff;#bab9ff;#c2c1ff;#cccaff;#d6d3ff;#dfdbff;#e6e2ff;#ebe7ff;#ede9ff;#ece8ff;#e8e4ff;#e2deff;#dad7ff;#d0ceff;#c7c5ff;#bebdff;#b6b6ff;#b1b1ff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff" repeatCount="indefinite"/>
   </rect>
-  <rect x="368" y="222" width="9.6" height="22" fill="#a98dfa">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#aa8efa;#ad92fa;#b39afb;#bca6fb;#c6b3fc;#d1c1fd;#dbcefd;#e3d9fe;#e9e1fe;#ece5fe;#ece5fe;#e9e0fe;#e2d8fe;#daccfd;#cfbffd;#c5b1fc;#bba4fb;#b299fb;#ac91fa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa;#a98dfa" repeatCount="indefinite"/>
+  <rect x="368" y="222" width="9.6" height="22" fill="#afafff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#b3b2ff;#b8b8ff;#c0bfff;#cac8ff;#d3d1ff;#ddd9ff;#e4e1ff;#eae6ff;#ede8ff;#ede8ff;#e9e5ff;#e4e0ff;#dcd8ff;#d2d0ff;#c9c7ff;#bfbeff;#b8b7ff;#b2b2ff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff" repeatCount="indefinite"/>
   </rect>
-  <rect x="377.6" y="222" width="9.6" height="22" fill="#ae91fb">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#b195fb;#b69cfb;#bea6fc;#c7b3fc;#d1c0fd;#dacdfe;#e3d8fe;#e9e0fe;#ece5ff;#ede5ff;#eae2fe;#e5dbfe;#ddd0fe;#d4c4fd;#cab7fd;#c1aafc;#b89ffc;#b297fb;#af92fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb;#ae91fb" repeatCount="indefinite"/>
+  <rect x="377.6" y="222" width="9.6" height="22" fill="#afafff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#b2b1ff;#b7b6ff;#bfbdff;#c8c6ff;#d1cfff;#dbd8ff;#e3dfff;#e9e5ff;#ece8ff;#ede8ff;#eae6ff;#e5e1ff;#dedaff;#d5d2ff;#cbc9ff;#c1c0ff;#b9b9ff;#b3b3ff;#b0b0ff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff;#afafff" repeatCount="indefinite"/>
   </rect>
-  <rect x="387.2" y="222" width="9.6" height="22" fill="#b395fb">
-    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b597fb;#b99efb;#c0a7fc;#c8b2fc;#d1bffd;#dacbfd;#e2d6fe;#e8dffe;#ece4ff;#ede6ff;#ece4fe;#e7ddfe;#e1d4fe;#d8c9fd;#cfbcfd;#c6b0fc;#bea5fc;#b89cfb;#b497fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb;#b395fb" repeatCount="indefinite"/>
+  <rect x="387.2" y="222" width="9.6" height="22" fill="#d7afff">
+    <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d8b1ff;#dab5ff;#ddbcff;#e0c4ff;#e5cdff;#e9d6ff;#ecdeff;#efe4ff;#f1e7ff;#f1e9ff;#f0e7ff;#eee2ff;#ebdcff;#e8d4ff;#e4cbff;#e0c2ff;#dcbaff;#d9b4ff;#d8b0ff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff;#d7afff" repeatCount="indefinite"/>
   </rect>
 </svg>

--- a/preview/splash.svg
+++ b/preview/splash.svg
@@ -4,57 +4,57 @@
   <rect x="0.5" y="0.5" width="831" height="385" rx="14" fill="none" stroke="#2d2b31" stroke-width="1"/>
   <text x="416" y="23" text-anchor="middle" font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="13" fill="#8a8a8a">torlink</text>
   <g font-family='ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace' font-size="16" fill="#ddd8ea">
-    <text x="339.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#5ae87a" font-weight="600">𐓏</text>
-    <rect x="291.2" y="90" width="9.6" height="11" fill="#faf5ff"/>
-    <rect x="300.8" y="90" width="9.6" height="22" fill="#f5ecff"/>
-    <rect x="310.4" y="90" width="9.6" height="11" fill="#f0e2ff"/>
-    <rect x="329.6" y="90" width="9.6" height="22" fill="#e6cffe"/>
-    <rect x="339.2" y="90" width="9.6" height="11" fill="#e1c5fe"/>
-    <rect x="348.8" y="90" width="9.6" height="22" fill="#dcbcfe"/>
-    <rect x="368" y="90" width="9.6" height="22" fill="#d3b0fe"/>
-    <rect x="377.6" y="90" width="9.6" height="11" fill="#d0adfd"/>
-    <rect x="387.2" y="90" width="9.6" height="22" fill="#ccaafd"/>
-    <rect x="406.4" y="90" width="9.6" height="22" fill="#c4a4fc"/>
-    <rect x="444.8" y="90" width="9.6" height="22" fill="#b597fb"/>
-    <rect x="464" y="90" width="9.6" height="22" fill="#ae91fb"/>
-    <rect x="473.6" y="101" width="9.6" height="11" fill="#aa8efa"/>
-    <rect x="492.8" y="90" width="9.6" height="22" fill="#a487f7"/>
-    <rect x="512" y="90" width="9.6" height="22" fill="#9e81f3"/>
-    <rect x="521.6" y="101" width="9.6" height="11" fill="#9b7ef0"/>
-    <rect x="531.2" y="90" width="9.6" height="11" fill="#997bee"/>
-    <rect x="300.8" y="112" width="9.6" height="22" fill="#9375e9"/>
-    <rect x="329.6" y="112" width="9.6" height="22" fill="#8b6ce2"/>
-    <rect x="339.2" y="123" width="9.6" height="11" fill="#8869e0"/>
-    <rect x="348.8" y="112" width="9.6" height="22" fill="#8566de"/>
-    <rect x="368" y="112" width="9.6" height="22" fill="#8060d9"/>
-    <rect x="377.6" y="112" width="9.6" height="11" fill="#7d5dd7"/>
-    <rect x="387.2" y="123" width="9.6" height="11" fill="#7a5bd3"/>
-    <rect x="406.4" y="112" width="9.6" height="22" fill="#7456c9"/>
-    <rect x="416" y="123" width="9.6" height="11" fill="#7154c4"/>
-    <rect x="425.6" y="123" width="9.6" height="11" fill="#6e52c0"/>
-    <rect x="444.8" y="112" width="9.6" height="22" fill="#684eb6"/>
-    <rect x="464" y="112" width="9.6" height="22" fill="#6249ac"/>
-    <rect x="483.2" y="112" width="9.6" height="11" fill="#5b45a2"/>
-    <rect x="492.8" y="112" width="9.6" height="22" fill="#58439d"/>
-    <rect x="512" y="112" width="9.6" height="22" fill="#523e94"/>
-    <rect x="531.2" y="112" width="9.6" height="22" fill="#4c3a8a"/>
-    <text x="195.2" y="194" textLength="441.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#e9e4f5">A curated, terminal-native torrent downloader.</text>
+    <text x="339.2" y="84" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#87ff87" font-weight="600">𐓏</text>
+    <rect x="291.2" y="90" width="9.6" height="11" fill="#ffffff"/>
+    <rect x="300.8" y="90" width="9.6" height="22" fill="#ffffff"/>
+    <rect x="310.4" y="90" width="9.6" height="11" fill="#ffd7ff"/>
+    <rect x="329.6" y="90" width="9.6" height="22" fill="#ffd7ff"/>
+    <rect x="339.2" y="90" width="9.6" height="11" fill="#d7d7ff"/>
+    <rect x="348.8" y="90" width="9.6" height="22" fill="#d7d7ff"/>
+    <rect x="368" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="377.6" y="90" width="9.6" height="11" fill="#d7afff"/>
+    <rect x="387.2" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="406.4" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="444.8" y="90" width="9.6" height="22" fill="#d7afff"/>
+    <rect x="464" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="473.6" y="101" width="9.6" height="11" fill="#afafff"/>
+    <rect x="492.8" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="512" y="90" width="9.6" height="22" fill="#afafff"/>
+    <rect x="521.6" y="101" width="9.6" height="11" fill="#af87ff"/>
+    <rect x="531.2" y="90" width="9.6" height="11" fill="#af87ff"/>
+    <rect x="300.8" y="112" width="9.6" height="22" fill="#af87ff"/>
+    <rect x="329.6" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="339.2" y="123" width="9.6" height="11" fill="#af87d7"/>
+    <rect x="348.8" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="368" y="112" width="9.6" height="22" fill="#af87d7"/>
+    <rect x="377.6" y="112" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="387.2" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="406.4" y="112" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="416" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="425.6" y="123" width="9.6" height="11" fill="#8787d7"/>
+    <rect x="444.8" y="112" width="9.6" height="22" fill="#8787d7"/>
+    <rect x="464" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="483.2" y="112" width="9.6" height="11" fill="#875faf"/>
+    <rect x="492.8" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="512" y="112" width="9.6" height="22" fill="#875faf"/>
+    <rect x="531.2" y="112" width="9.6" height="22" fill="#5f5faf"/>
+    <text x="195.2" y="194" textLength="441.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#ffd7ff">A curated, terminal-native torrent downloader.</text>
     <text x="262.4" y="216" textLength="316.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">games  ·  movies  ·  tv  ·  anime</text>
-    <text x="118.4" y="260" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╭─</text>
-    <text x="147.2" y="260" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Search</text>
-    <text x="214.4" y="260" textLength="499.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">───────────────────────────────────────────────────╮</text>
-    <rect x="122.5" y="266" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="137.6" y="282" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">❯</text>
+    <text x="118.4" y="260" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╭─</text>
+    <text x="147.2" y="260" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff" font-weight="600">Search</text>
+    <text x="214.4" y="260" textLength="499.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">───────────────────────────────────────────────────╮</text>
+    <rect x="122.5" y="266" width="1.4" height="22" fill="#afafff"/>
+    <text x="137.6" y="282" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">❯</text>
     <rect x="156.8" y="266" width="9.6" height="22" fill="#ddd8ea"/>
     <text x="156.8" y="282" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#0a0810">S</text>
     <text x="166.4" y="282" textLength="278.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">earch or paste a magnet link…</text>
-    <rect x="708.1" y="266" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="118.4" y="304" textLength="595.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╰────────────────────────────────────────────────────────────╯</text>
-    <text x="233.6" y="348" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↵</text>
+    <rect x="708.1" y="266" width="1.4" height="22" fill="#afafff"/>
+    <text x="118.4" y="304" textLength="595.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#afafff">╰────────────────────────────────────────────────────────────╯</text>
+    <text x="233.6" y="348" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
     <text x="252.8" y="348" textLength="153.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">search  ·  empty</text>
-    <text x="416" y="348" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↵</text>
+    <text x="416" y="348" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">↵</text>
     <text x="435.2" y="348" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">browse  ·</text>
-    <text x="540.8" y="348" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">^c</text>
+    <text x="540.8" y="348" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#d7afff">^c</text>
     <text x="569.6" y="348" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">quit</text>
   </g>
 </svg>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -260,3 +260,5 @@ save(
   </Box>,
   { shimmer: true },
 );
+
+

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -12,10 +12,16 @@ export interface TorrentProgress {
   name: string;
 }
 
+export interface TorrentFileMeta {
+  path: string;
+  length: number;
+}
+
 export interface TorrentMeta {
   name: string;
   total: number;
   files: number;
+  fileList: TorrentFileMeta[];
   // The .torrent metadata (piece hashes), available once metadata arrives. We
   // persist it so a later re-seed can verify the on-disk file without having to
   // re-fetch metadata from the swarm (which a bare magnet would require).
@@ -80,6 +86,7 @@ export class TorrentEngine {
         name: torrent.name,
         total: torrent.length,
         files: torrent.files?.length ?? 0,
+        fileList: (torrent.files ?? []).map((f) => ({ path: f.path, length: f.length })),
         torrentFile: torrent.torrentFile,
       });
     });
@@ -102,13 +109,58 @@ export class TorrentEngine {
     return this.client?.torrentPort ?? null;
   }
 
-  stats(id: string): TorrentProgress | null {
+  getTorrent(id: string): Torrent | undefined {
+    return this.torrents.get(id);
+  }
+
+  fileStats(id: string): { path: string; length: number; progress: number }[] | null {
+    const t = this.torrents.get(id);
+    if (!t?.files) return null;
+    return t.files.map((f) => ({ path: f.path, length: f.length, progress: f.progress }));
+  }
+
+  applyFileSelection(id: string, selectedIndices: Set<number>): void {
+    const t = this.torrents.get(id);
+    if (!t?.files) return;
+    for (let i = 0; i < t.files.length; i++) {
+      const file = t.files[i];
+      if (file) {
+        if (selectedIndices.has(i)) {
+          file.select();
+        } else {
+          file.deselect();
+        }
+      }
+    }
+  }
+
+  stats(id: string, selectedIndices?: Set<number>): TorrentProgress | null {
     const t = this.torrents.get(id);
     if (!t) return null;
+
+    let total = t.length;
+    let downloaded = t.downloaded;
+    let progress = t.progress;
+
+    if (selectedIndices && t.files) {
+      total = 0;
+      downloaded = 0;
+      for (let i = 0; i < t.files.length; i++) {
+        if (selectedIndices.has(i)) {
+          const f = t.files[i];
+          if (f) {
+            total += f.length;
+            downloaded += Math.round(f.progress * f.length);
+          }
+        }
+      }
+      progress = total > 0 ? downloaded / total : 0;
+    }
+
     return {
-      progress: t.progress,
-      downloaded: t.downloaded,
-      total: t.length,
+      progress,
+      downloaded,
+      total,
       speed: t.downloadSpeed,
       uploadSpeed: t.uploadSpeed,
       uploaded: t.uploaded,

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -61,3 +61,44 @@ describe("strayDownload (missing-file safety-net)", () => {
     expect(strayDownload({ total: 0, progress: 0, speed: 0 })).toBe(false);
   });
 });
+
+describe("DownloadQueue selective download", () => {
+  it("add with selectedIndices stores indices and processes selective stats on metadata", () => {
+    const q = new DownloadQueue();
+    q.add(
+      {
+        id: "sel1",
+        name: "Selective Item",
+        magnet: "magnet:?xt=urn:btih:1111111111111111111111111111111111111111",
+        selectedIndices: [0],
+      },
+      "/downloads",
+    );
+    const items = q.getItems();
+    const item = items.find((i) => i.id === "sel1");
+    expect(item).toBeDefined();
+    expect(item?.status).toBe("downloading");
+    expect(item?.selectedIndices).toEqual([0]);
+    expect(q.activeCount).toBe(1);
+
+    // Trigger metadata handler mock call
+    const handlers = q["engineHandlers"]("sel1");
+    handlers.onMetadata?.({
+      name: "Selective Item",
+      total: 300,
+      files: 2,
+      fileList: [
+        { path: "f1.txt", length: 100 },
+        { path: "f2.txt", length: 200 },
+      ],
+      torrentFile: new Uint8Array(),
+    });
+
+    const updated = q.getItems().find((i) => i.id === "sel1");
+    expect(updated?.totalBytes).toBe(100);
+    expect(updated?.fileList?.[0]?.selected).toBe(true);
+    expect(updated?.fileList?.[1]?.selected).toBe(false);
+
+    q.suspend();
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -1,4 +1,6 @@
 import { EventEmitter } from "node:events";
+import { promises as fs, existsSync } from "node:fs";
+import path from "node:path";
 import { TorrentEngine, type AddHandlers } from "./engine";
 import {
   saveQueue,
@@ -47,7 +49,7 @@ export interface AddInput {
 
 export class DownloadQueue extends EventEmitter {
   private items = new Map<string, QueueItem>();
-  private engine = new TorrentEngine();
+  public readonly engine = new TorrentEngine();
   private poll: ReturnType<typeof setInterval> | null = null;
   private history: HistoryItem[] = [];
   private seeds = new Map<string, SeedItem>();
@@ -76,7 +78,7 @@ export class DownloadQueue extends EventEmitter {
     return this.items.has(id);
   }
 
-  add(input: AddInput, dir: string): void {
+  add(input: AddInput & { selectedIndices?: number[] }, dir: string): void {
     if (this.seeds.has(input.id)) {
       this.engine.remove(input.id);
       this.seeds.delete(input.id);
@@ -87,7 +89,7 @@ export class DownloadQueue extends EventEmitter {
     const existing = this.items.get(input.id);
     if (existing && existing.status !== "failed") return;
     const item: QueueItem = existing
-      ? { ...existing, status: "downloading", error: undefined, speed: 0 }
+      ? { ...existing, status: "downloading", error: undefined, speed: 0, selectedIndices: input.selectedIndices }
       : {
           id: input.id,
           name: input.name,
@@ -100,6 +102,7 @@ export class DownloadQueue extends EventEmitter {
           downloadedBytes: 0,
           speed: 0,
           peers: 0,
+          selectedIndices: input.selectedIndices,
           addedAt: Date.now(),
         };
     this.items.set(item.id, item);
@@ -127,8 +130,24 @@ export class DownloadQueue extends EventEmitter {
         const it = this.items.get(id);
         if (!it) return; // the rest only matters while still downloading
         if (meta.name) it.name = meta.name;
-        if (meta.total) it.totalBytes = meta.total;
         it.files = meta.files;
+        if (meta.fileList) {
+          it.fileList = meta.fileList.map((f, i) => ({
+            path: f.path,
+            length: f.length,
+            progress: 0,
+            selected: it.selectedIndices ? it.selectedIndices.includes(i) : true,
+          }));
+        }
+        if (it.selectedIndices) {
+          this.engine.applyFileSelection(id, new Set<number>(it.selectedIndices));
+          it.totalBytes = it.selectedIndices.reduce(
+            (sum, i) => sum + (meta.fileList?.[i]?.length ?? 0),
+            0
+          );
+        } else {
+          if (meta.total) it.totalBytes = meta.total;
+        }
         this.changed();
         void this.persist();
       },
@@ -173,9 +192,28 @@ export class DownloadQueue extends EventEmitter {
     };
   }
 
+  private async cleanUnwanted(it: QueueItem): Promise<void> {
+    if (!it.fileList || !it.selectedIndices) return;
+    const selected = new Set(it.selectedIndices);
+    for (let i = 0; i < it.fileList.length; i++) {
+      if (selected.has(i)) continue;
+      const file = it.fileList[i];
+      if (!file) continue;
+      const src = path.join(it.dir, file.path);
+      if (!existsSync(src)) continue;
+      const unwantedDir = path.join(it.dir, path.dirname(file.path), ".unwanted");
+      try {
+        await fs.mkdir(unwantedDir, { recursive: true });
+        const dest = path.join(unwantedDir, path.basename(file.path));
+        await fs.rename(src, dest);
+      } catch {}
+    }
+  }
+
   private complete(it: QueueItem): void {
     this.recordHistory(it);
     this.items.delete(it.id);
+    void this.cleanUnwanted(it);
     // Opt-out seeding: a finished download is already a complete, verified
     // torrent, so keep it alive and seeding instead of tearing it down.
     this.beginSeed(it);
@@ -210,9 +248,10 @@ export class DownloadQueue extends EventEmitter {
 
   private tick(): void {
     let any = false;
-    for (const it of this.items.values()) {
+    for (const it of Array.from(this.items.values())) {
       if (it.status !== "downloading") continue;
-      const s = this.engine.stats(it.id);
+      const sel = it.selectedIndices ? new Set(it.selectedIndices) : undefined;
+      const s = this.engine.stats(it.id, sel);
       if (!s) continue;
       it.progress = Math.min(100, Math.round(s.progress * 100));
       it.downloadedBytes = s.downloaded;
@@ -224,6 +263,23 @@ export class DownloadQueue extends EventEmitter {
           ? s.timeRemaining / 1000
           : undefined;
       if (s.name) it.name = s.name;
+
+      const fs = this.engine.fileStats(it.id);
+      if (fs && it.fileList) {
+        for (let i = 0; i < it.fileList.length; i++) {
+          const file = it.fileList[i];
+          const fileStat = fs[i];
+          if (file && fileStat) {
+            file.progress = fileStat.progress;
+          }
+        }
+      }
+
+      if (sel && it.progress >= 100) {
+        if (it.totalBytes) it.downloadedBytes = it.totalBytes;
+        this.complete(it);
+      }
+
       any = true;
     }
     const now = Date.now();
@@ -455,7 +511,9 @@ export class DownloadQueue extends EventEmitter {
   restore(items: QueueItem[]): void {
     for (const raw of items) {
       this.items.set(raw.id, raw);
-      if (raw.status === "downloading") this.startEngine(raw);
+      if (raw.status === "downloading") {
+        this.startEngine(raw);
+      }
     }
     if (this.activeCount > 0) this.ensurePoll();
     this.changed();

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -4,6 +4,13 @@ export type DownloadStatus = "downloading" | "paused" | "completed" | "failed";
 
 export type SeedStatus = "seeding" | "paused" | "missing";
 
+export interface TorrentFileInfo {
+  path: string;
+  length: number;
+  progress: number;
+  selected: boolean;
+}
+
 export interface SeedItem {
   id: string;
   name: string;
@@ -31,6 +38,8 @@ export interface QueueItem {
   peers: number;
   eta?: number;
   files?: number;
+  fileList?: TorrentFileInfo[];
+  selectedIndices?: number[];
   error?: string;
   addedAt: number;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -214,6 +214,7 @@ export function App({
       magnet: string;
       source?: SourceId;
       sizeBytes?: number;
+      selectedIndices?: number[];
     }) => {
       if (!config || !queue) return;
       void fs.mkdir(config.downloadDir, { recursive: true }).catch(() => {});

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -28,9 +28,121 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function Detail({ r, width }: { r: TorrentResult; width: number }) {
+interface DetailProps {
+  r: TorrentResult;
+  width: number;
+  listHeight: number;
+  focused: boolean;
+  onClose: () => void;
+}
+
+function Detail({ r, width, listHeight, focused, onClose }: DetailProps) {
+  const { queue, config, startDownload, copyMagnet } = useStore();
   const ss = SOURCE_STYLE[r.source];
   const date = formatRelative(r.added);
+
+  const [fileList, setFileList] = useState<{ path: string; length: number }[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [cursor, setCursor] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // If already in queue, check if it has fileList
+    const qItem = queue.getItems().find((it) => it.id === r.infoHash);
+    if (qItem && qItem.fileList) {
+      setFileList(qItem.fileList.map((f) => ({ path: f.path, length: f.length })));
+      setSelected(new Set(qItem.selectedIndices ?? qItem.fileList.map((_, i) => i)));
+      return;
+    }
+
+    if (r.numFiles && r.numFiles <= 1) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    let active = true;
+    const tempId = `temp-${r.infoHash}`;
+
+    try {
+      queue.engine.add(
+        tempId,
+        r.magnet,
+        config.downloadDir,
+        {
+          onMetadata: (meta) => {
+            if (!active) return;
+            if (meta.fileList) {
+              setFileList(meta.fileList);
+              setSelected(new Set(meta.fileList.map((_, i) => i)));
+            }
+            setLoading(false);
+            queue.engine.applyFileSelection(tempId, new Set());
+          },
+          onError: (msg) => {
+            if (!active) return;
+            setError(msg);
+            setLoading(false);
+          },
+        },
+        config.trackers,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setLoading(false);
+    }
+
+    return () => {
+      active = false;
+      queue.engine.remove(tempId);
+    };
+  }, [r.infoHash, queue, config, r.magnet, r.numFiles]);
+
+  const showFileList = fileList && fileList.length > 1;
+
+  useInput(
+    (input, key) => {
+      if (key.escape) {
+        onClose();
+      } else if (input === "y") {
+        copyMagnet({ name: r.name, magnet: r.magnet });
+      } else if (input === "d") {
+        startDownload({
+          id: r.infoHash,
+          name: r.name,
+          magnet: r.magnet,
+          source: r.source,
+          sizeBytes: r.sizeBytes,
+          selectedIndices: showFileList ? Array.from(selected) : undefined,
+        });
+        onClose();
+      } else if (showFileList && fileList) {
+        if (key.upArrow || input === "k") {
+          setCursor((c) => Math.max(0, c - 1));
+        } else if (key.downArrow || input === "j") {
+          setCursor((c) => Math.min(fileList.length - 1, c + 1));
+        } else if (input === " ") {
+          setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(cursor)) next.delete(cursor);
+            else next.add(cursor);
+            return next;
+          });
+        } else if (input === "a") {
+          setSelected((prev) => {
+            if (prev.size === fileList.length) return new Set();
+            return new Set(fileList.map((_, i) => i));
+          });
+        } else if (input === "n") {
+          setSelected(new Set());
+        }
+      }
+    },
+    { isActive: focused },
+  );
+
   const health =
     r.seeders || r.leechers ? (
       <Text>
@@ -42,6 +154,11 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
     ) : (
       <Text dimColor>unknown</Text>
     );
+
+  const fileBoxHeight = Math.max(3, listHeight - 11);
+  const fileStart = windowStart(cursor, fileList?.length ?? 0, fileBoxHeight);
+  const visibleFiles = fileList ? fileList.slice(fileStart, fileStart + fileBoxHeight) : [];
+
   return (
     <Box flexDirection="column">
       <Box>
@@ -90,6 +207,73 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
           }
         />
       </Box>
+
+      {loading && (
+        <Box marginTop={1}>
+          <Spinner label="Loading file list…" />
+        </Box>
+      )}
+
+      {error && (
+        <Box marginTop={1}>
+          <Text color={COLOR.bad}>Failed to load files: {error}</Text>
+        </Box>
+      )}
+
+      {showFileList && fileList && (
+        <Box flexDirection="column" marginTop={1}>
+          <Box>
+            <Text bold dimColor>Files selection checklist:</Text>
+          </Box>
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor={COLOR.accent}
+            paddingX={1}
+            height={fileBoxHeight + 2}
+          >
+            {visibleFiles.map((file, i) => {
+              const globalIdx = fileStart + i;
+              const isFocused = globalIdx === cursor;
+              const isChecked = selected.has(globalIdx);
+
+              const displayPath = file.path.includes("/")
+                ? file.path.substring(file.path.indexOf("/") + 1)
+                : file.path;
+
+              return (
+                <Box key={file.path}>
+                  <Box width={2} flexShrink={0}>
+                    <Text color={COLOR.accent}>{isFocused ? ICON.pointer : ""}</Text>
+                  </Box>
+                  <Box width={4} flexShrink={0}>
+                    <Text color={isChecked ? COLOR.accent : COLOR.alt}>
+                      {isChecked ? "[x]" : "[ ]"}
+                    </Text>
+                  </Box>
+                  <Box flexGrow={1} minWidth={0}>
+                    <Text wrap="truncate-end" color={isFocused ? COLOR.accent : COLOR.text} dimColor={!isFocused && !isChecked}>
+                      {truncate(cleanText(displayPath), width - 30)}
+                    </Text>
+                  </Box>
+                  <Box width={10} flexShrink={0} justifyContent="flex-end">
+                    <Text dimColor>{formatBytes(file.length)}</Text>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+          <Box justifyContent="space-between" width={width}>
+            <Text dimColor>
+              [space] toggle  .  [a] all  .  [n] none
+            </Text>
+            <Text color={COLOR.good}>
+              Selected: {selected.size} / {fileList.length} files ({formatBytes(Array.from(selected).reduce((sum, idx) => sum + (fileList[idx]?.length ?? 0), 0))})
+            </Text>
+          </Box>
+        </Box>
+      )}
+
       <Box marginTop={1}>
         <Text color={COLOR.accent} bold>
           d
@@ -205,16 +389,7 @@ export function Results() {
     { isActive: focused && mode === "list" },
   );
 
-  useInput(
-    (input, key) => {
-      if (key.escape) {
-        setMode("list");
-        setDetail(null);
-      } else if (input === "d" && detail) openDownload(detail);
-      else if (input === "y" && detail) copyResultMagnet(detail);
-    },
-    { isActive: focused && mode === "detail" },
-  );
+
 
   useInput(
     (_input, key) => {
@@ -327,7 +502,16 @@ export function Results() {
           height={panelOuter}
         >
           {mode === "detail" && detail ? (
-            <Detail r={detail} width={Math.max(10, contentWidth - 4)} />
+            <Detail
+              r={detail}
+              width={Math.max(10, contentWidth - 4)}
+              listHeight={listHeight}
+              focused={focused}
+              onClose={() => {
+                setMode("list");
+                setDetail(null);
+              }}
+            />
           ) : (
             <>
               <Box>{status()}</Box>

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -31,6 +31,9 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "s", label: "Sort results" },
       { keys: "y", label: "Copy magnet" },
       { keys: "m", label: "Paste magnet" },
+      { keys: "space", label: "Toggle file selection" },
+      { keys: "a", label: "Select all files" },
+      { keys: "n", label: "Deselect all files" },
     ],
   },
   {

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -55,6 +55,7 @@ export interface Store {
     magnet: string;
     source?: SourceId;
     sizeBytes?: number;
+    selectedIndices?: number[];
   }) => void;
   copyMagnet: (input: { name: string; magnet: string }) => void;
 

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,10 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    offset: number;
+    progress: number;
+    select(priority?: number): void;
+    deselect(): void;
   }
 
   interface Torrent extends EventEmitter {


### PR DESCRIPTION
## What and why
Multi-file torrents currently download all containing files, wasting bandwidth and disk space when the user only wants specific files. This adds an inline file-selection checklist in the search results detail view so users can pick exactly which files to grab before starting the download.

- **Engine**: `applyFileSelection` deselects unwanted files at the piece level; added per-file progress tracking and selective `totalBytes` calculation.
- **Queue**: `add()` accepts `selectedIndices`; `onMetadata` applies selection and recalculates size; `cleanUnwanted` relocates deselected piece data to a hidden `.unwanted/` directory on completion.
- **Detail View**: Temporary metadata-only fetch populates the file list without committing to a download; auto-cleanup of the engine client on navigation away.
- **Keys**: `space` toggle · `a` all · `n` none (all registered in `HELP_GROUPS` cheatsheet).
- **UI Presentation**: Display paths strip the torrent root folder prefix for cleaner readability.

## Checklist
- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (`queue.test.ts` covers `selectedIndices` and metadata recalculations)
- [x] Added keys are updated in both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] No new `Store` fields were added (reused existing `startDownload` configuration)
- [x] OS-touching code works on Windows, macOS, and Linux (uses standard `node:fs` / `node:path`)
- [x] One concern, with a Conventional Commits title (`feat(download): ...`)