### PR TITLE
chore: update nix package 1.1.1 -> 1.2.0

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,20 +11,21 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
-  version = "1.1.1-unstable";
-  __structedAttrs = true;
+  version = "1.2.0";
+  __structuredAttrs = true;
   strictDeps = true;
 
   src = fetchFromGitHub {
     owner = "baairon";
     repo = "torlink";
-    rev = "3c5b5597d9ad212b6dab50af5a6e614cdfb82743";
-    hash = "sha256-f4olyyE2QqvVyakV5LvQq2Rm01fNeVox1Mk0VOat/nk=";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-nspTUJE9hPxHHt3SuYzZlsvPaUKq/UEwvdKb+/dn3lY=";
   };
 
   nodejs = nodejs_22;
   npmDepsHash = "sha256-7CCecywWleUE7wobdzwWb4Rff0LmrlHcON1iPeiiFnw=";
-  npmFlags = [ "--ignore-scripts" ]; # ignore scripts for ip-set broken pre-install
+  # ignore-scripts for ip-set broken preinstall
+  npmFlags = [ "--ignore-scripts" ];
 
   # node-datachannel binary tarball
   nodeDatachannelPrebuilt = fetchurl {
@@ -34,15 +35,14 @@ buildNpmPackage (finalAttrs: {
 
   # replicate postbuild from package.json
   postBuild = ''
-    cp scripts/cli-entry.cjs dist/cli.cjs
-    chmod +x dist/cli.cjs
+    node scripts/postbuild.cjs
   '';
 
   # extract node-datachannel tarball
+  # add wl-copy and xclip to nix readeable path
   postInstall = ''
     tar -xzf ${finalAttrs.nodeDatachannelPrebuilt} \
       -C $out/lib/node_modules/torlnk/node_modules/node-datachannel
-      # add wl-copy and xclip to nix readeable path
       wrapProgram $out/bin/torlnk \
         --prefix PATH : ${
           lib.makeBinPath [
@@ -55,6 +55,7 @@ buildNpmPackage (finalAttrs: {
   meta = {
     description = "Torlink is a torrent finder that lives in your terminal, with zero setup and nothing to configure.";
     homepage = "https://github.com/baairon/torlink";
+    changelog = "https://github.com/baairon/torlink/releases/tag/v${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ghastrum ];
     mainProgram = "torlnk";


### PR DESCRIPTION
# torlink 1.1.1 -> v1.2.0
## Tests
- Successfully adds trackers with the 't' key rev: f3880f1
- Successfully adds bare infohash (tested with infohash ubuntu 24.04.3) rev: bf2dace
- hjkl navigation works rev: 6ba3e42, 7748c41

## Changelog
- Pin to tag release v1.2.0
- npmDepsHash updated to latest hash
- postBuild is now cross-platform rev: 17a06fa
- Added meta.changelog

<details>
<summary>nix run log</summary>

```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/i9chsayd37v99nd13gqj112cywh4injm-source
source root is source
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
Executing npmConfigHook
Configuring npm
Validating consistency between /build/source/package-lock.json and /nix/store/ddnhc6w06p9clgh420mi78xn2wqdsq6f-torlink-1.2.0-npm-deps/package-lock.json
Setting npm_config_cache to /nix/store/ddnhc6w06p9clgh420mi78xn2wqdsq6f-torlink-1.2.0-npm-deps
Installing dependencies
npm warn deprecated prebuild-install@7.1.3: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead

added 312 packages, and audited 313 packages in 2s

97 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
patching script interpreter paths in node_modules
node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/utp-native/ucat.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/node-gyp-build/build-test.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/node-gyp-build/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/node-gyp-build/optional.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/acorn/bin/acorn: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/create-torrent/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/is-in-ci/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/tree-kill/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/mime/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/parse-torrent/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/nanoid/bin/nanoid.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/sucrase/bin/sucrase: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/sucrase/bin/sucrase-node: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/vitest/vitest.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/typescript/bin/tsc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/typescript/bin/tsserver: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/rc/cli.js: interpreter directive changed from "#! /usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/vite/bin/vite.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/tsx/dist/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/rolldown/bin/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/which/bin/node-which: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/why-is-node-running/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/bittorrent-tracker/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/tsup/node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/tsup/dist/cli-default.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/tsup/dist/cli-node.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
node_modules/prebuild-install/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
rebuilt dependencies successfully
patching script interpreter paths in node_modules
Finished npmConfigHook
Running phase: updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
Running phase: configurePhase
@nix { "action": "setPhase", "phase": "configurePhase" }
no configure script, doing nothing
Running phase: buildPhase
@nix { "action": "setPhase", "phase": "buildPhase" }
Executing npmBuildHook

> torlnk@1.2.0 build
> tsup

CLI Building entry: src/index.tsx
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /build/source/tsup.config.ts
CLI Target: node22
CLI Cleaning output folder
ESM Build start
ESM dist/index.js 65.83 KB
ESM ⚡️ Build success in 23ms
postbuild: wrote dist/cli.cjs
Finished npmBuildHook
Running phase: installPhase
@nix { "action": "setPhase", "phase": "installPhase" }
Executing npmInstallHook

up to date, audited 223 packages in 312ms

75 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Finished npmInstallHook
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
shrinking RPATHs of ELF executables and libraries in /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/utp-native/prebuilds/linux-x64/node.napi.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/node-datachannel/build/Release/node_datachannel.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-ia32/fs-native-extensions.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-ia32/fs-native-extensions.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-x64/fs-native-extensions.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-x64/fs-native-extensions.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-arm64/fs-native-extensions.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-arm64/fs-native-extensions.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm/fs-native-extensions.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm/fs-native-extensions.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm64/fs-native-extensions.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm64/fs-native-extensions.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-x64/fs-native-extensions.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-x64/fs-native-extensions.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.musl.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bufferutil/prebuilds/linux-x64/bufferutil.node
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-ia32/bare-os.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/linux-x64/bare-os.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/linux-arm64/bare-os.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-arm/bare-os.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-arm64/bare-os.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-x64/bare-os.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-ia32/bare-fs.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/linux-x64/bare-fs.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/linux-arm64/bare-fs.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-arm/bare-fs.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-arm64/bare-fs.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-x64/bare-fs.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-ia32/bare-url.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/linux-x64/bare-url.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/linux-arm64/bare-url.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-arm/bare-url.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-arm64/bare-url.bare
shrinking /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-x64/bare-url.bare
checking for references to /build/ in /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0...
patching script interpreter paths in /nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0
/nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/dist/index.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
/nix/store/h9q9vpx29ixvvfb8li1mq0mb1azcbg3c-torlink-1.2.0/lib/node_modules/torlnk/dist/cli.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"

```
</details>
