### PR TITLE
feat: add a download setup modal for folder and file selection

### DIFF
--- a/preview/downloads.svg
+++ b/preview/downloads.svg
@@ -104,10 +104,12 @@
     <text x="60.8" y="414" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Pause</text>
     <text x="137.6" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">c</text>
     <text x="156.8" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Cancel</text>
-    <text x="243.2" y="414" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
-    <text x="281.6" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
-    <text x="368" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
-    <text x="387.2" y="414" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
+    <text x="243.2" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">v</text>
+    <text x="262.4" y="414" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Files</text>
+    <text x="339.2" y="414" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
+    <text x="377.6" y="414" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
+    <text x="464" y="414" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
+    <text x="483.2" y="414" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
   </g>
   <rect x="262.4" y="222" width="9.6" height="22" fill="#7c5cd6">
     <animate attributeName="fill" calcMode="discrete" dur="3.48s" values="#7c5cd6;#7f5fd7;#8669da;#9277de;#a18ae3;#b29ee8;#c3b3ee;#d2c5f3;#ded4f7;#e5ddfa;#e8e0fb;#e5ddfa;#ded4f7;#d2c5f3;#c3b3ee;#b29ee8;#a18ae3;#9277de;#8669da;#7f5fd7;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6;#7c5cd6" repeatCount="indefinite"/>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -98,6 +98,8 @@ function makeStore(
     setSeedFocus: noop,
     startDownload: noop,
     copyMagnet: noop,
+    openAddModal: noop,
+    openFilesModal: noop,
     notice: null,
     setNotice: noop,
     quitAll: noop,

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { pushRecentDir } from "./config";
+
+describe("pushRecentDir", () => {
+  it("prepends a new directory", () => {
+    expect(pushRecentDir(["/a", "/b"], "/c")).toEqual(["/c", "/a", "/b"]);
+  });
+
+  it("moves an existing duplicate to the front instead of adding it twice", () => {
+    expect(pushRecentDir(["/a", "/b", "/c"], "/b")).toEqual(["/b", "/a", "/c"]);
+  });
+
+  it("caps the result at max entries", () => {
+    expect(pushRecentDir(["/a", "/b", "/c"], "/d", 3)).toEqual(["/d", "/a", "/b"]);
+  });
+
+  it("is a no-op for an empty dir", () => {
+    const list = ["/a", "/b"];
+    expect(pushRecentDir(list, "")).toBe(list);
+  });
+
+  it("does not mutate the input array", () => {
+    const list = ["/a", "/b"];
+    pushRecentDir(list, "/c");
+    expect(list).toEqual(["/a", "/b"]);
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,11 +5,13 @@ import { serializeWrites, writeJsonAtomic } from "../util/atomic";
 export interface Config {
   downloadDir: string;
   trackers: string[];
+  recentDirs: string[];
 }
 
 export const defaultConfig: Config = {
   downloadDir: defaultDownloadDir,
   trackers: [],
+  recentDirs: [],
 };
 
 export async function loadConfig(): Promise<Config> {
@@ -17,7 +19,7 @@ export async function loadConfig(): Promise<Config> {
   try {
     raw = await fs.readFile(configFile, "utf8");
   } catch {
-    return { ...defaultConfig, trackers: [] };
+    return { ...defaultConfig, trackers: [], recentDirs: [] };
   }
   try {
     const parsed = JSON.parse(raw) as Partial<Config>;
@@ -29,10 +31,13 @@ export async function loadConfig(): Promise<Config> {
       trackers: Array.isArray(parsed.trackers)
         ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
         : [],
+      recentDirs: Array.isArray(parsed.recentDirs)
+        ? parsed.recentDirs.filter((d): d is string => typeof d === "string" && d.length > 0)
+        : [],
     };
     return cfg;
   } catch {
-    return { ...defaultConfig, trackers: [] };
+    return { ...defaultConfig, trackers: [], recentDirs: [] };
   }
 }
 
@@ -40,4 +45,10 @@ const write = serializeWrites();
 
 export function saveConfig(config: Config): Promise<void> {
   return write(() => writeJsonAtomic(configFile, config));
+}
+
+/** Prepends `dir` to `list` (MRU), removing any earlier duplicate and capping at `max` entries. */
+export function pushRecentDir(list: string[], dir: string, max = 8): string[] {
+  if (!dir) return list;
+  return [dir, ...list.filter((d) => d !== dir)].slice(0, max);
 }

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -12,14 +12,30 @@ export interface TorrentProgress {
   name: string;
 }
 
+export interface FileInfo {
+  name: string;
+  path: string;
+  length: number;
+}
+
 export interface TorrentMeta {
   name: string;
   total: number;
   files: number;
+  fileList: FileInfo[];
   // The .torrent metadata (piece hashes), available once metadata arrives. We
   // persist it so a later re-seed can verify the on-disk file without having to
   // re-fetch metadata from the swarm (which a bare magnet would require).
   torrentFile?: Uint8Array;
+}
+
+// Which files an `add` should fetch. `metaOnly` selects nothing (used by
+// queue.prepare to probe metadata without downloading); `deselected` selects
+// every file *except* the given indices. Neither present means "everything"
+// (the default, unthrottled path).
+export interface SelectionOptions {
+  deselected?: number[];
+  metaOnly?: boolean;
 }
 
 export interface AddHandlers {
@@ -55,6 +71,7 @@ export class TorrentEngine {
     dir: string,
     handlers: AddHandlers,
     announce?: string[],
+    selection?: SelectionOptions,
   ): void {
     const client = this.ensureClient();
     const existing = this.torrents.get(id);
@@ -65,7 +82,15 @@ export class TorrentEngine {
       } catch {}
     }
 
-    const opts = announce && announce.length > 0 ? { path: dir, announce } : { path: dir };
+    const opts: { path?: string; announce?: string[]; deselect?: boolean } = { path: dir };
+    if (announce && announce.length > 0) opts.announce = announce;
+    // A partial selection (or a metadata-only probe) needs webtorrent's
+    // deselect opt *and* an explicit deselect-all once metadata arrives below
+    // -- `deselect: true` alone doesn't reliably stop the whole-torrent
+    // auto-select webtorrent does on add.
+    const selective = Boolean(selection?.metaOnly || selection?.deselected);
+    if (selective) opts.deselect = true;
+
     let torrent: Torrent;
     try {
       torrent = client.add(source, opts);
@@ -76,10 +101,29 @@ export class TorrentEngine {
     this.torrents.set(id, torrent);
 
     torrent.on("metadata", () => {
+      const fileList: FileInfo[] = (torrent.files ?? []).map((f) => ({
+        name: f.name,
+        path: f.path,
+        length: f.length,
+      }));
+
+      if (selective && torrent.pieces?.length) {
+        torrent.deselect(0, torrent.pieces.length - 1, false);
+      }
+      if (selection?.metaOnly) {
+        // Select nothing: this add exists only to fetch metadata.
+      } else if (selection?.deselected) {
+        const off = new Set(selection.deselected);
+        torrent.files.forEach((f, i) => {
+          if (!off.has(i)) f.select();
+        });
+      }
+
       handlers.onMetadata?.({
         name: torrent.name,
         total: torrent.length,
         files: torrent.files?.length ?? 0,
+        fileList,
         torrentFile: torrent.torrentFile,
       });
     });
@@ -116,6 +160,26 @@ export class TorrentEngine {
       timeRemaining: t.timeRemaining,
       name: t.name,
     };
+  }
+
+  // Live selection edits for a torrent already in progress (during-download
+  // file toggling). No-ops before metadata / out of range.
+  selectFile(id: string, index: number): void {
+    const t = this.torrents.get(id);
+    if (!t?.files || index < 0 || index >= t.files.length) return;
+    t.files[index]?.select();
+  }
+
+  deselectFile(id: string, index: number): void {
+    const t = this.torrents.get(id);
+    if (!t?.files || index < 0 || index >= t.files.length) return;
+    t.files[index]?.deselect();
+  }
+
+  files(id: string): FileInfo[] | null {
+    const t = this.torrents.get(id);
+    if (!t?.files) return null;
+    return t.files.map((f) => ({ name: f.name, path: f.path, length: f.length }));
   }
 
   remove(id: string): void {

--- a/src/download/history.ts
+++ b/src/download/history.ts
@@ -14,6 +14,8 @@ export interface HistoryItem {
   magnet: string;
   dir: string;
   completedAt: number;
+  /** Indices of files the user turned off; empty/undefined means all files download. */
+  deselected?: number[];
 }
 
 const write = serializeWrites();

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { DownloadQueue, strayDownload } from "./queue";
 import type { HistoryItem } from "./history";
+import type { QueueItem } from "./types";
 
 function h(over: Partial<HistoryItem> = {}): HistoryItem {
   return {
@@ -10,6 +11,23 @@ function h(over: Partial<HistoryItem> = {}): HistoryItem {
     dir: "/downloads",
     sizeBytes: 100,
     completedAt: 1,
+    ...over,
+  };
+}
+
+function qi(over: Partial<QueueItem> = {}): QueueItem {
+  return {
+    id: "q1",
+    name: "Some Download",
+    magnet: "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+    dir: "/downloads",
+    status: "paused",
+    progress: 40,
+    totalBytes: 100,
+    downloadedBytes: 40,
+    speed: 0,
+    peers: 0,
+    addedAt: 1,
     ...over,
   };
 }
@@ -39,6 +57,55 @@ describe("DownloadQueue seeding", () => {
     q.restoreSeeds([{ id: "h4", status: "paused" }]);
     expect(q.getSeed("h4")?.status).toBe("paused");
     expect(q.seedingCount).toBe(0);
+    q.suspend();
+  });
+});
+
+describe("DownloadQueue.setFileSelected", () => {
+  it("deselecting an index adds it to item.deselected, sorted", () => {
+    const q = new DownloadQueue();
+    q.restore([qi({ id: "q1" })]);
+    q.setFileSelected("q1", 2, false);
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toEqual([2]);
+    q.setFileSelected("q1", 0, false);
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toEqual([0, 2]);
+    q.suspend();
+  });
+
+  it("re-selecting a deselected index removes it", () => {
+    const q = new DownloadQueue();
+    q.restore([qi({ id: "q1", deselected: [0, 1, 2] })]);
+    q.setFileSelected("q1", 1, true);
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toEqual([0, 2]);
+    q.suspend();
+  });
+
+  it("toggling multiple indices keeps the array sorted and unique", () => {
+    const q = new DownloadQueue();
+    q.restore([qi({ id: "q1" })]);
+    q.setFileSelected("q1", 3, false);
+    q.setFileSelected("q1", 1, false);
+    q.setFileSelected("q1", 1, false); // duplicate toggle, no-op on the set
+    q.setFileSelected("q1", 0, false);
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toEqual([0, 1, 3]);
+    q.suspend();
+  });
+
+  it("is a no-op for an unknown id", () => {
+    const q = new DownloadQueue();
+    q.restore([qi({ id: "q1" })]);
+    expect(() => q.setFileSelected("does-not-exist", 0, false)).not.toThrow();
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toBeUndefined();
+    q.suspend();
+  });
+
+  it("behaves the same array-only way for a failed item", () => {
+    const q = new DownloadQueue();
+    q.restore([qi({ id: "q1", status: "failed" })]);
+    q.setFileSelected("q1", 4, false);
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toEqual([4]);
+    q.setFileSelected("q1", 4, true);
+    expect(q.getItems().find((it) => it.id === "q1")?.deselected).toEqual([]);
     q.suspend();
   });
 });

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { TorrentEngine, type AddHandlers } from "./engine";
+import { TorrentEngine, type AddHandlers, type FileInfo } from "./engine";
 import {
   saveQueue,
   saveQueueSync,
@@ -54,6 +54,10 @@ export class DownloadQueue extends EventEmitter {
   private strayHits = new Map<string, number>();
   private seedStartedAt = new Map<string, number>();
   private trackers: string[] = [];
+  // In-flight "prepare" probes: metadata-only adds used to show a torrent's
+  // file list before the user commits to a download. Deliberately not in
+  // `items` so they never show up in Downloads / count toward activeCount.
+  private preparing = new Map<string, { dir: string }>();
 
   // Extra announce URLs appended to every torrent added from now on.
   // Existing running torrents aren't retro-updated — the change takes effect
@@ -76,7 +80,7 @@ export class DownloadQueue extends EventEmitter {
     return this.items.has(id);
   }
 
-  add(input: AddInput, dir: string): void {
+  add(input: AddInput, dir: string, deselected?: number[]): void {
     if (this.seeds.has(input.id)) {
       this.engine.remove(input.id);
       this.seeds.delete(input.id);
@@ -87,7 +91,7 @@ export class DownloadQueue extends EventEmitter {
     const existing = this.items.get(input.id);
     if (existing && existing.status !== "failed") return;
     const item: QueueItem = existing
-      ? { ...existing, status: "downloading", error: undefined, speed: 0 }
+      ? { ...existing, status: "downloading", error: undefined, speed: 0, deselected }
       : {
           id: input.id,
           name: input.name,
@@ -101,6 +105,7 @@ export class DownloadQueue extends EventEmitter {
           speed: 0,
           peers: 0,
           addedAt: Date.now(),
+          deselected,
         };
     this.items.set(item.id, item);
     this.startEngine(item);
@@ -110,7 +115,59 @@ export class DownloadQueue extends EventEmitter {
   }
 
   private startEngine(item: QueueItem): void {
-    this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+    // Prefer the stored .torrent when we have one (e.g. from a prior prepare
+    // probe or a previous run of this item): webtorrent verifies it locally
+    // instead of re-fetching metadata from the swarm, so the selection below
+    // applies instantly.
+    const source = torrentMetaExists(item.id) ? torrentMetaPath(item.id) : item.magnet;
+    this.engine.add(item.id, source, item.dir, this.engineHandlers(item.id), this.trackers, {
+      deselected: item.deselected,
+    });
+  }
+
+  // Probe a magnet's file list without downloading anything or touching the
+  // Downloads list: adds it metadata-only (see engine's SelectionOptions) and
+  // saves the .torrent as soon as it arrives, so a later commitPrepare can
+  // re-add from that stored file for instant metadata.
+  prepare(
+    input: { id: string; magnet: string },
+    dir: string,
+    handlers: { onFiles: (files: FileInfo[]) => void; onError?: (msg: string) => void },
+  ): void {
+    this.preparing.set(input.id, { dir });
+    this.engine.add(
+      input.id,
+      input.magnet,
+      dir,
+      {
+        onMetadata: (meta) => {
+          if (meta.torrentFile) void saveTorrentMeta(input.id, meta.torrentFile);
+          handlers.onFiles(meta.fileList);
+        },
+        onError: (msg) => handlers.onError?.(msg),
+      },
+      this.trackers,
+      { metaOnly: true },
+    );
+  }
+
+  // Promote a prepared probe into a real download: `add` already destroys the
+  // metaOnly torrent and re-adds under the same id (preferring the saved
+  // .torrent), this time with the real selection.
+  commitPrepare(input: AddInput, dir: string, deselected: number[]): void {
+    this.preparing.delete(input.id);
+    this.add(input, dir, deselected);
+  }
+
+  cancelPrepare(id: string): void {
+    if (!this.preparing.has(id)) return;
+    this.engine.remove(id);
+    this.preparing.delete(id);
+    // Only clean up the probed .torrent if nothing else references this id;
+    // an item/seed/history entry may depend on it for instant metadata.
+    if (!this.items.has(id) && !this.seeds.has(id) && !this.history.find((h) => h.id === id)) {
+      deleteTorrentMeta(id);
+    }
   }
 
   // One torrent serves an item across its whole life (download -> seed ->
@@ -129,6 +186,7 @@ export class DownloadQueue extends EventEmitter {
         if (meta.name) it.name = meta.name;
         if (meta.total) it.totalBytes = meta.total;
         it.files = meta.files;
+        it.fileList = meta.fileList;
         this.changed();
         void this.persist();
       },
@@ -306,6 +364,29 @@ export class DownloadQueue extends EventEmitter {
     else if (it.status === "paused") this.resume(id);
   }
 
+  // Toggle a single file's selection for an in-progress or paused download. A
+  // live download gets an immediate select/deselect on the engine; a paused
+  // one just updates the persisted list, which re-applies on resume.
+  setFileSelected(id: string, index: number, selected: boolean): void {
+    const it = this.items.get(id);
+    if (!it) return;
+    const off = new Set(it.deselected ?? []);
+    if (selected) off.delete(index);
+    else off.add(index);
+    it.deselected = [...off].sort((a, b) => a - b);
+    if (it.status === "downloading") {
+      if (selected) this.engine.selectFile(id, index);
+      else this.engine.deselectFile(id, index);
+    }
+    this.changed();
+    void this.persist();
+  }
+
+  // Live file list for a during-download editing UI.
+  files(id: string): FileInfo[] | null {
+    return this.engine.files(id);
+  }
+
   cancel(id: string): void {
     if (!this.items.has(id)) return;
     this.engine.remove(id);
@@ -380,7 +461,9 @@ export class DownloadQueue extends EventEmitter {
     // Seed from the stored .torrent metadata when we have it (verifies the local
     // file immediately, no swarm needed); fall back to the magnet otherwise.
     const source = torrentMetaExists(h.id) ? torrentMetaPath(h.id) : h.magnet;
-    this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers);
+    this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers, {
+      deselected: h.deselected,
+    });
     this.ensurePoll();
     this.changed();
     void this.persistSeeds();
@@ -478,6 +561,7 @@ export class DownloadQueue extends EventEmitter {
       magnet: it.magnet,
       dir: it.dir,
       completedAt: Date.now(),
+      deselected: it.deselected,
     };
     this.history = [rec, ...this.history.filter((h) => h.id !== it.id)].slice(0, HISTORY_MAX);
     void saveHistory(this.history).catch(() => {});

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -1,4 +1,5 @@
 import type { SourceId } from "../sources/types";
+import type { FileInfo } from "./engine";
 
 export type DownloadStatus = "downloading" | "paused" | "completed" | "failed";
 
@@ -33,4 +34,9 @@ export interface QueueItem {
   files?: number;
   error?: string;
   addedAt: number;
+  /** Indices of files the user turned off; empty/undefined means all files download. */
+  deselected?: number[];
+  /** Cached file list so paused/restored items can still show/edit selection
+   * once the live torrent (and its engine-side file list) is gone. */
+  fileList?: FileInfo[];
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout, useStdin } from "ink";
 import { promises as fs } from "node:fs";
-import { loadConfig, saveConfig, type Config } from "../config/config";
+import { loadConfig, saveConfig, pushRecentDir, type Config } from "../config/config";
 import { normalizeDownloadDir } from "../config/folder";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
@@ -34,10 +34,12 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { AddModal } from "./components/AddModal";
+import { DownloadFilesModal } from "./components/DownloadFilesModal";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
-import type { SourceId } from "../sources/types";
+import type { SourceId, TorrentResult } from "../sources/types";
 
 export function App({
   initialMagnet,
@@ -85,6 +87,8 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  const [addTarget, setAddTarget] = useState<TorrentResult | null>(null);
+  const [filesTarget, setFilesTarget] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const booting = useRef(false);
 
@@ -225,6 +229,38 @@ export function App({
     [config, queue],
   );
 
+  const openAddModal = useCallback((result: TorrentResult) => {
+    setAddTarget(result);
+  }, []);
+
+  const openFilesModal = useCallback((id: string) => {
+    setFilesTarget(id);
+  }, []);
+
+  const commitAdd = useCallback(
+    (dir: string, deselected: number[]) => {
+      if (!config || !queue || !addTarget) return;
+      void fs.mkdir(dir, { recursive: true }).catch(() => {});
+      setConfig({ ...config, recentDirs: pushRecentDir(config.recentDirs, dir) });
+      queue.commitPrepare(
+        {
+          id: addTarget.infoHash,
+          name: addTarget.name,
+          magnet: addTarget.magnet,
+          source: addTarget.source,
+          sizeBytes: addTarget.sizeBytes,
+        },
+        dir,
+        deselected,
+      );
+      setNotice(`Added: ${truncate(cleanText(addTarget.name), 40)}`);
+      setSection("downloads");
+      setRegion("content");
+      setAddTarget(null);
+    },
+    [config, queue, addTarget, setConfig],
+  );
+
   const copyMagnet = useCallback((input: { name: string; magnet: string }) => {
     void (async () => {
       const ok = await writeClipboard(input.magnet);
@@ -306,7 +342,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || !!addTarget || !!filesTarget ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -316,6 +352,8 @@ export function App({
       setSeedFocus,
       startDownload,
       copyMagnet,
+      openAddModal,
+      openFilesModal,
       notice,
       setNotice,
       quitAll,
@@ -336,11 +374,15 @@ export function App({
     showHelp,
     editingFolder,
     editingTrackers,
+    addTarget,
+    filesTarget,
     captureMode,
     downloadFocus,
     seedFocus,
     startDownload,
     copyMagnet,
+    openAddModal,
+    openFilesModal,
     notice,
     listRows,
     compact,
@@ -357,7 +399,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || addTarget || filesTarget) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -465,10 +507,36 @@ export function App({
           </Box>
         ) : null}
 
+        {addTarget ? (
+          <Box marginTop={1}>
+            <AddModal
+              result={addTarget}
+              defaultDir={store.config.downloadDir}
+              recents={store.config.recentDirs}
+              queue={store.queue}
+              onCommit={commitAdd}
+              onCancel={() => setAddTarget(null)}
+              width={Math.max(28, Math.min(cols - 4, 72))}
+            />
+          </Box>
+        ) : null}
+
+        {filesTarget ? (
+          <Box marginTop={1}>
+            <DownloadFilesModal
+              id={filesTarget}
+              queue={store.queue}
+              onClose={() => setFilesTarget(null)}
+              width={Math.max(28, Math.min(cols - 4, 72))}
+              height={bodyH}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || addTarget || filesTarget ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -484,7 +552,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || addTarget || filesTarget ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/AddModal.test.tsx
+++ b/src/ui/components/AddModal.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "ink-testing-library";
+import { AddModal } from "./AddModal";
+import { StoreContext, type Store } from "../store";
+import { formatBytes } from "../../util/format";
+import type { DownloadQueue } from "../../download/queue";
+import type { FileInfo } from "../../download/engine";
+import type { TorrentResult } from "../../sources/types";
+
+const ENTER = "\r";
+const TAB = "\t";
+const ESC = "\x1b";
+const DOWN = "\x1b[B";
+const SPACE = " ";
+
+// Ink processes keypresses through the `scheduler` package rather than
+// flushing the resulting state synchronously, and the modal's mount effect
+// (queue.prepare) is a passive effect too. Tests yield a tick between an
+// input/mount and whatever depends on its result (a re-render, a follow-up
+// keystroke whose handling depends on updated state, etc).
+const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+// A lone ESC byte is ambiguous (it may be the start of a multi-byte escape
+// sequence), so Ink's input parser holds it for `pendingInputFlushDelayMilliseconds`
+// (20ms) before treating it as a standalone Escape keypress. A plain tick()
+// isn't enough here; wait past that window instead.
+const awaitEscapeFlush = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 25));
+
+const result: TorrentResult = {
+  infoHash: "deadbeef",
+  name: "Some Movie",
+  sizeBytes: 1000,
+  seeders: 5,
+  leechers: 1,
+  source: "yts",
+  magnet: "magnet:?xt=urn:btih:deadbeef",
+};
+
+const FAKE_FILES: FileInfo[] = [
+  { name: "a", path: "a", length: 100 },
+  { name: "b", path: "b", length: 200 },
+];
+
+interface StubQueue {
+  prepare: (
+    input: unknown,
+    dir: string,
+    handlers: { onFiles: (f: FileInfo[]) => void },
+  ) => void;
+  cancelPrepare: ReturnType<typeof vi.fn>;
+  commitPrepare: ReturnType<typeof vi.fn>;
+}
+
+function makeQueue(files: FileInfo[] = FAKE_FILES): StubQueue {
+  return {
+    prepare: (_input, _dir, handlers) => {
+      handlers.onFiles(files);
+    },
+    cancelPrepare: vi.fn(),
+    commitPrepare: vi.fn(),
+  };
+}
+
+const store = { listRows: 14 } as unknown as Store;
+
+function renderModal(opts: { queue?: StubQueue; recents?: string[]; defaultDir?: string } = {}) {
+  const queue = opts.queue ?? makeQueue();
+  const onCommit = vi.fn();
+  const onCancel = vi.fn();
+  const utils = render(
+    <StoreContext.Provider value={store}>
+      <AddModal
+        result={result}
+        defaultDir={opts.defaultDir ?? "/dl"}
+        recents={opts.recents ?? ["/games"]}
+        queue={queue as unknown as DownloadQueue}
+        onCommit={onCommit}
+        onCancel={onCancel}
+        width={60}
+      />
+    </StoreContext.Provider>,
+  );
+  return { ...utils, queue, onCommit, onCancel };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AddModal", () => {
+  it("loads the prepared file list on mount", async () => {
+    const { lastFrame } = renderModal();
+    await tick();
+    const frame = lastFrame() ?? "";
+    const rows = frame.split("\n").filter((line) => line.includes("[x]") || line.includes("[ ]"));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toContain("[x]");
+    expect(rows[0]).toContain(formatBytes(100));
+    expect(rows[1]).toContain("[x]");
+    expect(rows[1]).toContain(formatBytes(200));
+  });
+
+  it("Enter on the path pane commits the (typed) default dir with nothing deselected", async () => {
+    const { stdin, onCommit } = renderModal();
+    stdin.write(ENTER);
+    await tick();
+    expect(onCommit).toHaveBeenCalledWith("/dl", []);
+  });
+
+  it("Tab -> Files pane -> space deselects a file, reported on commit", async () => {
+    const { stdin, onCommit } = renderModal();
+    await tick(); // let the file list load so FileSelect mounts
+    stdin.write(TAB);
+    await tick(); // focus -> files, FileSelect's useInput becomes active
+    stdin.write(SPACE); // deselect index 0
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onCommit).toHaveBeenCalledWith("/dl", [0]);
+  });
+
+  it("blocks the commit and shows a notice when every file is deselected", async () => {
+    const { stdin, onCommit, lastFrame } = renderModal();
+    await tick();
+    stdin.write(TAB);
+    await tick();
+    stdin.write(SPACE); // deselect index 0
+    await tick();
+    stdin.write(DOWN); // move to index 1
+    await tick();
+    stdin.write(SPACE); // deselect index 1 - none left
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(lastFrame() ?? "").toContain("Select at least one file.");
+  });
+
+  it("Esc cancels", async () => {
+    const { stdin, onCancel } = renderModal();
+    stdin.write(ESC);
+    await awaitEscapeFlush();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the prepared probe on unmount without a commit", async () => {
+    const { unmount, queue } = renderModal();
+    await tick();
+    unmount();
+    expect(queue.cancelPrepare).toHaveBeenCalledWith(result.infoHash);
+  });
+
+  it("does not cancel the prepared probe once already committed", async () => {
+    const { stdin, unmount, queue } = renderModal();
+    stdin.write(ENTER);
+    await tick();
+    unmount();
+    expect(queue.cancelPrepare).not.toHaveBeenCalled();
+  });
+
+  it("Down from the path input moves into the recent list; picking a recent dir commits it", async () => {
+    const { stdin, onCommit } = renderModal({ defaultDir: "/dl", recents: ["/games"] });
+    stdin.write(DOWN); // path input -> recent row 0 ("/dl", labeled default)
+    await tick();
+    stdin.write(DOWN); // recent row 0 -> recent row 1 ("/games")
+    await tick();
+    stdin.write(ENTER);
+    await tick();
+    expect(onCommit).toHaveBeenCalledWith("/games", []);
+  });
+});

--- a/src/ui/components/AddModal.tsx
+++ b/src/ui/components/AddModal.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { TextField } from "./TextField";
+import { Spinner } from "./Spinner";
+import { FileSelect } from "./FileSelect";
+import { Footer } from "./Footer";
+import { useStore } from "../store";
+import { wrapStep } from "../move";
+import { normalizeDownloadDir } from "../../config/folder";
+import { cleanText } from "../../util/format";
+import { COLOR, GUTTER, ICON } from "../theme";
+import type { Hint } from "../keymap";
+import type { DownloadQueue } from "../../download/queue";
+import type { FileInfo } from "../../download/engine";
+import type { TorrentResult } from "../../sources/types";
+
+// Terse, single-line hints. Rendered through Footer so the row wraps at word
+// boundaries (one root <Text>) instead of clipping mid-word on a narrow modal.
+const HINTS: Hint[] = [
+  { keys: "tab", label: "switch" },
+  { keys: "↑↓", label: "move" },
+  { keys: "space", label: "toggle" },
+  { keys: "↵", label: "start" },
+  { keys: "esc", label: "cancel" },
+];
+
+interface AddModalProps {
+  result: TorrentResult;
+  defaultDir: string;
+  recents: string[];
+  queue: DownloadQueue;
+  onCommit: (dir: string, deselected: number[]) => void;
+  onCancel: () => void;
+  width: number;
+}
+
+type Focus = "path" | "files";
+
+export function AddModal({
+  result,
+  defaultDir,
+  recents,
+  queue,
+  onCommit,
+  onCancel,
+  width,
+}: AddModalProps) {
+  const { listRows } = useStore();
+  const [focus, setFocus] = useState<Focus>("path");
+  const [pathCursor, setPathCursor] = useState(0);
+  const [typed, setTyped] = useState(defaultDir);
+  const [deselected, setDeselected] = useState<Set<number>>(() => new Set());
+  const [files, setFiles] = useState<FileInfo[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const committed = useRef(false);
+
+  // [default, ...recents] deduped, default always first.
+  const recentList = useMemo(() => {
+    const seen = new Set<string>();
+    const list: string[] = [];
+    for (const dir of [defaultDir, ...recents]) {
+      if (!dir || seen.has(dir)) continue;
+      seen.add(dir);
+      list.push(dir);
+    }
+    return list;
+  }, [defaultDir, recents]);
+
+  useEffect(() => {
+    queue.prepare({ id: result.infoHash, magnet: result.magnet }, defaultDir, {
+      onFiles: setFiles,
+      onError: (msg) => setError(msg),
+    });
+    return () => {
+      if (!committed.current) queue.cancelPrepare(result.infoHash);
+    };
+  }, [queue, result.infoHash, result.magnet, defaultDir]);
+
+  const resolveDir = (): string =>
+    pathCursor === 0 ? normalizeDownloadDir(typed) || defaultDir : recentList[pathCursor - 1]!;
+
+  function confirm(dir: string): void {
+    if (files && files.length > 0 && deselected.size >= files.length) {
+      setError("Select at least one file.");
+      return;
+    }
+    committed.current = true;
+    onCommit(dir, [...deselected].sort((a, b) => a - b));
+  }
+
+  useInput((input, key) => {
+    if (key.tab) {
+      setFocus((f) => (f === "path" ? "files" : "path"));
+      return;
+    }
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (focus === "path" && pathCursor > 0) {
+      if (key.upArrow || input === "k") {
+        setPathCursor(pathCursor === 1 ? 0 : pathCursor - 1);
+        return;
+      }
+      if (key.downArrow || input === "j") {
+        setPathCursor(wrapStep(pathCursor - 1, 1, recentList.length) + 1);
+        return;
+      }
+      if (key.return) {
+        confirm(resolveDir());
+        return;
+      }
+      return;
+    }
+    if (focus === "files" && key.return) {
+      confirm(resolveDir());
+    }
+  });
+
+  const pathPanelHeight = 1 + recentList.length;
+  const filesPanelHeight = Math.max(3, listRows - pathPanelHeight - 5);
+  const filesInnerWidth = Math.max(10, width - 4);
+  const filesSlack = Math.max(1, filesPanelHeight - 1 - (error && files ? 1 : 0));
+
+  function handleToggle(index: number): void {
+    setDeselected((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+    setError(null);
+  }
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Box marginBottom={1}>
+        <Text bold color={COLOR.text} wrap="truncate-end">
+          {cleanText(result.name)}
+        </Text>
+      </Box>
+      <Panel title="path" width={width} focused={focus === "path"} height={pathPanelHeight}>
+        <Box>
+          <Box width={GUTTER} flexShrink={0}>
+            <Text color={COLOR.accent}>{focus === "path" && pathCursor === 0 ? ICON.pointer : ""}</Text>
+          </Box>
+          <Box flexGrow={1} minWidth={0}>
+            <TextField
+              isDisabled={focus !== "path" || pathCursor !== 0}
+              defaultValue={defaultDir}
+              placeholder="~/Downloads/torlink"
+              onChange={setTyped}
+              onSubmit={() => confirm(resolveDir())}
+              onExitDown={() => setPathCursor(1)}
+            />
+          </Box>
+        </Box>
+        {recentList.map((dir, i) => {
+          const here = focus === "path" && pathCursor === i + 1;
+          return (
+            <Box key={dir}>
+              <Box width={GUTTER} flexShrink={0}>
+                <Text color={COLOR.accent}>{here ? ICON.pointer : ""}</Text>
+              </Box>
+              <Box flexGrow={1} minWidth={0}>
+                <Text wrap="truncate-end" color={here ? COLOR.accent : undefined} bold={here} dimColor={!here}>
+                  {dir}
+                </Text>
+              </Box>
+              {i === 0 ? (
+                <Box flexShrink={0} marginLeft={1}>
+                  <Text dimColor>default</Text>
+                </Box>
+              ) : null}
+            </Box>
+          );
+        })}
+      </Panel>
+
+      <Box marginTop={1}>
+        <Panel title="files" width={width} focused={focus === "files"} height={filesPanelHeight}>
+          {files === null && !error ? (
+            <Spinner label="Reading files…" />
+          ) : files === null && error ? (
+            <Text dimColor>{error}</Text>
+          ) : (
+            <>
+              <FileSelect
+                files={files!}
+                deselected={deselected}
+                onToggle={handleToggle}
+                active={focus === "files"}
+                focused={focus === "files"}
+                width={filesInnerWidth}
+                height={filesSlack}
+              />
+              {error ? <Text dimColor>{error}</Text> : null}
+            </>
+          )}
+        </Panel>
+      </Box>
+
+      <Box marginTop={1}>
+        <Footer hints={HINTS} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/DownloadFilesModal.tsx
+++ b/src/ui/components/DownloadFilesModal.tsx
@@ -1,0 +1,46 @@
+import { useMemo } from "react";
+import { Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { FileSelect } from "./FileSelect";
+import { useQueueItems } from "../store";
+import type { DownloadQueue } from "../../download/queue";
+
+interface DownloadFilesModalProps {
+  id: string;
+  queue: DownloadQueue;
+  onClose: () => void;
+  width: number;
+  height: number;
+}
+
+export function DownloadFilesModal({ id, queue, onClose, width, height }: DownloadFilesModalProps) {
+  const items = useQueueItems(queue);
+  const item = items.find((it) => it.id === id);
+  const deselectedSet = useMemo(() => new Set(item?.deselected ?? []), [item?.deselected]);
+  const files = queue.files(id) ?? item?.fileList ?? null;
+
+  useInput((_input, key) => {
+    if (key.return || key.escape) onClose();
+  });
+
+  const panelH = Math.max(3, height - 1);
+  const listH = Math.max(1, panelH - 1);
+
+  return (
+    <Panel title="select files" width={width} focused height={panelH}>
+      {files === null ? (
+        <Text dimColor>Files available once metadata arrives.</Text>
+      ) : (
+        <FileSelect
+          files={files}
+          deselected={deselectedSet}
+          onToggle={(i) => queue.setFileSelected(id, i, deselectedSet.has(i))}
+          active
+          focused
+          width={Math.max(10, width - 4)}
+          height={listH}
+        />
+      )}
+    </Panel>
+  );
+}

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -44,7 +44,8 @@ function rightStats(it: QueueItem): string {
 }
 
 export function Downloads() {
-  const { queue, region, contentWidth, listRows, startDownload, setDownloadFocus } = useStore();
+  const { queue, region, contentWidth, listRows, startDownload, openFilesModal, setDownloadFocus } =
+    useStore();
   const active = useQueueItems(queue);
   const recent = useQueueHistory(queue);
   const focused = region === "content";
@@ -66,6 +67,7 @@ export function Downloads() {
         if (!it) return;
         if (input === "c") queue.cancel(it.id);
         else if (input === "p") queue.togglePause(it.id);
+        else if (input === "v" && it.status !== "failed") openFilesModal(it.id);
       } else {
         const h = recent[recentCursor];
         if (!h) return;

--- a/src/ui/components/FileSelect.test.tsx
+++ b/src/ui/components/FileSelect.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { FileSelect } from "./FileSelect";
+import type { FileInfo } from "../../download/engine";
+import { formatBytes } from "../../util/format";
+
+const DOWN = "\x1b[B";
+
+// Ink flushes state updates from a keypress asynchronously (via the
+// `scheduler` package), so a second keystroke that depends on the first
+// having already re-rendered needs a tick in between.
+const tick = (): Promise<void> => new Promise((resolve) => setImmediate(resolve));
+
+const files: FileInfo[] = [
+  { name: "movie.mkv", path: "movie.mkv", length: 1_500_000_000 },
+  { name: "subs.srt", path: "subs.srt", length: 2048 },
+  { name: "sample.mkv", path: "sample.mkv", length: 1024 },
+];
+
+describe("FileSelect", () => {
+  it("toggles the file under the cursor (index 0) on space", () => {
+    const onToggle = vi.fn();
+    const { stdin } = render(
+      <FileSelect
+        files={files}
+        deselected={new Set()}
+        onToggle={onToggle}
+        active
+        focused
+        width={40}
+        height={5}
+      />,
+    );
+    stdin.write(" ");
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith(0);
+  });
+
+  it("moves the cursor down before toggling", async () => {
+    const onToggle = vi.fn();
+    const { stdin } = render(
+      <FileSelect
+        files={files}
+        deselected={new Set()}
+        onToggle={onToggle}
+        active
+        focused
+        width={40}
+        height={5}
+      />,
+    );
+    stdin.write(DOWN);
+    await tick();
+    stdin.write(" ");
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith(1);
+  });
+
+  it("does not call onToggle when inactive", () => {
+    const onToggle = vi.fn();
+    const { stdin } = render(
+      <FileSelect
+        files={files}
+        deselected={new Set()}
+        onToggle={onToggle}
+        active={false}
+        focused
+        width={40}
+        height={5}
+      />,
+    );
+    stdin.write(" ");
+    stdin.write(DOWN);
+    stdin.write(" ");
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("renders [x]/[ ] checkboxes, file names and sizes", () => {
+    const { lastFrame } = render(
+      <FileSelect
+        files={files}
+        deselected={new Set([1])}
+        onToggle={vi.fn()}
+        active
+        focused
+        width={40}
+        height={5}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+
+    expect(lines[0]).toContain("[x]");
+    expect(lines[0]).toContain("movie.mkv");
+    expect(lines[0]).toContain(formatBytes(1_500_000_000));
+
+    expect(lines[1]).toContain("[ ]");
+    expect(lines[1]).toContain("subs.srt");
+    expect(lines[1]).toContain(formatBytes(2048));
+
+    expect(lines[2]).toContain("[x]");
+    expect(lines[2]).toContain("sample.mkv");
+    expect(lines[2]).toContain(formatBytes(1024));
+  });
+});

--- a/src/ui/components/FileSelect.tsx
+++ b/src/ui/components/FileSelect.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import type { FileInfo } from "../../download/engine";
+import { wrapStep, windowStart } from "../move";
+import { COLOR, GUTTER, ICON } from "../theme";
+import { formatBytes } from "../../util/format";
+
+interface FileSelectProps {
+  files: FileInfo[];
+  deselected: Set<number>;
+  onToggle: (index: number) => void;
+  active: boolean;
+  focused: boolean;
+  width: number;
+  height: number;
+}
+
+const CHECKBOX_W = 3;
+const SIZE_W = 10;
+
+// Shared, scrollable checkbox list for a torrent's files. Space toggles the
+// cursor row; up/down move it. Tab/enter/esc are deliberately left unhandled
+// so a hosting modal (AddModal, DownloadFilesModal) owns those keys.
+export function FileSelect({
+  files,
+  deselected,
+  onToggle,
+  active,
+  focused,
+  width,
+  height,
+}: FileSelectProps) {
+  const [cursor, setCursor] = useState(0);
+  const clamped = Math.min(cursor, Math.max(0, files.length - 1));
+
+  useInput(
+    (input, key) => {
+      if (key.upArrow || input === "k") setCursor(wrapStep(clamped, -1, files.length));
+      else if (key.downArrow || input === "j") setCursor(wrapStep(clamped, 1, files.length));
+      else if (input === " ") onToggle(clamped);
+    },
+    { isActive: active },
+  );
+
+  const start = windowStart(clamped, files.length, height);
+  const visible = files.slice(start, start + height);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      {visible.map((file, i) => {
+        const index = start + i;
+        const here = index === clamped && focused;
+        const off = deselected.has(index);
+        return (
+          <Box key={file.path}>
+            <Box width={GUTTER} flexShrink={0}>
+              <Text color={COLOR.accent}>{focused && here ? ICON.pointer : ""}</Text>
+            </Box>
+            <Box width={CHECKBOX_W} flexShrink={0}>
+              <Text color={here ? COLOR.accent : undefined} bold={here} dimColor={!here}>
+                {off ? "[ ]" : "[x]"}
+              </Text>
+            </Box>
+            <Box flexGrow={1} minWidth={0} marginLeft={1}>
+              <Text
+                wrap="truncate-end"
+                color={here ? COLOR.accent : undefined}
+                bold={here}
+                dimColor={off || !here}
+              >
+                {file.name}
+              </Text>
+            </Box>
+            <Box width={SIZE_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
+              <Text dimColor>{formatBytes(file.length)}</Text>
+            </Box>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -116,7 +116,7 @@ export function Results() {
     region,
     setRegion,
     setCaptureMode,
-    startDownload,
+    openAddModal,
     copyMagnet,
     contentWidth,
     listRows,
@@ -159,15 +159,6 @@ export function Results() {
   const listHeight = Math.max(3, panelOuter - 4);
   const pageJump = Math.max(1, listHeight - 1);
 
-  const openDownload = (r: TorrentResult): void =>
-    startDownload({
-      id: r.infoHash,
-      name: r.name,
-      magnet: r.magnet,
-      source: r.source,
-      sizeBytes: r.sizeBytes,
-    });
-
   const copyResultMagnet = (r: TorrentResult): void =>
     copyMagnet({ name: r.name, magnet: r.magnet });
 
@@ -194,7 +185,7 @@ export function Results() {
         }
       } else if (input === "d") {
         const r = results[clamped];
-        if (r) openDownload(r);
+        if (r) openAddModal(r);
       } else if (input === "y") {
         const r = results[clamped];
         if (r) copyResultMagnet(r);
@@ -210,7 +201,7 @@ export function Results() {
       if (key.escape) {
         setMode("list");
         setDetail(null);
-      } else if (input === "d" && detail) openDownload(detail);
+      } else if (input === "d" && detail) openAddModal(detail);
       else if (input === "y" && detail) copyResultMagnet(detail);
     },
     { isActive: focused && mode === "detail" },

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -40,6 +40,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "c", label: "Cancel or remove from list" },
       { keys: "f", label: "Retry failed" },
       { keys: "d", label: "Download again" },
+      { keys: "v", label: "Select files" },
       { keys: "x", label: "Clear recent" },
     ],
   },
@@ -48,6 +49,16 @@ export const HELP_GROUPS: HelpGroup[] = [
     hints: [
       { keys: "p", label: "Pause/resume" },
       { keys: "c", label: "Remove from list" },
+    ],
+  },
+  {
+    title: "Add / files",
+    hints: [
+      { keys: "tab", label: "Switch path/files" },
+      { keys: "↑ ↓", label: "Move" },
+      { keys: "space", label: "Toggle file" },
+      { keys: "↵", label: "Start/confirm" },
+      { keys: "esc", label: "Cancel" },
     ],
   },
 ];
@@ -82,7 +93,13 @@ export function footerHints(
   }
   if (section === "downloads") {
     if (downloadFocus === "paused") {
-      return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, SWITCH, ALWAYS];
+      return [
+        { keys: "p", label: "Resume" },
+        { keys: "c", label: "Cancel" },
+        { keys: "v", label: "Files" },
+        SWITCH,
+        ALWAYS,
+      ];
     }
     if (downloadFocus === "failed") {
       return [{ keys: "f", label: "Retry" }, { keys: "c", label: "Remove" }, SWITCH, ALWAYS];
@@ -97,7 +114,13 @@ export function footerHints(
         ALWAYS,
       ];
     }
-    return [{ keys: "p", label: "Pause" }, { keys: "c", label: "Cancel" }, SWITCH, ALWAYS];
+    return [
+      { keys: "p", label: "Pause" },
+      { keys: "c", label: "Cancel" },
+      { keys: "v", label: "Files" },
+      SWITCH,
+      ALWAYS,
+    ];
   }
   return [
     NAVIGATE,

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -3,7 +3,7 @@ import type { Config } from "../config/config";
 import type { DownloadQueue } from "../download/queue";
 import type { HistoryItem } from "../download/history";
 import type { QueueItem, SeedItem } from "../download/types";
-import type { SourceGroup, SourceId } from "../sources/types";
+import type { SourceGroup, SourceId, TorrentResult } from "../sources/types";
 
 export type View = "splash" | "browser";
 
@@ -57,6 +57,8 @@ export interface Store {
     sizeBytes?: number;
   }) => void;
   copyMagnet: (input: { name: string; magnet: string }) => void;
+  openAddModal: (result: TorrentResult) => void;
+  openFilesModal: (id: string) => void;
 
   notice: string | null;
   setNotice: (s: string | null) => void;

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,9 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    downloaded: number;
+    select(): void;
+    deselect(): void;
   }
 
   interface Torrent extends EventEmitter {
@@ -25,15 +28,19 @@ declare module "webtorrent" {
     paused: boolean;
     path: string;
     files: TorrentFile[];
+    pieces: unknown[];
     pause(): void;
     resume(): void;
     addPeer(peer: string): boolean;
     destroy(cb?: (err?: Error) => void): void;
+    select(start: number, end: number, priority: number | false): void;
+    deselect(start: number, end: number, priority: number | false): void;
   }
 
   interface TorrentOptions {
     path?: string;
     announce?: string[];
+    deselect?: boolean;
   }
 
   interface WebTorrentOptions {


### PR DESCRIPTION
## What and why

Pressing `d` used to drop a torrent straight into the single global download folder with every file selected. This adds a small setup modal so each download can go where you want and fetch only the files you need — the two things people most often want to control at download time. It's one flow: path first, `tab` to files, `↵` to start.

- **Path pane** — type a destination or pick from a recent-folders list (MRU, per-download; the global default set via `o` is untouched).
- **Files pane** (`tab` over) — the file list loads via a metadata-only probe that downloads nothing, then `space` deselects files you don't want and `↵` starts the download with just your picks. `↵` straight from the Path pane keeps the old "everything" behaviour, so nothing gets slower for people who don't care.
- **`v` on a download** revisits file selection later; the choice persists across pause/resume and restart, and is reapplied when the torrent re-seeds, so an excluded file is never silently re-fetched.

Magnet paste, CLI launch, and "download again" are unchanged (default folder, all files). Selective downloading uses webtorrent's `deselect` add-option plus an explicit deselect-all-then-select-wanted on the `metadata` event; worth a quick smoke test with a multi-file magnet since that behaviour is hard to unit-test.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (adds tests for the recent-folders MRU, the file-select toggle, the full add-modal flow, and `setFileSelected`)
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` (`v` in Downloads + a new "Add / files" group)
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` (`openAddModal`/`openFilesModal`)
- [x] OS-touching code works on Windows, macOS, and Linux (destination paths reuse the existing `normalizeDownloadDir`/`expandHome`; no new OS branches)
- [x] One concern, with a Conventional Commits title (`feat:`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
