### PR TITLE
fix(ui): sanitize terminal escape sequences in result detail view

### DIFF
--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -10,7 +10,7 @@ import { getSource, SOURCES } from "../../sources/registry";
 import { wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
 import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
-import { cleanText, formatBytes, formatCount, formatRelative, truncate } from "../../util/format";
+import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Source, TorrentResult } from "../../sources/types";
 
 type Mode = "list" | "search" | "detail";
@@ -77,7 +77,7 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
           label="Hash"
           value={
             <Text color={COLOR.alt} dimColor wrap="truncate-end">
-              {r.infoHash}
+              {stripControl(r.infoHash)}
             </Text>
           }
         />
@@ -85,7 +85,7 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
           label="Magnet"
           value={
             <Text color={COLOR.alt} dimColor wrap="truncate-end">
-              {r.magnet}
+              {stripControl(r.magnet)}
             </Text>
           }
         />

--- a/src/util/format.test.ts
+++ b/src/util/format.test.ts
@@ -7,6 +7,7 @@ import {
   formatRelative,
   formatEtaShort,
   cleanText,
+  stripControl,
   truncate,
 } from "./format";
 
@@ -89,5 +90,31 @@ describe("truncate", () => {
   it("truncates with an ellipsis", () => {
     expect(truncate("hello world", 5)).toBe("hell…");
     expect(truncate("hi", 5)).toBe("hi");
+  });
+});
+
+describe("stripControl", () => {
+  const ESC = String.fromCharCode(0x1b);
+  const BEL = String.fromCharCode(0x07);
+  const hash = "0123456789abcdef0123456789abcdef01234567";
+
+  it("removes an OSC-52 clipboard-write smuggled into a magnet", () => {
+    const magnet = `magnet:?xt=urn:btih:${hash}${ESC}]52;c;ZXZpbA==${BEL}`;
+    expect(stripControl(magnet)).toBe(`magnet:?xt=urn:btih:${hash}]52;c;ZXZpbA==`);
+  });
+
+  it("removes CSI colour/cursor escapes", () => {
+    expect(stripControl(`${ESC}[31mred${ESC}[0m`)).toBe("[31mred[0m");
+  });
+
+  it("removes DEL and C1 controls (8-bit CSI/OSC/ST forms)", () => {
+    const c1 = `x${String.fromCharCode(0x9b)}y${String.fromCharCode(0x9c)}z${String.fromCharCode(0x7f)}`;
+    expect(stripControl(c1)).toBe("xyz");
+  });
+
+  it("preserves ordinary characters exactly, without cleanText's folding", () => {
+    expect(stripControl(hash)).toBe(hash);
+    expect(stripControl("a  b")).toBe("a  b");
+    expect(stripControl("")).toBe("");
   });
 });

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -107,6 +107,28 @@ export function cleanText(s: string): string {
   return out.replace(/\s+/g, " ").trim() || "Untitled";
 }
 
+// True for a code point a terminal interprets as part of a control or escape
+// sequence: C0 controls (including ESC 0x1b and BEL 0x07), DEL 0x7f, and the C1
+// controls 0x80-0x9f (which encode the 8-bit forms of CSI/OSC/ST).
+function isControlCodePoint(cp: number): boolean {
+  return cp <= 0x1f || cp === 0x7f || (cp >= 0x80 && cp <= 0x9f);
+}
+
+// Strip control/escape-capable characters from a string that will be printed
+// verbatim. Use this on attacker-influenced fields that bypass cleanText() —
+// info hashes and magnet links — so a malicious or hijacked source can't smuggle
+// e.g. an OSC-52 clipboard-write sequence to the terminal through them. Unlike
+// cleanText(), it preserves the exact remaining characters (no whitespace
+// collapsing, NFC folding, or "Untitled" fallback), which matters for
+// identifiers and URLs.
+export function stripControl(s: string): string {
+  let out = "";
+  for (const ch of s) {
+    if (!isControlCodePoint(ch.codePointAt(0)!)) out += ch;
+  }
+  return out;
+}
+
 export function truncate(s: string, max: number): string {
   if (max <= 1) return s.slice(0, Math.max(0, max));
   return s.length <= max ? s : s.slice(0, max - 1) + "…";


### PR DESCRIPTION
## Summary

A small output-encoding hardening fix: the result **detail pane** prints the
`infoHash` and `magnet` fields verbatim, while the result *name* is already run
through `cleanText()`. Because search results come from third-party indexers,
control bytes embedded in a magnet or hash reach the terminal unescaped when the
user opens that result's detail view.

This adds a `stripControl()` helper and applies it to both fields at render.

## The gap

`src/ui/components/Results.tsx`, the `Detail` component:

```tsx
<Text color={COLOR.alt} dimColor wrap="truncate-end">{r.infoHash}</Text>
...
<Text color={COLOR.alt} dimColor wrap="truncate-end">{r.magnet}</Text>
```

`cleanText()` (which strips control chars, among other things) is applied to
`r.name` everywhere it's shown, but not to these two fields. `ink`'s
`truncate-end` wrap is ANSI-aware and preserves embedded escape sequences, so
whatever bytes are in `infoHash`/`magnet` are written straight to the terminal.

A few source parsers pass these fields through without a charset filter, so
`ESC`/`BEL` survive into a `TorrentResult` — e.g. `sources/eztv.ts` takes
`magnet_url` / `hash` verbatim from the JSON API, and `sources/nyaa.ts` reads
`<nyaa:infoHash>` as-is. (The `rss`/`x1337` regexes charset-limit `infoHash` but
their magnet patterns still admit `ESC`/`BEL`.)

## Impact — low, terminal-dependent

A malicious or hijacked indexer response can embed an OSC-52 clipboard-write
(`ESC ] 52 ; c ; <base64> BEL`) or other escape in a magnet/hash. When the user
opens that result's detail pane, on terminals that honour OSC-52 writes (iTerm2,
kitty, some tmux setups) the system clipboard can be silently overwritten — e.g.
swapped for a different magnet, so the user's next paste is attacker-controlled.
Other escapes allow status-line / hyperlink spoofing. It's **low severity**: it
needs a malicious source response and the user opening the detail view, and the
effect is terminal-dependent. No RCE in torlink itself.

## The fix

- `stripControl()` in `src/util/format.ts` removes C0 controls (incl. `ESC`,
  `BEL`), `DEL`, and C1 controls (`0x80–0x9f`, the 8-bit CSI/OSC/ST forms).
- Applied to `infoHash` and `magnet` in the detail view.

I used a dedicated helper rather than `cleanText()` on purpose: `cleanText()`
collapses whitespace, NFC-folds, and falls back to `"Untitled"`, none of which
is right for an identifier or a URL — it would corrupt a legitimate magnet.
`stripControl()` preserves the exact remaining characters and only drops the
escape-capable ones. (An equally valid, more aggressive option is to reject a
magnet whose `infoHash` doesn't match `/^([a-f0-9]{40}|[a-z2-7]{32})$/` at the
parser boundary — happy to go that route instead if you'd prefer defense there.)

## Testing

- `npm run typecheck` — clean
- `npm test` — 94 passing, incl. 4 new `stripControl` cases (OSC-52-in-magnet,
  CSI escapes, DEL + C1 controls, and exact-preservation of ordinary text)

---

Found via an automated security-audit project; reporting with a patch rather
than an issue since it's low-severity and the fix is small. No rush on this, and
feel free to triage it as a won't-fix if you'd rather validate at the parser
boundary. Thanks for torlink.
