### PR TITLE
feat: sort search results by date added

### DIFF
--- a/src/ui/sort.test.ts
+++ b/src/ui/sort.test.ts
@@ -18,10 +18,10 @@ function r(p: Partial<TorrentResult> & { infoHash: string }): TorrentResult {
 const ids = (list: TorrentResult[]): string[] => list.map((x) => x.infoHash);
 
 describe("nextSort", () => {
-  it("cycles through 7 states: none -> size asc/desc -> seeders asc/desc -> source asc/desc -> none", () => {
+  it("cycles through 9 states: none -> size asc/desc -> seeders asc/desc -> source asc/desc -> added asc/desc -> none", () => {
     const seq: Sort[] = [];
     let s: Sort = "none";
-    for (let i = 0; i < 7; i++) {
+    for (let i = 0; i < 9; i++) {
       s = nextSort(s);
       seq.push(s);
     }
@@ -32,12 +32,14 @@ describe("nextSort", () => {
       { field: "seeders", dir: "desc" },
       { field: "source", dir: "asc" },
       { field: "source", dir: "desc" },
+      { field: "added", dir: "asc" },
+      { field: "added", dir: "desc" },
       "none",
     ]);
   });
 
-  it("SORT_CYCLE has exactly 7 states starting with none", () => {
-    expect(SORT_CYCLE).toHaveLength(7);
+  it("SORT_CYCLE has exactly 9 states starting with none", () => {
+    expect(SORT_CYCLE).toHaveLength(9);
     expect(SORT_CYCLE[0]).toBe("none");
   });
 });
@@ -111,6 +113,33 @@ describe("sortResults", () => {
       r({ infoHash: "c", source: "nyaa" }),
     ];
     expect(ids(sortResults(list, { field: "source", dir: "desc" }))).toEqual(["b", "c", "a"]);
+  });
+
+  it("added asc: oldest first", () => {
+    const list = [
+      r({ infoHash: "a", added: 300 }),
+      r({ infoHash: "b", added: 100 }),
+      r({ infoHash: "c", added: 200 }),
+    ];
+    expect(ids(sortResults(list, { field: "added", dir: "asc" }))).toEqual(["b", "c", "a"]);
+  });
+
+  it("added desc: newest first", () => {
+    const list = [
+      r({ infoHash: "a", added: 300 }),
+      r({ infoHash: "b", added: 100 }),
+      r({ infoHash: "c", added: 200 }),
+    ];
+    expect(ids(sortResults(list, { field: "added", dir: "desc" }))).toEqual(["a", "c", "b"]);
+  });
+
+  it("added treats missing timestamps as zero", () => {
+    const list = [
+      r({ infoHash: "a", added: 500 }),
+      r({ infoHash: "b" }),
+      r({ infoHash: "c", added: 100 }),
+    ];
+    expect(ids(sortResults(list, { field: "added", dir: "asc" }))).toEqual(["b", "c", "a"]);
   });
 
   it("does not mutate the input array", () => {

--- a/src/ui/sort.ts
+++ b/src/ui/sort.ts
@@ -1,6 +1,6 @@
 import type { TorrentResult } from "../sources/types";
 
-export type SortField = "size" | "seeders" | "source";
+export type SortField = "size" | "seeders" | "source" | "added";
 export type SortDir = "asc" | "desc";
 export interface SortState {
   field: SortField;
@@ -22,6 +22,8 @@ export const SORT_CYCLE: Sort[] = [
   { field: "seeders", dir: "desc" },
   { field: "source", dir: "asc" },
   { field: "source", dir: "desc" },
+  { field: "added", dir: "asc" },
+  { field: "added", dir: "desc" },
 ];
 
 function sameSort(a: Sort, b: Sort): boolean {
@@ -56,6 +58,12 @@ export function sortResults(list: TorrentResult[], sort: Sort): TorrentResult[] 
       break;
     case "source":
       arr.sort((a, b) => mul * a.source.localeCompare(b.source) || b.seeders - a.seeders);
+      break;
+    case "added":
+      arr.sort(
+        (a, b) =>
+          mul * ((a.added ?? 0) - (b.added ?? 0)) || b.seeders - a.seeders,
+      );
       break;
   }
   return arr;


### PR DESCRIPTION
## Summary
- Extends the `s`-key sort cycle with `added` ascending and descending
- Lets users surface the newest uploads or oldest archives without leaving the results list
- Includes vitest coverage for the new sort field and missing-timestamp edge case

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [ ] Search for something, press `s` until sort shows `added ▴` / `added ▾`
- [ ] Confirm results reorder by upload date
- [ ] Cycle through all sort modes and confirm it returns to default