### PR TITLE
feat: pick a folder per download with D

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ That's the only thing you'll type. torlink opens straight to a search bar: searc
 
 ## Finding something
 
-Type what you're looking for and press Enter. Results stream in from every source as they answer, tagged with size and how many people are sharing each one, so you can see what'll come down fast. Arrow to what you want and press `d` to save it.
+Type what you're looking for and press Enter. Results stream in from every source as they answer, tagged with size and how many people are sharing each one, so you can see what'll come down fast. Arrow to what you want and press `d` to save it, or `D` to pick a different folder for just that download.
 
 <p align="center">
   <img src="preview/browse.svg" alt="torlink's browse view: the sidebar, the search bar, and merged results from every source" style="max-width: 832px; width: 100%; height: auto;">
@@ -30,7 +30,7 @@ Type what you're looking for and press Enter. Results stream in from every sourc
 
 Active downloads sit up top with their progress, speed, and time left; when one finishes it drops into Recently downloaded just below, so the list stays tidy. Everything's still there when you come back, and anything interrupted picks up where it left off.
 
-Downloads run in the background while you keep searching, so you can queue up as many as you want. They save to your downloads folder, and the Downloads pane keeps tabs on each one. When something finishes it keeps seeding automatically so the next person can find it too, and the Seeding tab lets you pause or stop that anytime.
+Downloads run in the background while you keep searching, so you can queue up as many as you want. They save to your downloads folder — press `o` anytime to change where that is, or grab one result with `D` to send it somewhere else without touching the default — and the Downloads pane keeps tabs on each one. When something finishes it keeps seeding automatically so the next person can find it too, and the Seeding tab lets you pause or stop that anytime.
 
 <p align="center">
   <img src="preview/downloads.svg" alt="torlink's Downloads pane: live progress on top, recently downloaded below" style="max-width: 832px; width: 100%; height: auto;">

--- a/preview/browse.svg
+++ b/preview/browse.svg
@@ -109,17 +109,17 @@
     <text x="204.8" y="480" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╰───────────────────────────────────────────────────────────╯</text>
     <text x="41.6" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">↑↓←→</text>
     <text x="89.6" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Move</text>
-    <text x="156.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">d</text>
-    <text x="176" y="502" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Download</text>
-    <text x="281.6" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">y</text>
-    <text x="300.8" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Copy</text>
-    <text x="368" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
-    <text x="387.2" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Sort</text>
-    <text x="454.4" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">/</text>
-    <text x="473.6" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search</text>
-    <text x="560" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
-    <text x="598.4" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
-    <text x="684.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
-    <text x="704" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
+    <text x="156.8" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">d/D</text>
+    <text x="195.2" y="502" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Download</text>
+    <text x="300.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">y</text>
+    <text x="320" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Copy</text>
+    <text x="387.2" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">s</text>
+    <text x="406.4" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Sort</text>
+    <text x="473.6" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">/</text>
+    <text x="492.8" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search</text>
+    <text x="579.2" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
+    <text x="617.6" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
+    <text x="704" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
+    <text x="723.2" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
   </g>
 </svg>

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -97,6 +97,7 @@ function makeStore(
     seedFocus: null,
     setSeedFocus: noop,
     startDownload: noop,
+    requestDownloadTo: noop,
     copyMagnet: noop,
     notice: null,
     setNotice: noop,

--- a/src/download/queue.add.test.ts
+++ b/src/download/queue.add.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { DownloadQueue } from "./queue";
+import type { QueueItem } from "./types";
+
+// add() drives the engine, which would spin up webtorrent and touch the
+// network. Stub it (the way clipboard.test.ts stubs node:child_process) so
+// these tests cover the queue's own bookkeeping. Kept out of queue.test.ts,
+// whose tests prove they never reach the engine by construction.
+vi.mock("./engine", () => ({
+  TorrentEngine: class {
+    add(): void {}
+    remove(): void {}
+    stats(): undefined {
+      return undefined;
+    }
+    destroy(): void {}
+  },
+}));
+
+function failedItem(over: Partial<QueueItem> = {}): QueueItem {
+  return {
+    id: "t1",
+    name: "Some Torrent",
+    magnet: "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+    dir: "/downloads/a",
+    status: "failed",
+    progress: 40,
+    totalBytes: 100,
+    downloadedBytes: 40,
+    speed: 0,
+    peers: 0,
+    error: "boom",
+    addedAt: 1,
+    ...over,
+  };
+}
+
+const input = { id: "t1", name: "Some Torrent", magnet: failedItem().magnet };
+
+describe("DownloadQueue.add retry semantics", () => {
+  it("re-adds a failed item into the newly requested dir, dropping stale resume progress", () => {
+    const q = new DownloadQueue();
+    q.restore([failedItem()]);
+    q.add(input, "/downloads/b");
+    const it = q.getItems()[0]!;
+    expect(it.status).toBe("downloading");
+    expect(it.dir).toBe("/downloads/b");
+    expect(it.progress).toBe(0);
+    expect(it.downloadedBytes).toBe(0);
+    expect(it.error).toBeUndefined();
+    q.suspend();
+  });
+
+  it("keeps resume progress when a failed item retries into the same dir", () => {
+    const q = new DownloadQueue();
+    q.restore([failedItem()]);
+    q.add(input, "/downloads/a");
+    const it = q.getItems()[0]!;
+    expect(it.status).toBe("downloading");
+    expect(it.dir).toBe("/downloads/a");
+    expect(it.progress).toBe(40);
+    expect(it.downloadedBytes).toBe(40);
+    q.suspend();
+  });
+
+  it("leaves an active download untouched when re-added with a different dir", () => {
+    const q = new DownloadQueue();
+    q.restore([failedItem({ status: "downloading", error: undefined })]);
+    q.add(input, "/downloads/b");
+    const it = q.getItems()[0]!;
+    expect(it.dir).toBe("/downloads/a");
+    expect(it.progress).toBe(40);
+    q.suspend();
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -87,7 +87,19 @@ export class DownloadQueue extends EventEmitter {
     const existing = this.items.get(input.id);
     if (existing && existing.status !== "failed") return;
     const item: QueueItem = existing
-      ? { ...existing, status: "downloading", error: undefined, speed: 0 }
+      ? {
+          ...existing,
+          // A re-add is a fresh request, so it targets the dir asked for now.
+          // Partial data doesn't follow to a new folder, so resume progress
+          // only survives when the dir is unchanged.
+          dir,
+          status: "downloading",
+          error: undefined,
+          speed: 0,
+          ...(existing.dir === dir
+            ? {}
+            : { progress: 0, downloadedBytes: 0, eta: undefined }),
+        }
       : {
           id: input.id,
           name: input.name,

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -85,6 +85,17 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  // A result waiting on the "download to" prompt (D); null when the prompt is
+  // closed. lastDownloadToDir pre-fills the next prompt so queueing a batch
+  // into the same alternate folder only costs one typed path per session.
+  const [pendingDownload, setPendingDownload] = useState<{
+    id: string;
+    name: string;
+    magnet: string;
+    source?: SourceId;
+    sizeBytes?: number;
+  } | null>(null);
+  const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const booting = useRef(false);
 
@@ -225,6 +236,54 @@ export function App({
     [config, queue],
   );
 
+  const requestDownloadTo = useCallback(
+    (input: {
+      id: string;
+      name: string;
+      magnet: string;
+      source?: SourceId;
+      sizeBytes?: number;
+    }) => {
+      setPendingDownload(input);
+    },
+    [],
+  );
+
+  const closeDownloadToPrompt = useCallback(() => {
+    setPendingDownload(null);
+  }, []);
+
+  const startDownloadTo = useCallback(
+    (raw: string) => {
+      const input = pendingDownload;
+      setPendingDownload(null);
+      const dir = normalizeDownloadDir(raw);
+      if (!queue || !input || !dir) return;
+      // add() ignores the dir for anything already active, so don't claim a
+      // folder that won't be used. Failed items fall through: a re-add with a
+      // fresh dir is exactly how a bad-disk download gets redirected.
+      const existing = queue.getItems().find((it) => it.id === input.id);
+      if (existing && existing.status !== "failed") {
+        setNotice(`Already in queue: ${truncate(cleanText(input.name), 40)}`);
+        return;
+      }
+      void (async () => {
+        try {
+          await fs.mkdir(dir, { recursive: true });
+        } catch {
+          setNotice(`Couldn't use folder: ${truncate(dir, 48)}`);
+          return;
+        }
+        setLastDownloadToDir(dir);
+        queue.add(input, dir);
+        setNotice(`Added: ${truncate(cleanText(input.name), 28)} → ${truncate(dir, 36)}`);
+        setSection("downloads");
+        setRegion("content");
+      })();
+    },
+    [queue, pendingDownload],
+  );
+
   const copyMagnet = useCallback((input: { name: string; magnet: string }) => {
     void (async () => {
       const ok = await writeClipboard(input.magnet);
@@ -306,7 +365,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -315,6 +374,7 @@ export function App({
       seedFocus,
       setSeedFocus,
       startDownload,
+      requestDownloadTo,
       copyMagnet,
       notice,
       setNotice,
@@ -336,10 +396,12 @@ export function App({
     showHelp,
     editingFolder,
     editingTrackers,
+    pendingDownload,
     captureMode,
     downloadFocus,
     seedFocus,
     startDownload,
+    requestDownloadTo,
     copyMagnet,
     notice,
     listRows,
@@ -357,7 +419,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -465,10 +527,22 @@ export function App({
           </Box>
         ) : null}
 
+        {pendingDownload ? (
+          <Box marginTop={1}>
+            <FolderPrompt
+              title="download to"
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              value={lastDownloadToDir ?? store.config.downloadDir}
+              onSubmit={startDownloadTo}
+              onCancel={closeDownloadToPrompt}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -484,7 +558,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/FolderPrompt.tsx
+++ b/src/ui/components/FolderPrompt.tsx
@@ -6,18 +6,25 @@ import { COLOR, ICON } from "../theme";
 interface FolderPromptProps {
   width: number;
   value: string;
+  title?: string;
   onSubmit: (value: string) => void;
   onCancel: () => void;
 }
 
-export function FolderPrompt({ width, value, onSubmit, onCancel }: FolderPromptProps) {
+export function FolderPrompt({
+  width,
+  value,
+  title = "download folder",
+  onSubmit,
+  onCancel,
+}: FolderPromptProps) {
   useInput((_input, key) => {
     if (key.escape) onCancel();
   });
 
   return (
     <Box flexDirection="column" width={width}>
-      <Panel title="download folder" width={width} focused height={2}>
+      <Panel title={title} width={width} focused height={2}>
         <Box>
           <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
           <Box flexGrow={1} minWidth={0}>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -92,7 +92,7 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
       </Box>
       <Box marginTop={1}>
         <Text color={COLOR.accent} bold>
-          d
+          d/D
         </Text>
         <Text color={COLOR.text}> Download</Text>
         <Text dimColor>{`     ${ICON.dot}     `}</Text>
@@ -117,6 +117,7 @@ export function Results() {
     setRegion,
     setCaptureMode,
     startDownload,
+    requestDownloadTo,
     copyMagnet,
     contentWidth,
     listRows,
@@ -168,6 +169,15 @@ export function Results() {
       sizeBytes: r.sizeBytes,
     });
 
+  const openDownloadTo = (r: TorrentResult): void =>
+    requestDownloadTo({
+      id: r.infoHash,
+      name: r.name,
+      magnet: r.magnet,
+      source: r.source,
+      sizeBytes: r.sizeBytes,
+    });
+
   const copyResultMagnet = (r: TorrentResult): void =>
     copyMagnet({ name: r.name, magnet: r.magnet });
 
@@ -195,6 +205,9 @@ export function Results() {
       } else if (input === "d") {
         const r = results[clamped];
         if (r) openDownload(r);
+      } else if (input === "D") {
+        const r = results[clamped];
+        if (r) openDownloadTo(r);
       } else if (input === "y") {
         const r = results[clamped];
         if (r) copyResultMagnet(r);
@@ -211,6 +224,7 @@ export function Results() {
         setMode("list");
         setDetail(null);
       } else if (input === "d" && detail) openDownload(detail);
+      else if (input === "D" && detail) openDownloadTo(detail);
       else if (input === "y" && detail) copyResultMagnet(detail);
     },
     { isActive: focused && mode === "detail" },

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -28,6 +28,8 @@ export const HELP_GROUPS: HelpGroup[] = [
     hints: [
       { keys: "/", label: "Edit search" },
       { keys: "↵", label: "Run search" },
+      { keys: "d", label: "Download" },
+      { keys: "D", label: "Download to a folder…" },
       { keys: "s", label: "Sort results" },
       { keys: "y", label: "Copy magnet" },
       { keys: "m", label: "Paste magnet" },
@@ -101,7 +103,9 @@ export function footerHints(
   }
   return [
     NAVIGATE,
-    { keys: "d", label: "Download" },
+    // d downloads to the default folder, D asks where; the `?` sheet spells
+    // out the difference, the footer just shows both keys exist.
+    { keys: "d/D", label: "Download" },
     { keys: "y", label: "Copy" },
     { keys: "s", label: "Sort" },
     { keys: "/", label: "Search" },

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -56,6 +56,15 @@ export interface Store {
     source?: SourceId;
     sizeBytes?: number;
   }) => void;
+  // Opens the "download to" prompt (D) so this one download can land in a
+  // folder other than the configured default.
+  requestDownloadTo: (input: {
+    id: string;
+    name: string;
+    magnet: string;
+    source?: SourceId;
+    sizeBytes?: number;
+  }) => void;
   copyMagnet: (input: { name: string; magnet: string }) => void;
 
   notice: string | null;


### PR DESCRIPTION
## What and why

The `o` key sets one global download folder, so sending a single result somewhere else — a movie to the NAS, a game to the bigger drive — meant changing the setting and changing it back. `D` on a result (list or detail view) now opens a "download to" prompt for just that item; plain `d` stays a one-keypress download to the default.

The prompt reuses `FolderPrompt` (new optional `title` prop) and follows the same modal wiring as the `o`/`t` prompts. It pre-fills with the last folder used via `D` this session (falling back to the default), so queueing a batch into the same alternate folder costs one typed path. Nothing new is persisted — the queue already stores a `dir` per item, so resume, re-seed, and download-again honor the choice as-is.

One behavior fix rides along because `D` exposed it: `queue.add()` used to ignore the requested dir when re-adding a **failed** item, so redirecting a failed download (the disk-full case `D` exists for) silently retried into the old folder. `add()` now adopts the requested dir on failed retry, dropping resume progress only when the folder actually changed (covered in `queue.add.test.ts` with the engine mocked). Worth flagging: this also means plain `d` on a failed item retries into the *current* default rather than the item's original folder — "d goes to the default, D goes where you say" is now uniformly true. The `f` retry key goes through `queue.retry()` and keeps the item's own folder, unchanged. `D` on an already-active item reports "Already in queue" instead of claiming a folder that wouldn't be used.

Also: the `?` sheet was missing `d` entirely — it now lists `d` and `D`; the footer shows `d/D Download` (a separate `D` hint would overflow the footer's no-wrap budget at 80 cols); the README's Finding/Downloads sections now document both `o` and `D` (neither was mentioned); `preview/browse.svg` regenerated via `npm run previews`.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (93 tests, 3 new)
- [x] New logic has a test (vitest; mock node built-ins for platform code) — `src/download/queue.add.test.ts` stubs the engine the way `clipboard.test.ts` stubs `node:child_process`
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux — paths go through the existing `normalizeDownloadDir` (`~`/`~\` expansion, `path.normalize`); the only new fs call is `fs.mkdir(recursive: true)`
- [x] One concern, with a Conventional Commits title (`feat:`)
