### PR TITLE
Fix Linux ARM startup crash

### DIFF
--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -85,3 +85,51 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     expect(constructorCalls[0]).not.toHaveProperty("natPmp", false);
   });
 });
+
+describe("TorrentEngine Linux ARM startup", () => {
+  it("disables uTP on Linux ARM so startup avoids the native utp module", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const originalPlatform = process.platform;
+    const originalArch = process.arch;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    Object.defineProperty(process, "arch", { value: "arm64" });
+    try {
+      const engine = new TorrentEngine();
+      engine.add(
+        "test-id",
+        "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+        "/downloads",
+        {},
+      );
+      engine.destroy();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "arch", { value: originalArch });
+    }
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]).toMatchObject({ utp: false });
+  });
+
+  it("keeps uTP enabled on non-ARM Linux", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const originalPlatform = process.platform;
+    const originalArch = process.arch;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    Object.defineProperty(process, "arch", { value: "x64" });
+    try {
+      const engine = new TorrentEngine();
+      engine.add(
+        "test-id",
+        "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+        "/downloads",
+        {},
+      );
+      engine.destroy();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "arch", { value: originalArch });
+    }
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]).not.toHaveProperty("utp", false);
+  });
+});

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -32,21 +32,32 @@ function message(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
+function webTorrentOptions(): { natPmp?: boolean; utp?: boolean } {
+  const opts: { natPmp?: boolean; utp?: boolean } = {};
+
+  // On macOS, mDNSResponder occupies UDP port 5350 — the NAT-PMP
+  // client port. Binding it fails asynchronously with EADDRINUSE,
+  // and since the PMP client is a raw EventEmitter with no error
+  // listener, the error surfaces as an uncaughtException that kills
+  // the app the moment a download starts. NAT-PMP can never succeed
+  // on macOS because the port is permanently taken, so disable it
+  // and let UPnP handle NAT traversal instead.
+  if (process.platform === "darwin") opts.natPmp = false;
+
+  // Some Linux ARM environments report a native segfault while starting the CLI.
+  // Keep WebTorrent on TCP there and avoid loading the optional utp-native path.
+  if (process.platform === "linux" && process.arch.startsWith("arm")) opts.utp = false;
+
+  return opts;
+}
+
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
-      // On macOS, mDNSResponder occupies UDP port 5350 — the NAT-PMP
-      // client port. Binding it fails asynchronously with EADDRINUSE,
-      // and since the PMP client is a raw EventEmitter with no error
-      // listener, the error surfaces as an uncaughtException that kills
-      // the app the moment a download starts. NAT-PMP can never succeed
-      // on macOS because the port is permanently taken, so disable it
-      // and let UPnP handle NAT traversal instead.
-      const opts = process.platform === "darwin" ? { natPmp: false } : {};
-      this.client = new WebTorrent(opts);
+      this.client = new WebTorrent(webTorrentOptions());
       this.client.on("error", () => {});
     }
     return this.client;


### PR DESCRIPTION
Disables WebTorrent uTP on Linux ARM so startup avoids the optional native `utp-native` path. TCP downloads still work, and other platforms keep the existing behavior.

Closes #52.

Checked with:
- `npm test`
- `npm run typecheck`
- `npm run build`