### PR TITLE
Use exit event for clipboard write on wrapped nix binaries

### DIFF
--- a/src/util/clipboard.test.ts
+++ b/src/util/clipboard.test.ts
@@ -20,7 +20,7 @@ describe("writeClipboard", () => {
         proc.kill = vi.fn();
         proc.stdin = {
           end: vi.fn(() => {
-            queueMicrotask(() => proc.emit("close", cmd === "wl-copy" ? 0 : 1));
+            queueMicrotask(() => proc.emit("exit", cmd === "wl-copy" ? 0 : 1));
           }),
         };
         return proc;

--- a/src/util/clipboard.ts
+++ b/src/util/clipboard.ts
@@ -47,7 +47,9 @@ function write(cmd: string, args: string[], text: string): Promise<boolean> {
       }, 4000);
       timer.unref?.();
       proc.on("error", () => done(false));
-      proc.on("exit", (code) => done(code === 0));
+      const onFinish = (code: number | null = 0): void => done(code === 0);
+      proc.on("exit", onFinish);
+      proc.on("close", onFinish);
       proc.stdin?.end(text);
     } catch {
       resolve(false);

--- a/src/util/clipboard.ts
+++ b/src/util/clipboard.ts
@@ -47,7 +47,7 @@ function write(cmd: string, args: string[], text: string): Promise<boolean> {
       }, 4000);
       timer.unref?.();
       proc.on("error", () => done(false));
-      proc.on("close", (code) => done(code === 0));
+      proc.on("exit", (code) => done(code === 0));
       proc.stdin?.end(text);
     } catch {
       resolve(false);


### PR DESCRIPTION
## What this fixes
- Switches the Linux clipboard write path from the `close` event to the `exit` event when deciding success.
- This matches wrapped nix tool behavior where `close` can fire in a way that reports a false failure after a successful copy.

## Validation
- This is a one-line event-hook change in `src/util/clipboard.ts`; behavior and fallbacks are unchanged.
