### PR TITLE
chore: update nix package 1.3.0 -> 1.3.1

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,7 +11,7 @@
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
-  version = "1.3.0";
+  version = "1.3.1";
   __structuredAttrs = true;
   strictDeps = true;
 
@@ -19,11 +19,11 @@ buildNpmPackage (finalAttrs: {
     owner = "baairon";
     repo = "torlink";
     tag = "v${finalAttrs.version}";
-    hash = "sha256-cjwXe1OMTUJjBlzZcX3Ay/jzKanCZYhRu2SErb/JigA=";
+    hash = "sha256-XMwJ1nVVcwXOhj3moqBMRngOAnAfbOuICHMAYQheeWA=";
   };
 
   nodejs = nodejs_22;
-  npmDepsHash = "sha256-kIKtwoyXLAVL5Ki/12nfifg6nnQC68LVOCzgrfRVCxM=";
+  npmDepsHash = "sha256-FT4SUjuEKefMG2zzA/QhafZbLab0tUeWHnO30+7smnI=";
   # ignore-scripts for ip-set broken preinstall
   npmFlags = [ "--ignore-scripts" ];
 


### PR DESCRIPTION
# torlink 1.3.0 -> 1.3.1
## Tests
- Fluid streaming works correctly
- Cheatsheet dynamically resizes according to terminal width

## Changelog
- Pin to tag release v1.3.1
- npmDepsHash updated to latest hash

<details>
<summary>nix run log</summary>

```
torlink> structuredAttrs is enabled
torlink> Running phase: unpackPhase
torlink> unpacking source archive /nix/store/j163i3l1alhmjvvs671isrc3mn1wila3-source
torlink> source root is source
torlink> Running phase: patchPhase
torlink> Executing npmConfigHook
torlink> Configuring npm
torlink> Validating consistency between /build/source/package-lock.json and /nix/store/1d8glsahx863g6cw6qb5d321jgaafjk6-torlink-1.3.1-npm-deps/package-lock.json
torlink> Setting npm_config_cache to /nix/store/1d8glsahx863g6cw6qb5d321jgaafjk6-torlink-1.3.1-npm-deps
torlink> Installing dependencies
torlink> npm warn deprecated prebuild-install@7.1.3: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
torlink> npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
torlink> 
torlink> added 312 packages, and audited 313 packages in 2s
torlink> 
torlink> 97 packages are looking for funding
torlink>   run `npm fund` for details
torlink> 
torlink> found 0 vulnerabilities
torlink> patching script interpreter paths in node_modules
torlink> node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/utp-native/ucat.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-gyp-build/build-test.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-gyp-build/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-gyp-build/optional.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/acorn/bin/acorn: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/create-torrent/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/is-in-ci/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tree-kill/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/mime/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/parse-torrent/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/nanoid/bin/nanoid.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/sucrase/bin/sucrase: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/sucrase/bin/sucrase-node: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/vitest/vitest.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/typescript/bin/tsc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/typescript/bin/tsserver: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rc/cli.js: interpreter directive changed from "#! /usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/vite/bin/vite.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsx/dist/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rolldown/bin/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/which/bin/node-which: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/why-is-node-running/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/bittorrent-tracker/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsup/node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsup/dist/cli-default.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsup/dist/cli-node.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/prebuild-install/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> rebuilt dependencies successfully
torlink> patching script interpreter paths in node_modules
torlink> Finished npmConfigHook
torlink> Running phase: updateAutotoolsGnuConfigScriptsPhase
torlink> Running phase: configurePhase
torlink> no configure script, doing nothing
torlink> Running phase: buildPhase
torlink> Executing npmBuildHook
torlink> 
torlink> > torlnk@1.3.1 build
torlink> > tsup
torlink> 
torlink> CLI Building entry: src/index.tsx
torlink> CLI Using tsconfig: tsconfig.json
torlink> CLI tsup v8.5.1
torlink> CLI Using tsup config: /build/source/tsup.config.ts
torlink> CLI Target: node22
torlink> CLI Cleaning output folder
torlink> ESM Build start
torlink> ESM dist/index.js 70.29 KB
torlink> ESM ⚡️ Build success in 23ms
torlink> postbuild: wrote dist/cli.cjs
torlink> Finished npmBuildHook
torlink> Running phase: installPhase
torlink> Executing npmInstallHook
torlink> 
torlink> up to date, audited 223 packages in 309ms
torlink> 
torlink> 75 packages are looking for funding
torlink>   run `npm fund` for details
torlink> 
torlink> found 0 vulnerabilities
torlink> Finished npmInstallHook
torlink> Running phase: fixupPhase
torlink> shrinking RPATHs of ELF executables and libraries in /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/utp-native/prebuilds/linux-x64/node.napi.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/node-datachannel/build/Release/node_datachannel.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-ia32/fs-native-extensions.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-ia32/fs-native-extensions.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-x64/fs-native-extensions.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-x64/fs-native-extensions.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-arm64/fs-native-extensions.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-arm64/fs-native-extensions.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm/fs-native-extensions.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm/fs-native-extensions.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm64/fs-native-extensions.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm64/fs-native-extensions.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-x64/fs-native-extensions.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-x64/fs-native-extensions.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.musl.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bufferutil/prebuilds/linux-x64/bufferutil.node
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-ia32/bare-os.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/linux-x64/bare-os.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/linux-arm64/bare-os.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-arm/bare-os.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-arm64/bare-os.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-x64/bare-os.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-ia32/bare-fs.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/linux-x64/bare-fs.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/linux-arm64/bare-fs.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-arm/bare-fs.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-arm64/bare-fs.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-x64/bare-fs.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-ia32/bare-url.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/linux-x64/bare-url.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/linux-arm64/bare-url.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-arm/bare-url.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-arm64/bare-url.bare
torlink> shrinking /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-x64/bare-url.bare
torlink> checking for references to /build/ in /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1...
torlink> patching script interpreter paths in /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1
torlink> /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/dist/index.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> /nix/store/gc0qd9fdsrkl1mxaw37pakmcqb48ia5a-torlink-1.3.1/lib/node_modules/torlnk/dist/cli.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
```
</details>