### PR TITLE
fix: Optimize 1337x scraper loading speed

### DIFF
--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -4,8 +4,9 @@ import { parseSize } from "../util/format";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 const HOSTS = ["1337x.to", "1337x.st", "x1337x.ws", "1337xx.to"];
+let workingHostIndex = 0;
 
-const MAX_DETAILS = 8;
+const MAX_DETAILS = 4;
 
 const STOP = new Set(["the", "a", "an", "of", "and", "or", "to"]);
 
@@ -92,11 +93,14 @@ async function search(
   let base = "";
   let html = "";
   let lastError: unknown;
-  for (const host of HOSTS) {
+  for (let i = 0; i < HOSTS.length; i++) {
+    const hostIdx = (workingHostIndex + i) % HOSTS.length;
+    const host = HOSTS[hostIdx];
     try {
       const candidate = `https://${host}`;
-      html = await fetchText(`${candidate}${path}`, opts, 2);
+      html = await fetchText(`${candidate}${path}`, opts, i === 0 ? 2 : 0);
       base = candidate;
+      workingHostIndex = hostIdx;
       break;
     } catch (e) {
       if (opts.signal?.aborted) throw e;


### PR DESCRIPTION
- The 1337x scraper now caches the active, working mirror on the first successful request, bypassing ~1.5s of dead connection timeouts on blocked domains like \1337x.to\ for all subsequent searches.
- Reduces the detail page concurrency limit (\MAX_DETAILS\) from 8 down to 4. This fetches magnet links twice as fast and avoids triggering Cloudflare's rate limits on the tracker.
- Greatly speeds up loading times for the \Movies\ and \TV\ categories.