### PR TITLE
feat: headless watch-folder mode (torlnk watch <dir>)

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -33,4 +33,29 @@ describe("parseCliArgs", () => {
   it("rejects a non-hash bareword", () => {
     expect(parseCliArgs(["hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
+  it("parses watch with a directory", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: undefined,
+    });
+  });
+  it("parses watch with a --to download dir", () => {
+    expect(parseCliArgs(["watch", "/srv/blackhole", "--to", "/mnt/media"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+    });
+    expect(parseCliArgs(["watch", "--dir", "/mnt/media", "/srv/blackhole"])).toEqual({
+      kind: "watch",
+      dir: "/srv/blackhole",
+      downloadDir: "/mnt/media",
+    });
+  });
+  it("rejects watch with no directory", () => {
+    expect(parseCliArgs(["watch"])).toEqual({
+      kind: "invalid",
+      arg: "watch (missing directory)",
+    });
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,7 +4,24 @@ export type CliCommand =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
+  | { kind: "watch"; dir: string; downloadDir?: string }
   | { kind: "invalid"; arg: string };
+
+// `--to <dir>` (alias `--dir`) overrides where finished files land, for the
+// headless subcommands; returns the value and the remaining args.
+function takeToFlag(rest: string[]): { downloadDir?: string; rest: string[] } {
+  const out: string[] = [];
+  let downloadDir: string | undefined;
+  for (let i = 0; i < rest.length; i++) {
+    const arg = rest[i]!;
+    if ((arg === "--to" || arg === "--dir") && i + 1 < rest.length) {
+      downloadDir = rest[++i];
+    } else {
+      out.push(arg);
+    }
+  }
+  return { downloadDir, rest: out };
+}
 
 export function parseCliArgs(argv: string[]): CliCommand {
   const args = argv.filter((a) => a.trim() !== "");
@@ -12,6 +29,12 @@ export function parseCliArgs(argv: string[]): CliCommand {
   const a = args[0]!;
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
+  if (a === "watch") {
+    const { downloadDir, rest } = takeToFlag(args.slice(1));
+    const dir = rest[0];
+    if (!dir) return { kind: "invalid", arg: "watch (missing directory)" };
+    return { kind: "watch", dir, downloadDir };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -24,9 +47,14 @@ usage
   torlnk                      open the search TUI
   torlnk "magnet:?xt=..."     start a download on launch
   torlnk path/to/file.torrent open a .torrent file on launch
+  torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
 d to download, ? for keys
 tip: quote magnet links (they contain & characters)
+
+watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
+info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
+where files land. Handled files move to <dir>/.processed (or /.failed).
 `;

--- a/src/daemon/runtime.test.ts
+++ b/src/daemon/runtime.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { addInput, type Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+// A stand-in for DownloadQueue that records adds without spinning up webtorrent.
+function fakeRuntime(dir: string, has = false): { runtime: Runtime; add: ReturnType<typeof vi.fn> } {
+  const add = vi.fn();
+  const runtime = {
+    queue: { has: () => has, add } as unknown as Runtime["queue"],
+    downloadDir: dir,
+  };
+  return { runtime, add };
+}
+
+describe("addInput", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-rt-"));
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("adds a magnet keyed by its info hash", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, MAGNET)).toBe("added");
+    expect(add).toHaveBeenCalledWith(
+      { id: HASH, name: "Example", magnet: MAGNET },
+      dir,
+    );
+  });
+
+  it("adds a bare info hash", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, HASH)).toBe("added");
+    expect(add).toHaveBeenCalledOnce();
+  });
+
+  it("reports a duplicate without adding", async () => {
+    const { runtime, add } = fakeRuntime(dir, true);
+    expect(await addInput(runtime, MAGNET)).toBe("duplicate");
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("reports invalid input without adding or throwing", async () => {
+    const { runtime, add } = fakeRuntime(dir);
+    expect(await addInput(runtime, "not a magnet")).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+  });
+});

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -1,0 +1,55 @@
+// Headless runtime: drive the download queue without the Ink TUI.
+//
+// The TUI is one front-end over DownloadQueue; a seedbox needs another that has
+// no terminal at all. This mirrors App.tsx's boot sequence (load config, restore
+// queue/history/seeds) so a headless run resumes exactly what an interactive one
+// would, then exposes a single addInput() the watch folder and HTTP API share.
+
+import { promises as fs } from "node:fs";
+import { loadConfig } from "../config/config";
+import { DownloadQueue } from "../download/queue";
+import { loadQueue, loadSeeds } from "../download/persist";
+import { loadHistory } from "../download/history";
+import { reconcileQueue } from "../download/reconcile";
+import { parseInput } from "../sources/magnet";
+import { magnetFromTorrentFile } from "../sources/torrentFile";
+
+export interface Runtime {
+  queue: DownloadQueue;
+  downloadDir: string;
+}
+
+// Build a queue and restore persisted state, matching the TUI's boot order
+// (history before seeds — seeds resolve against history). `downloadDir` falls
+// back to the saved config's dir when the caller doesn't override it.
+export async function startRuntime(overrideDir?: string): Promise<Runtime> {
+  const cfg = await loadConfig();
+  const queue = new DownloadQueue();
+  queue.setTrackers(cfg.trackers);
+  queue.restore(reconcileQueue(await loadQueue()));
+  queue.restoreHistory(await loadHistory());
+  queue.restoreSeeds(await loadSeeds());
+  const downloadDir = overrideDir && overrideDir.trim() ? overrideDir.trim() : cfg.downloadDir;
+  return { queue, downloadDir };
+}
+
+export type AddOutcome = "added" | "duplicate" | "invalid";
+
+// Turn a magnet URI, bare info hash, or a path to a .torrent file into a queued
+// download. Deduplicates by info hash (the queue's own id), so re-submitting the
+// same torrent is a no-op rather than a restart. Never throws — bad input is
+// reported as "invalid" so callers (a watcher, an HTTP handler) can fail soft.
+export async function addInput(runtime: Runtime, input: string): Promise<AddOutcome> {
+  const trimmed = input.trim();
+  const parsed = /\.torrent$/i.test(trimmed)
+    ? await magnetFromTorrentFile(trimmed)
+    : parseInput(trimmed);
+  if (!parsed) return "invalid";
+  if (runtime.queue.has(parsed.infoHash)) return "duplicate";
+  await fs.mkdir(runtime.downloadDir, { recursive: true }).catch(() => {});
+  runtime.queue.add(
+    { id: parsed.infoHash, name: parsed.name, magnet: parsed.magnet },
+    runtime.downloadDir,
+  );
+  return "added";
+}

--- a/src/daemon/watch.test.ts
+++ b/src/daemon/watch.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import {
+  isWatchCandidate,
+  firstMeaningfulLine,
+  processFile,
+  PROCESSED_DIR,
+  FAILED_DIR,
+} from "./watch";
+import type { Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+describe("isWatchCandidate", () => {
+  it("accepts torrent/magnet/txt files", () => {
+    expect(isWatchCandidate("Foo.torrent")).toBe(true);
+    expect(isWatchCandidate("Foo.magnet")).toBe(true);
+    expect(isWatchCandidate("Foo.txt")).toBe(true);
+    expect(isWatchCandidate("Foo.MAGNET")).toBe(true);
+  });
+  it("ignores partial writes, dotfiles, and other extensions", () => {
+    expect(isWatchCandidate("Foo.torrent.part")).toBe(false);
+    expect(isWatchCandidate(".hidden.magnet")).toBe(false);
+    expect(isWatchCandidate("movie.mkv")).toBe(false);
+  });
+});
+
+describe("firstMeaningfulLine", () => {
+  it("returns the first non-blank, non-comment line", () => {
+    expect(firstMeaningfulLine("\n\n# a comment\n  magnet:?x  \nsecond")).toBe("magnet:?x");
+  });
+  it("returns null when there is nothing usable", () => {
+    expect(firstMeaningfulLine("\n  \n# only a comment\n")).toBeNull();
+  });
+});
+
+describe("processFile", () => {
+  let dir: string;
+  let downloadDir: string;
+  let add: ReturnType<typeof vi.fn>;
+  let runtime: Runtime;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-watch-"));
+    downloadDir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-dl-"));
+    add = vi.fn();
+    runtime = {
+      queue: { has: () => false, add } as unknown as Runtime["queue"],
+      downloadDir,
+    };
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(downloadDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("adds a magnet from a .magnet file and archives it to .processed", async () => {
+    await fs.writeFile(path.join(dir, "drop.magnet"), `${MAGNET}\n`);
+    const outcome = await processFile(runtime, dir, "drop.magnet");
+    expect(outcome).toBe("added");
+    expect(add).toHaveBeenCalledOnce();
+    // Original is gone; a timestamped copy lands in .processed.
+    expect(await fs.readdir(dir)).not.toContain("drop.magnet");
+    const archived = await fs.readdir(path.join(dir, PROCESSED_DIR));
+    expect(archived.some((f) => f.endsWith("drop.magnet"))).toBe(true);
+  });
+
+  it("routes an unparseable file to .failed without adding", async () => {
+    await fs.writeFile(path.join(dir, "junk.txt"), "not a magnet at all");
+    const outcome = await processFile(runtime, dir, "junk.txt");
+    expect(outcome).toBe("invalid");
+    expect(add).not.toHaveBeenCalled();
+    const failed = await fs.readdir(path.join(dir, FAILED_DIR));
+    expect(failed.some((f) => f.endsWith("junk.txt"))).toBe(true);
+  });
+});

--- a/src/daemon/watch.ts
+++ b/src/daemon/watch.ts
@@ -1,0 +1,116 @@
+// Headless watch-folder mode: torlnk watches a directory and downloads any
+// torrent dropped into it. This is the "blackhole" pattern torrent clients use
+// so other tools (a seedbox web app, a script, curl) can hand off a torrent by
+// writing a file — no keypress, no TUI. Drop a `.torrent` file, or a `.magnet`
+// / `.txt` file whose contents are a magnet URI or a bare info hash.
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { startRuntime, addInput, type Runtime, type AddOutcome } from "./runtime";
+
+// Subfolders the watcher moves handled files into, so each is processed once and
+// the drop folder stays tidy. Leading dots keep them out of the way and out of
+// its own scans.
+export const PROCESSED_DIR = ".processed";
+export const FAILED_DIR = ".failed";
+
+// Files we act on. A `.torrent` is handed off by path; `.magnet` / `.txt` hold a
+// magnet URI or bare info hash as text. Everything else (partial writes ending
+// in `.part`, the move-target subfolders, dotfiles) is ignored.
+export function isWatchCandidate(name: string): boolean {
+  if (name.startsWith(".")) return false;
+  if (/\.part$/i.test(name)) return false;
+  return /\.(torrent|magnet|txt)$/i.test(name);
+}
+
+// A dropped text file may have a trailing newline, comments, or blank lines.
+// Take the first non-empty, non-comment line as the magnet / info hash.
+export function firstMeaningfulLine(text: string): string | null {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line && !line.startsWith("#")) return line;
+  }
+  return null;
+}
+
+function log(message: string): void {
+  const stamp = new Date().toISOString();
+  console.log(`[torlnk watch] ${stamp} ${message}`);
+}
+
+async function moveInto(dir: string, sub: string, name: string): Promise<void> {
+  const destDir = path.join(dir, sub);
+  await fs.mkdir(destDir, { recursive: true }).catch(() => {});
+  // Prefix with a timestamp so re-dropping a same-named file never clobbers a
+  // previous one in the archive folder.
+  const dest = path.join(destDir, `${Date.now()}-${name}`);
+  await fs.rename(path.join(dir, name), dest).catch(() => {});
+}
+
+async function resolveInput(dir: string, name: string): Promise<string | null> {
+  const full = path.join(dir, name);
+  if (/\.torrent$/i.test(name)) return full; // handed off by path
+  const text = await fs.readFile(full, "utf8").catch(() => "");
+  return firstMeaningfulLine(text);
+}
+
+// Process one candidate file: add it, then archive it by outcome. Returns the
+// outcome for logging/tests. Never throws — a bad file must not stop the loop.
+export async function processFile(runtime: Runtime, dir: string, name: string): Promise<AddOutcome> {
+  const input = await resolveInput(dir, name);
+  let outcome: AddOutcome;
+  try {
+    outcome = input ? await addInput(runtime, input) : "invalid";
+  } catch {
+    outcome = "invalid";
+  }
+  await moveInto(dir, outcome === "invalid" ? FAILED_DIR : PROCESSED_DIR, name);
+  return outcome;
+}
+
+async function scanOnce(runtime: Runtime, dir: string): Promise<void> {
+  const entries = await fs.readdir(dir).catch(() => [] as string[]);
+  for (const name of entries) {
+    if (!isWatchCandidate(name)) continue;
+    const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+    if (!stat || !stat.isFile() || stat.size === 0) continue; // skip dirs / in-flight writes
+    const outcome = await processFile(runtime, dir, name);
+    log(`${outcome}: ${name}`);
+  }
+}
+
+const POLL_MS = 2000;
+
+// fs.watch is unreliable across platforms (misses events, fires twice, no
+// recursion guarantees), so we poll — dead simple and identical on every OS.
+export async function runWatch(watchDir: string, downloadDir?: string): Promise<void> {
+  const dir = path.resolve(watchDir);
+  await fs.mkdir(dir, { recursive: true }).catch(() => {});
+
+  const runtime = await startRuntime(downloadDir);
+  runtime.queue.on("completed", (name: string) => log(`done, now seeding: ${name}`));
+
+  log(`watching ${dir}`);
+  log(`downloads -> ${runtime.downloadDir}`);
+
+  await scanOnce(runtime, dir);
+  // Serialize scans: one in flight at a time so a slow add never overlaps itself.
+  let scanning = false;
+  const timer = setInterval(() => {
+    if (scanning) return;
+    scanning = true;
+    void scanOnce(runtime, dir).finally(() => {
+      scanning = false;
+    });
+  }, POLL_MS);
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      clearInterval(timer);
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,20 @@ if (cmd.kind === "invalid") {
   process.exit(1);
 }
 
+// Headless subcommand: run the download queue with no terminal UI (for seedboxes
+// and servers). Kept above the alt-screen setup below — this path never touches
+// the TUI. Loaded dynamically so a plain `torlnk` launch pays nothing for it.
+if (cmd.kind === "watch") {
+  const dir = cmd.dir;
+  const downloadDir = cmd.downloadDir;
+  void import("./daemon/watch").then(({ runWatch }) =>
+    runWatch(dir, downloadDir).catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }),
+  );
+} else {
+
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own
 // cursor (the search field block, list pointers), so the terminal's should
 // stay hidden. restoreTerminal shows it again on exit.
@@ -80,3 +94,5 @@ process.on("uncaughtException", (err) => {
   console.error(err);
   process.exit(1);
 });
+
+}


### PR DESCRIPTION
## What

Adds a headless `torlnk watch <dir>` subcommand: drop a torrent into a watched directory and torlink downloads then seeds it, with no TUI.

Accepts a `.torrent` file, or a `.magnet` / `.txt` file whose contents are a magnet URI or a bare info hash. Handled files move to `<dir>/.processed`; anything unparseable moves to `<dir>/.failed` and the loop carries on.

```sh
torlnk watch /srv/blackhole            # download into the default folder
torlnk watch /srv/blackhole --to /mnt/media
```

## Why

torlink can only be driven by a person at the keyboard today. A seedbox, a cron job, or another app has no way to hand it a torrent. The "blackhole" watch folder is the standard, tool-agnostic hand-off every other client supports — write a file, it downloads.

## How it fits the grain

- **Reuses what's there.** `DownloadQueue` is already UI-independent; this drives it verbatim behind a small runtime that mirrors `App.tsx`'s boot order (restore queue → history → seeds). No new state, no second download path.
- **Stays additive.** The `watch` subcommand dispatches *above* the alt-screen setup in `index.tsx`, so a plain `torlnk` launch is byte-for-byte the same and pays nothing for it (the watch code is dynamically imported).
- **Cross-platform.** Polls the directory instead of `fs.watch` (which misses events and behaves differently per OS) — one code path on win/mac/linux.
- **Fails soft.** A bad drop is archived to `.failed` and logged; it never throws or stops the watcher. Dedupes by info hash so a re-drop is a no-op.
- **Tested.** `npm run typecheck` clean, `npm test` green (134 tests). New tests cover file classification, text parsing, add outcomes, and the end-to-end add-then-archive path.

Scoped to one concern; the HTTP add API is a separate PR.