### PR TITLE
feat: headless HTTP add API (torlnk serve)

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -33,4 +33,28 @@ describe("parseCliArgs", () => {
   it("rejects a non-hash bareword", () => {
     expect(parseCliArgs(["hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
+  it("parses serve with defaults", () => {
+    expect(parseCliArgs(["serve"])).toEqual({
+      kind: "serve",
+      port: undefined,
+      host: undefined,
+      token: undefined,
+      downloadDir: undefined,
+    });
+  });
+  it("parses serve flags", () => {
+    expect(
+      parseCliArgs(["serve", "--port", "9999", "--host", "0.0.0.0", "--token", "s3cret", "--to", "/mnt/media"]),
+    ).toEqual({
+      kind: "serve",
+      port: 9999,
+      host: "0.0.0.0",
+      token: "s3cret",
+      downloadDir: "/mnt/media",
+    });
+  });
+  it("ignores a bad --port", () => {
+    expect(parseCliArgs(["serve", "--port", "abc"]).kind).toBe("serve");
+    expect((parseCliArgs(["serve", "--port", "abc"]) as { port?: number }).port).toBeUndefined();
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,7 +4,24 @@ export type CliCommand =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
+  | { kind: "serve"; port?: number; host?: string; token?: string; downloadDir?: string }
   | { kind: "invalid"; arg: string };
+
+// Minimal `--flag value` reader for the headless subcommands. Unknown tokens are
+// left in `rest` so the caller can decide what to do with them.
+function readFlags(args: string[]): { flags: Record<string, string>; rest: string[] } {
+  const flags: Record<string, string> = {};
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg.startsWith("--") && i + 1 < args.length) {
+      flags[arg.slice(2)] = args[++i]!;
+    } else {
+      rest.push(arg);
+    }
+  }
+  return { flags, rest };
+}
 
 export function parseCliArgs(argv: string[]): CliCommand {
   const args = argv.filter((a) => a.trim() !== "");
@@ -12,6 +29,17 @@ export function parseCliArgs(argv: string[]): CliCommand {
   const a = args[0]!;
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
+  if (a === "serve") {
+    const { flags } = readFlags(args.slice(1));
+    const portNum = flags.port ? Number.parseInt(flags.port, 10) : undefined;
+    return {
+      kind: "serve",
+      port: portNum && Number.isFinite(portNum) && portNum > 0 ? portNum : undefined,
+      host: flags.host,
+      token: flags.token,
+      downloadDir: flags.to ?? flags.dir,
+    };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -24,9 +52,18 @@ usage
   torlnk                      open the search TUI
   torlnk "magnet:?xt=..."     start a download on launch
   torlnk path/to/file.torrent open a .torrent file on launch
+  torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
 d to download, ? for keys
 tip: quote magnet links (they contain & characters)
+
+serve mode (no TUI): a small HTTP API for handing torlink a magnet.
+  POST /add {"magnet":"..."}   queue a magnet or info hash
+  GET  /downloads              list active downloads and seeds
+  GET  /health                 liveness (no auth)
+flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),
+--token <secret> (required to bind a public --host; or TORLINK_API_TOKEN),
+--to <dir> (where files land).
 `;

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -1,0 +1,55 @@
+// Headless runtime: drive the download queue without the Ink TUI.
+//
+// The TUI is one front-end over DownloadQueue; a seedbox needs another that has
+// no terminal at all. This mirrors App.tsx's boot sequence (load config, restore
+// queue/history/seeds) so a headless run resumes exactly what an interactive one
+// would, then exposes a single addInput() the watch folder and HTTP API share.
+
+import { promises as fs } from "node:fs";
+import { loadConfig } from "../config/config";
+import { DownloadQueue } from "../download/queue";
+import { loadQueue, loadSeeds } from "../download/persist";
+import { loadHistory } from "../download/history";
+import { reconcileQueue } from "../download/reconcile";
+import { parseInput } from "../sources/magnet";
+import { magnetFromTorrentFile } from "../sources/torrentFile";
+
+export interface Runtime {
+  queue: DownloadQueue;
+  downloadDir: string;
+}
+
+// Build a queue and restore persisted state, matching the TUI's boot order
+// (history before seeds — seeds resolve against history). `downloadDir` falls
+// back to the saved config's dir when the caller doesn't override it.
+export async function startRuntime(overrideDir?: string): Promise<Runtime> {
+  const cfg = await loadConfig();
+  const queue = new DownloadQueue();
+  queue.setTrackers(cfg.trackers);
+  queue.restore(reconcileQueue(await loadQueue()));
+  queue.restoreHistory(await loadHistory());
+  queue.restoreSeeds(await loadSeeds());
+  const downloadDir = overrideDir && overrideDir.trim() ? overrideDir.trim() : cfg.downloadDir;
+  return { queue, downloadDir };
+}
+
+export type AddOutcome = "added" | "duplicate" | "invalid";
+
+// Turn a magnet URI, bare info hash, or a path to a .torrent file into a queued
+// download. Deduplicates by info hash (the queue's own id), so re-submitting the
+// same torrent is a no-op rather than a restart. Never throws — bad input is
+// reported as "invalid" so callers (a watcher, an HTTP handler) can fail soft.
+export async function addInput(runtime: Runtime, input: string): Promise<AddOutcome> {
+  const trimmed = input.trim();
+  const parsed = /\.torrent$/i.test(trimmed)
+    ? await magnetFromTorrentFile(trimmed)
+    : parseInput(trimmed);
+  if (!parsed) return "invalid";
+  if (runtime.queue.has(parsed.infoHash)) return "duplicate";
+  await fs.mkdir(runtime.downloadDir, { recursive: true }).catch(() => {});
+  runtime.queue.add(
+    { id: parsed.infoHash, name: parsed.name, magnet: parsed.magnet },
+    runtime.downloadDir,
+  );
+  return "added";
+}

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { handleApi, isAuthorized, extractMagnet } from "./serve";
+import type { Runtime } from "./runtime";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Example`;
+
+describe("isAuthorized", () => {
+  it("is open when no token is configured", () => {
+    expect(isAuthorized(null, undefined)).toBe(true);
+  });
+  it("accepts a matching bearer token or raw token", () => {
+    expect(isAuthorized("s3cret", "Bearer s3cret")).toBe(true);
+    expect(isAuthorized("s3cret", "s3cret")).toBe(true);
+  });
+  it("rejects a missing or wrong token", () => {
+    expect(isAuthorized("s3cret", undefined)).toBe(false);
+    expect(isAuthorized("s3cret", "Bearer nope")).toBe(false);
+  });
+});
+
+describe("extractMagnet", () => {
+  it("reads a magnet from JSON", () => {
+    expect(extractMagnet(`{"magnet":"${MAGNET}"}`)).toBe(MAGNET);
+  });
+  it("reads an infohash field", () => {
+    expect(extractMagnet(`{"infohash":"${HASH}"}`)).toBe(HASH);
+  });
+  it("accepts a raw magnet body", () => {
+    expect(extractMagnet(MAGNET)).toBe(MAGNET);
+  });
+  it("returns null for empty or unusable bodies", () => {
+    expect(extractMagnet("")).toBeNull();
+    expect(extractMagnet("{bad json")).toBeNull();
+    expect(extractMagnet(`{"other":1}`)).toBeNull();
+  });
+});
+
+describe("handleApi", () => {
+  let dir: string;
+  let add: ReturnType<typeof vi.fn>;
+  let runtime: Runtime;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-serve-"));
+    add = vi.fn();
+    runtime = {
+      queue: {
+        has: () => false,
+        add,
+        getItems: () => [],
+        getSeeds: () => [],
+      } as unknown as Runtime["queue"],
+      downloadDir: dir,
+    };
+  });
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("serves /health without auth", async () => {
+    const res = await handleApi(runtime, "tok", "GET", "/health", undefined, "");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("401s a protected route without a token", async () => {
+    const res = await handleApi(runtime, "tok", "POST", "/add", undefined, `{"magnet":"${MAGNET}"}`);
+    expect(res.status).toBe(401);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("adds a magnet on POST /add", async () => {
+    const res = await handleApi(runtime, "tok", "POST", "/add", "Bearer tok", `{"magnet":"${MAGNET}"}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, outcome: "added" });
+    expect(add).toHaveBeenCalledWith({ id: HASH, name: "Example", magnet: MAGNET }, dir);
+  });
+
+  it("400s an invalid magnet", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, `{"magnet":"nope"}`);
+    expect(res.status).toBe(400);
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("lists downloads on GET /downloads", async () => {
+    const res = await handleApi(runtime, null, "GET", "/downloads", undefined, "");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ downloads: [], seeds: [] });
+  });
+
+  it("404s an unknown route", async () => {
+    const res = await handleApi(runtime, null, "GET", "/nope", undefined, "");
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -1,0 +1,189 @@
+// Headless HTTP add API: torlnk exposes a tiny local server so another program
+// (a seedbox web app, a script, curl) can hand it a torrent over HTTP instead of
+// a keypress. It complements the watch folder — same headless runtime, a
+// different doorway.
+//
+// Default port 9161 sits next to Tor's control port (9051 / browser 9151); it's
+// deliberately non-standard and overridable with --port. Binds 127.0.0.1 by
+// default; exposing it on a public interface requires a token.
+
+import http from "node:http";
+import { startRuntime, addInput, type Runtime } from "./runtime";
+import { VERSION } from "../version";
+
+export const DEFAULT_API_PORT = 9161;
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+const MAX_BODY_BYTES = 64 * 1024; // a magnet is small; cap the body hard
+
+export interface ApiResponse {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+export interface ServeOptions {
+  port?: number;
+  host?: string;
+  token?: string;
+  downloadDir?: string;
+}
+
+// Constant-ish comparison — the token isn't a password hash, but don't leak
+// length via early exit on the common prefix.
+function tokenMatches(expected: string, provided: string): boolean {
+  if (expected.length !== provided.length) return false;
+  let diff = 0;
+  for (let i = 0; i < expected.length; i++) diff |= expected.charCodeAt(i) ^ provided.charCodeAt(i);
+  return diff === 0;
+}
+
+export function isAuthorized(token: string | null, authHeader: string | undefined): boolean {
+  if (!token) return true; // no token configured -> open (loopback only, enforced at bind)
+  if (!authHeader) return false;
+  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
+  return tokenMatches(token, provided);
+}
+
+// Pull a magnet / info hash out of a request body. Accepts JSON ({ magnet } or
+// { infohash }) or a raw body that is itself a magnet or info hash — forgiving,
+// so callers don't have to guess the exact envelope.
+export function extractMagnet(bodyText: string): string | null {
+  const raw = bodyText.trim();
+  if (!raw) return null;
+  if (raw.startsWith("{")) {
+    try {
+      const obj = JSON.parse(raw) as Record<string, unknown>;
+      const val = obj.magnet ?? obj.infohash ?? obj.infoHash ?? obj.hash;
+      return typeof val === "string" && val.trim() ? val.trim() : null;
+    } catch {
+      return null;
+    }
+  }
+  return raw;
+}
+
+function statusPayload(runtime: Runtime): Record<string, unknown> {
+  const downloads = runtime.queue.getItems().map((it) => ({
+    id: it.id,
+    name: it.name,
+    status: it.status,
+    progress: it.progress,
+    peers: it.peers,
+    speed: it.speed,
+  }));
+  const seeds = runtime.queue.getSeeds().map((s) => ({
+    id: s.id,
+    name: s.name,
+    status: s.status,
+    peers: s.peers,
+    uploaded: s.uploaded,
+  }));
+  return { downloads, seeds };
+}
+
+// Pure request router — no node:http types, so it's trivially testable.
+export async function handleApi(
+  runtime: Runtime,
+  token: string | null,
+  method: string,
+  urlPath: string,
+  authHeader: string | undefined,
+  bodyText: string,
+): Promise<ApiResponse> {
+  if (method === "GET" && urlPath === "/health") {
+    return { status: 200, body: { ok: true, version: VERSION } };
+  }
+  if (!isAuthorized(token, authHeader)) {
+    return { status: 401, body: { error: "unauthorized" } };
+  }
+  if (method === "GET" && (urlPath === "/downloads" || urlPath === "/status")) {
+    return { status: 200, body: statusPayload(runtime) };
+  }
+  if (method === "POST" && urlPath === "/add") {
+    const magnet = extractMagnet(bodyText);
+    if (!magnet) return { status: 400, body: { error: "missing magnet or info hash" } };
+    const outcome = await addInput(runtime, magnet);
+    if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
+    return { status: 200, body: { ok: true, outcome } };
+  }
+  return { status: 404, body: { error: "not found" } };
+}
+
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve) => {
+    let size = 0;
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => {
+      size += c.length;
+      if (size > MAX_BODY_BYTES) {
+        req.destroy();
+        resolve("");
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", () => resolve(""));
+  });
+}
+
+function log(message: string): void {
+  console.log(`[torlnk serve] ${new Date().toISOString()} ${message}`);
+}
+
+export async function runServe(options: ServeOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_API_PORT;
+  const host = options.host ?? "127.0.0.1";
+  const token = options.token && options.token.trim() ? options.token.trim() : null;
+
+  // Fail soft, not open: never expose a public interface without a token.
+  if (!LOOPBACK_HOSTS.has(host) && !token) {
+    console.error(
+      `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
+        `(or set TORLINK_API_TOKEN), or bind 127.0.0.1.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const runtime = await startRuntime(options.downloadDir);
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? "GET";
+      const urlPath = (req.url ?? "/").split("?")[0]!;
+      const bodyText = method === "POST" ? await readBody(req) : "";
+      let out: ApiResponse;
+      try {
+        out = await handleApi(runtime, token, method, urlPath, req.headers.authorization, bodyText);
+      } catch {
+        out = { status: 500, body: { error: "internal error" } };
+      }
+      const payload = JSON.stringify(out.body);
+      res.writeHead(out.status, { "Content-Type": "application/json" });
+      res.end(payload);
+      if (method !== "GET" || urlPath !== "/health") {
+        log(`${method} ${urlPath} -> ${out.status}`);
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, host, () => {
+      log(`listening on http://${host}:${port}  (downloads -> ${runtime.downloadDir})`);
+      log(token ? "auth: token required" : "auth: none (loopback only)");
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close();
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,24 @@ if (cmd.kind === "invalid") {
   process.exit(1);
 }
 
+// Headless subcommand: run the download queue with no terminal UI (for seedboxes
+// and servers). Kept above the alt-screen setup below — this path never touches
+// the TUI. Loaded dynamically so a plain `torlnk` launch pays nothing for it.
+if (cmd.kind === "serve") {
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_API_TOKEN,
+    downloadDir: cmd.downloadDir,
+  };
+  void import("./daemon/serve").then(({ runServe }) =>
+    runServe(options).catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }),
+  );
+} else {
+
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own
 // cursor (the search field block, list pointers), so the terminal's should
 // stay hidden. restoreTerminal shows it again on exit.
@@ -80,3 +98,5 @@ process.on("uncaughtException", (err) => {
   console.error(err);
   process.exit(1);
 });
+
+}


### PR DESCRIPTION
## What

Adds a headless `torlnk serve` subcommand: a small local HTTP server for handing torlink a magnet over HTTP.

```
POST /add {"magnet":"..."}   queue a magnet or bare info hash
GET  /downloads              list active downloads and seeds
GET  /health                 liveness (no auth)
```

```sh
torlnk serve                                   # 127.0.0.1:9161, no auth
torlnk serve --host 0.0.0.0 --token s3cret     # exposed, token required
curl -XPOST 127.0.0.1:9161/add -d '{"magnet":"magnet:?xt=..."}'
```

Default port **9161** is deliberately non-standard — it sits next to Tor's control port (9051 / browser 9151) — and is overridable with `--port`.

## Why

Same motivation as the watch-folder PR, different doorway: torlink can only be driven by a person at the keyboard today. This lets a script, a cron job, or another app queue a torrent with a request instead of a file drop.

## How it fits the grain

- **Reuses what's there.** Drives the UI-independent `DownloadQueue` behind the same tiny headless runtime, mirroring `App.tsx`'s boot order. No new download path.
- **No new dependency.** Node's built-in `node:http` only — torlink stays small.
- **Additive.** A `serve` subcommand dispatched *above* the alt-screen setup, so a plain `torlnk` launch is unchanged and pays nothing (the server is dynamically imported).
- **Fails soft and safe.** Clear JSON `400/401/404`, a 64 KB body cap, and it **refuses to bind a public `--host` without a token** (loopback stays open for convenience). Dedupes by info hash.
- **Testable.** The router is a pure function with no `node:http` types. `npm run typecheck` clean, `npm test` green (137 tests) covering auth, body parsing, and every route.

Scoped to one concern. Companion PRs: the watch folder (#74) and an HTTP file server for completed downloads (coming next).