### PR TITLE
feat: headless HTTP file server for completed downloads (torlnk files)

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -33,4 +33,24 @@ describe("parseCliArgs", () => {
   it("rejects a non-hash bareword", () => {
     expect(parseCliArgs(["hello"])).toEqual({ kind: "invalid", arg: "hello" });
   });
+  it("parses files with defaults", () => {
+    expect(parseCliArgs(["files"])).toEqual({
+      kind: "files",
+      port: undefined,
+      host: undefined,
+      token: undefined,
+      dir: undefined,
+    });
+  });
+  it("parses files flags", () => {
+    expect(
+      parseCliArgs(["files", "--port", "9160", "--host", "0.0.0.0", "--token", "s3cret", "--dir", "/mnt/media"]),
+    ).toEqual({
+      kind: "files",
+      port: 9160,
+      host: "0.0.0.0",
+      token: "s3cret",
+      dir: "/mnt/media",
+    });
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -4,7 +4,18 @@ export type CliCommand =
   | { kind: "version" }
   | { kind: "help" }
   | { kind: "run"; initialMagnet?: string; initialTorrent?: string }
+  | { kind: "files"; port?: number; host?: string; token?: string; dir?: string }
   | { kind: "invalid"; arg: string };
+
+// Minimal `--flag value` reader for the headless subcommands.
+function readFlags(args: string[]): Record<string, string> {
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg.startsWith("--") && i + 1 < args.length) flags[arg.slice(2)] = args[++i]!;
+  }
+  return flags;
+}
 
 export function parseCliArgs(argv: string[]): CliCommand {
   const args = argv.filter((a) => a.trim() !== "");
@@ -12,6 +23,17 @@ export function parseCliArgs(argv: string[]): CliCommand {
   const a = args[0]!;
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
+  if (a === "files") {
+    const flags = readFlags(args.slice(1));
+    const portNum = flags.port ? Number.parseInt(flags.port, 10) : undefined;
+    return {
+      kind: "files",
+      port: portNum && Number.isFinite(portNum) && portNum > 0 ? portNum : undefined,
+      host: flags.host,
+      token: flags.token,
+      dir: flags.dir,
+    };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -24,9 +46,18 @@ usage
   torlnk                      open the search TUI
   torlnk "magnet:?xt=..."     start a download on launch
   torlnk path/to/file.torrent open a .torrent file on launch
+  torlnk files                headless: serve downloads over HTTP on :9160
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,
 d to download, ? for keys
 tip: quote magnet links (they contain & characters)
+
+files mode (no TUI): a read-only, range-aware HTTP server over the downloads
+folder, so finished files stream to a browser or media player.
+  GET /            list the folder (JSON)
+  GET /<path>      stream a file (supports Range for seeking/resuming)
+flags: --port <n> (default 9160), --host <addr> (default 127.0.0.1),
+--token <secret> (required to bind a public --host; or TORLINK_FILES_TOKEN),
+--dir <dir> (folder to serve; defaults to your downloads folder).
 `;

--- a/src/daemon/files.test.ts
+++ b/src/daemon/files.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { contentType, safeResolve, parseRange } from "./files";
+
+describe("contentType", () => {
+  it("maps known media extensions", () => {
+    expect(contentType("Movie.mp4")).toBe("video/mp4");
+    expect(contentType("track.MP3")).toBe("audio/mpeg");
+    expect(contentType("clip.mkv")).toBe("video/x-matroska");
+  });
+  it("falls back to octet-stream", () => {
+    expect(contentType("archive.xyz")).toBe("application/octet-stream");
+    expect(contentType("noext")).toBe("application/octet-stream");
+  });
+});
+
+describe("safeResolve", () => {
+  const root = path.resolve("/srv/downloads");
+  it("resolves a file beneath the root", () => {
+    expect(safeResolve(root, "/Movie/Movie.mkv")).toBe(path.join(root, "Movie", "Movie.mkv"));
+  });
+  it("maps the empty path to the root itself", () => {
+    expect(safeResolve(root, "/")).toBe(root);
+  });
+  it("rejects traversal, encoded or plain", () => {
+    expect(safeResolve(root, "/../etc/passwd")).toBeNull();
+    expect(safeResolve(root, "/%2e%2e/secret")).toBeNull();
+    expect(safeResolve(root, "/a/../../b")).toBeNull();
+  });
+  it("rejects a malformed percent-encoding", () => {
+    expect(safeResolve(root, "/%")).toBeNull();
+  });
+});
+
+describe("parseRange", () => {
+  const size = 1000;
+  it("returns null with no header (send whole file)", () => {
+    expect(parseRange(undefined, size)).toBeNull();
+    expect(parseRange("bytes=-", size)).toBeNull();
+  });
+  it("parses a closed range", () => {
+    expect(parseRange("bytes=0-499", size)).toEqual({ start: 0, end: 499 });
+  });
+  it("parses an open-ended range", () => {
+    expect(parseRange("bytes=500-", size)).toEqual({ start: 500, end: 999 });
+  });
+  it("parses a suffix range", () => {
+    expect(parseRange("bytes=-200", size)).toEqual({ start: 800, end: 999 });
+  });
+  it("clamps an end past the file", () => {
+    expect(parseRange("bytes=900-5000", size)).toEqual({ start: 900, end: 999 });
+  });
+  it("flags an unsatisfiable range", () => {
+    expect(parseRange("bytes=2000-3000", size)).toBe("unsatisfiable");
+    expect(parseRange("bytes=-0", size)).toBe("unsatisfiable");
+  });
+  it("ignores a malformed header", () => {
+    expect(parseRange("chunks=0-1", size)).toBeNull();
+  });
+});

--- a/src/daemon/files.ts
+++ b/src/daemon/files.ts
@@ -1,0 +1,252 @@
+// Headless HTTP file server: serve the downloads directory over HTTP so finished
+// files can be streamed or fetched from another machine — a browser, a media
+// player, a seedbox front-end. Read-only, range-aware (so video seeks and
+// resumable downloads work), and rooted at the downloads folder with no way out.
+//
+// Default port 9160 sits beside Tor's SOCKS port (9050 / browser 9150); it's
+// deliberately non-standard and overridable with --port.
+
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { loadConfig } from "../config/config";
+
+export const DEFAULT_FILES_PORT = 9160;
+
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+
+const MIME: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".m4v": "video/mp4",
+  ".mkv": "video/x-matroska",
+  ".webm": "video/webm",
+  ".avi": "video/x-msvideo",
+  ".mov": "video/quicktime",
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".flac": "audio/flac",
+  ".ogg": "audio/ogg",
+  ".opus": "audio/opus",
+  ".wav": "audio/wav",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".srt": "text/plain; charset=utf-8",
+  ".vtt": "text/vtt",
+  ".txt": "text/plain; charset=utf-8",
+  ".pdf": "application/pdf",
+  ".nfo": "text/plain; charset=utf-8",
+};
+
+export function contentType(name: string): string {
+  return MIME[path.extname(name).toLowerCase()] ?? "application/octet-stream";
+}
+
+// Resolve a request path against the root, refusing anything that escapes it
+// (traversal, absolute paths, encoded ../). Returns an absolute path inside root
+// or null. The empty path maps to the root itself (directory listing).
+export function safeResolve(root: string, urlPath: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(urlPath);
+  } catch {
+    return null;
+  }
+  const segments = decoded.split("/").filter((s) => s.length > 0);
+  if (segments.some((s) => s === "..")) return null;
+  const resolvedRoot = path.resolve(root);
+  const full = path.resolve(resolvedRoot, ...segments);
+  // Must be the root or strictly beneath it.
+  if (full !== resolvedRoot && !full.startsWith(resolvedRoot + path.sep)) return null;
+  return full;
+}
+
+export interface Range {
+  start: number;
+  end: number;
+}
+
+// Parse a single-range `bytes=start-end` header against a known size. Returns
+// null for a missing/multi/malformed range (caller sends the whole file) and
+// "unsatisfiable" when the range falls outside the file (caller sends 416).
+export function parseRange(header: string | undefined, size: number): Range | null | "unsatisfiable" {
+  if (!header) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!m) return null;
+  const startRaw = m[1];
+  const endRaw = m[2];
+  if (startRaw === "" && endRaw === "") return null;
+  let start: number;
+  let end: number;
+  if (startRaw === "") {
+    // suffix range: last N bytes
+    const n = Number.parseInt(endRaw!, 10);
+    if (n <= 0) return "unsatisfiable";
+    start = Math.max(0, size - n);
+    end = size - 1;
+  } else {
+    start = Number.parseInt(startRaw!, 10);
+    end = endRaw === "" ? size - 1 : Number.parseInt(endRaw!, 10);
+  }
+  if (start > end || start >= size) return "unsatisfiable";
+  if (end >= size) end = size - 1;
+  return { start, end };
+}
+
+function authHeaderOk(token: string | null, authHeader: string | undefined): boolean {
+  if (!token) return true;
+  if (!authHeader) return false;
+  const bearer = /^Bearer\s+(.+)$/i.exec(authHeader.trim());
+  const provided = bearer ? bearer[1]!.trim() : authHeader.trim();
+  return provided === token;
+}
+
+function log(message: string): void {
+  console.log(`[torlnk files] ${new Date().toISOString()} ${message}`);
+}
+
+async function sendListing(res: http.ServerResponse, dir: string, method: string): Promise<void> {
+  const names = await fs.readdir(dir).catch(() => [] as string[]);
+  const entries = await Promise.all(
+    names.map(async (name) => {
+      const stat = await fs.stat(path.join(dir, name)).catch(() => null);
+      return {
+        name,
+        type: stat?.isDirectory() ? "dir" : "file",
+        size: stat?.isFile() ? stat.size : undefined,
+      };
+    }),
+  );
+  const payload = JSON.stringify({ entries });
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(method === "HEAD" ? undefined : payload);
+}
+
+function sendFile(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  full: string,
+  size: number,
+): void {
+  const type = contentType(full);
+  const range = parseRange(req.headers.range, size);
+
+  if (range === "unsatisfiable") {
+    res.writeHead(416, { "Content-Range": `bytes */${size}` });
+    res.end();
+    return;
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": type,
+    "Accept-Ranges": "bytes",
+  };
+
+  if (range) {
+    const length = range.end - range.start + 1;
+    res.writeHead(206, {
+      ...headers,
+      "Content-Range": `bytes ${range.start}-${range.end}/${size}`,
+      "Content-Length": String(length),
+    });
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+    createReadStream(full, { start: range.start, end: range.end }).pipe(res);
+    return;
+  }
+
+  res.writeHead(200, { ...headers, "Content-Length": String(size) });
+  if (req.method === "HEAD") {
+    res.end();
+    return;
+  }
+  createReadStream(full).pipe(res);
+}
+
+export interface FilesOptions {
+  port?: number;
+  host?: string;
+  token?: string;
+  dir?: string;
+}
+
+export async function runFiles(options: FilesOptions = {}): Promise<void> {
+  const port = options.port ?? DEFAULT_FILES_PORT;
+  const host = options.host ?? "127.0.0.1";
+  const token = options.token && options.token.trim() ? options.token.trim() : null;
+
+  // Fail soft, not open: don't expose the disk on a public interface tokenless.
+  if (!LOOPBACK_HOSTS.has(host) && !token) {
+    console.error(
+      `error: refusing to bind ${host} without a token. Pass --token <secret> ` +
+        `(or set TORLINK_FILES_TOKEN), or bind 127.0.0.1.`,
+    );
+    process.exit(1);
+    return;
+  }
+
+  const root = path.resolve(
+    options.dir && options.dir.trim() ? options.dir.trim() : (await loadConfig()).downloadDir,
+  );
+  await fs.mkdir(root, { recursive: true }).catch(() => {});
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? "GET";
+      if (method !== "GET" && method !== "HEAD") {
+        res.writeHead(405, { "Content-Type": "application/json", Allow: "GET, HEAD" });
+        res.end(JSON.stringify({ error: "method not allowed" }));
+        return;
+      }
+      if (!authHeaderOk(token, req.headers.authorization)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "unauthorized" }));
+        return;
+      }
+      const urlPath = (req.url ?? "/").split("?")[0]!;
+      const full = safeResolve(root, urlPath);
+      if (!full) {
+        res.writeHead(403, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "forbidden" }));
+        return;
+      }
+      const stat = await fs.stat(full).catch(() => null);
+      if (!stat) {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not found" }));
+        return;
+      }
+      try {
+        if (stat.isDirectory()) await sendListing(res, full, method);
+        else sendFile(req, res, full, stat.size);
+      } catch {
+        if (!res.headersSent) {
+          res.writeHead(500, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "internal error" }));
+        }
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(port, host, () => {
+      log(`serving ${root} on http://${host}:${port}`);
+      log(token ? "auth: token required" : "auth: none (loopback only)");
+      resolve();
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      server.close();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,24 @@ if (cmd.kind === "invalid") {
   process.exit(1);
 }
 
+// Headless subcommand: serve the downloads folder over HTTP with no terminal UI.
+// Kept above the alt-screen setup below — this path never touches the TUI.
+// Loaded dynamically so a plain `torlnk` launch pays nothing for it.
+if (cmd.kind === "files") {
+  const options = {
+    port: cmd.port,
+    host: cmd.host,
+    token: cmd.token ?? process.env.TORLINK_FILES_TOKEN,
+    dir: cmd.dir,
+  };
+  void import("./daemon/files").then(({ runFiles }) =>
+    runFiles(options).catch((err: unknown) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }),
+  );
+} else {
+
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own
 // cursor (the search field block, list pointers), so the terminal's should
 // stay hidden. restoreTerminal shows it again on exit.
@@ -80,3 +98,5 @@ process.on("uncaughtException", (err) => {
   console.error(err);
   process.exit(1);
 });
+
+}


### PR DESCRIPTION
## What

Adds a headless `torlnk files` subcommand: a read-only, range-aware HTTP server over the downloads folder, so a finished file can be streamed or fetched from another machine.

```
GET /            list the folder (JSON)
GET /<path>      stream a file, honoring Range for seeking/resuming
```

```sh
torlnk files                                   # serves your downloads on 127.0.0.1:9160
torlnk files --dir /mnt/media --host 0.0.0.0 --token s3cret
curl -H 'Range: bytes=0-1023' 127.0.0.1:9160/Movie/Movie.mkv   # 206 Partial Content
```

Default port **9160** is deliberately non-standard — beside Tor's SOCKS port (9050 / browser 9150) — and overridable with `--port`.

## Why

torlink downloads to the box it runs on, and today that's where the file stays. This lets a browser or media player on another machine stream what finished — the read side of the same "torlink as a headless node" story as the watch folder and add API.

## How it fits the grain

- **No new dependency.** `node:http` + `fs.createReadStream` only — torlink stays small.
- **Additive.** A `files` subcommand dispatched *above* the alt-screen setup, so a plain `torlnk` launch is unchanged and pays nothing (dynamically imported).
- **Streams, never buffers.** Pipes the file through with HTTP `Range` support, so players seek and downloads resume without holding a whole file in memory.
- **Fails soft and safe.** Rooted at the downloads folder with traversal blocked (plain *and* percent-encoded, verified), read-only (`GET`/`HEAD`), and it **refuses to bind a public `--host` without a token** (loopback stays open).
- **Tested.** Pure helpers (path resolution, content type, Range parsing) are unit-tested. `npm run typecheck` clean, `npm test` green (136 tests).

Scoped to one concern. Companion PRs: the watch folder (#74) and the HTTP add API (#75).