### PR TITLE
fix: coalesce streaming search updates so input bursts aren't dropped

### DIFF
--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -58,6 +58,13 @@ function idleState(): ConcurrentSearchState {
   };
 }
 
+// Coalesce interval for streaming result updates. Sources finish in bursts (a
+// cache hit or a couple of fast hosts land almost together), and each update
+// re-sorts and re-renders the whole list. Flushing at most once per this window
+// keeps a burst from flooding Ink with re-renders and blocking stdin — the same
+// leading-throttle the queue hooks in store.ts use for `update` events.
+const RESULT_FLUSH_MS = 150;
+
 export function useConcurrentSearch(query: string): ConcurrentSearchState {
   const [state, setState] = useState<ConcurrentSearchState>(idleState);
 
@@ -67,6 +74,35 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
     const collected: TorrentResult[] = [];
     const per = blankPerSource(true);
     let done = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const flush = (): void => {
+      setState({
+        results: defaultOrder(dedupe(collected.slice())),
+        perSource: { ...per },
+        loading: done < SOURCES.length,
+        done,
+        total: SOURCES.length,
+      });
+    };
+
+    // Push the accumulated state to the UI, but no more than once per window.
+    // The final source flushes immediately so "done" / loading:false is prompt.
+    const scheduleFlush = (): void => {
+      if (done >= SOURCES.length) {
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        flush();
+        return;
+      }
+      if (timer) return;
+      timer = setTimeout(() => {
+        timer = null;
+        if (alive) flush();
+      }, RESULT_FLUSH_MS);
+    };
 
     setState({
       results: [],
@@ -95,19 +131,14 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
         .finally(() => {
           if (!alive) return;
           done += 1;
-          setState({
-            results: defaultOrder(dedupe(collected.slice())),
-            perSource: { ...per },
-            loading: done < SOURCES.length,
-            done,
-            total: SOURCES.length,
-          });
+          scheduleFlush();
         });
     }
 
     return () => {
       alive = false;
       ctrl.abort();
+      if (timer) clearTimeout(timer);
     };
   }, [query]);
 


### PR DESCRIPTION
## Symptom

On a slow connection the TUI can go unresponsive for a beat while a search is running, and keypresses during that window are dropped rather than queued — after the pause only the first one registers.

## Cause

`useConcurrentSearch` calls `setState` on **every** source completion, and each update `dedupe`s + `sort`s + re-renders the whole result list. Sources rarely finish evenly spaced — a cache hit and a couple of fast hosts land almost together — so you get a burst of full re-renders back-to-back. Each render blocks stdin, and a burst blocks it long enough that buffered keypresses get coalesced away.

## Fix

Flush the accumulated results at most once per 150ms (leading throttle), with an immediate final flush when the last source finishes so `done`/`loading:false` stays prompt. A search goes from up to N full re-renders to a handful, and the UI stays responsive to keys while results stream in.

This isn't a new pattern — it's exactly what the queue hooks in `store.ts` (`useQueueItems`, `useQueueHistory`, `useSeeds`) already do to coalesce `update` events. This just brings the search hook in line with them.

`npm run typecheck` clean, `npm test` green.