### PR TITLE
fix: Fixed overflow in textfield, and seperated delete 

### DIFF
--- a/src/ui/components/SearchBar.tsx
+++ b/src/ui/components/SearchBar.tsx
@@ -33,6 +33,7 @@ export function SearchBar({
             <TextField
               defaultValue={value}
               placeholder={placeholder}
+              width={Math.max(1, width - 6)}
               onSubmit={onSubmit}
               onChange={onChange}
               onExitDown={onExitDown}

--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -5,6 +5,7 @@ export interface TextFieldProps {
   isDisabled?: boolean;
   defaultValue?: string;
   placeholder?: string;
+  width?: number;
   onChange?: (value: string) => void;
   onSubmit?: (value: string) => void;
   onExitDown?: () => void;
@@ -21,6 +22,14 @@ export function deleteBefore(value: string, cursor: number): Edit {
   return {
     value: value.slice(0, cursor - 1) + value.slice(cursor),
     cursor: cursor - 1,
+  };
+}
+
+export function deleteAt(value: string, cursor: number): Edit {
+  if (cursor === value.length) return { value, cursor };
+  return {
+    value: value.slice(0, cursor) + value.slice(cursor + 1),
+    cursor,
   };
 }
 
@@ -48,6 +57,7 @@ export function TextField({
   isDisabled = false,
   defaultValue = "",
   placeholder = "",
+  width,
   onChange,
   onSubmit,
   onExitDown,
@@ -109,12 +119,19 @@ export function TextField({
         setCursor(Math.min(value.length, cursor + 1));
         return;
       }
-      if (key.backspace || key.delete) {
+      if (key.delete) {
+        apply(deleteAt(value, cursor));
+        return;
+      }
+      if (key.backspace) {
         apply(deleteBefore(value, cursor));
         return;
       }
       if (key.meta || !input) return;
-      const text = input.replace(/\x1b?\[<\d+;\d+;\d+[Mm]/g, "");
+      const text = input
+        .replace(/\x1b?\[<\d+;\d+;\d+[Mm]/g, "") // SGR mouse
+        .replace(/\x1b\[20[01]~/g, "") // Bracketed paste
+        .replace(/[\r\n]+/g, ""); // Newlines
       if (!text) return;
       apply(insertAt(value, cursor, text));
     },
@@ -137,9 +154,24 @@ export function TextField({
     return <Text inverse>{CURSOR}</Text>;
   }
 
-  const before = value.slice(0, cursor);
+  // Compute a viewport window that keeps the cursor visible.
+  // The cursor char itself always occupies 1 column inside the viewport.
+  const viewW = width && width > 0 ? width : Infinity;
+  let viewStart = 0;
+  if (value.length + 1 > viewW) {
+    // Ensure cursor position is visible: keep at least 1 char of context
+    // after the cursor when possible.
+    const cursorScreenPos = cursor; // 0-indexed position in full string
+    if (cursorScreenPos >= viewW - 1) {
+      viewStart = cursorScreenPos - viewW + 2;
+    }
+  }
+  const viewEnd = viewStart + viewW;
+
+  const before = value.slice(Math.max(viewStart, 0), cursor);
   const atChar = value[cursor] ?? CURSOR;
-  const after = cursor < value.length ? value.slice(cursor + 1) : "";
+  const after =
+    cursor < value.length ? value.slice(cursor + 1, Math.min(value.length, viewEnd)) : "";
   return (
     <Text>
       {before}


### PR DESCRIPTION

Made it such that when pasting a magnet link in the splash screen, the cursor appears alongside the last character. When before the cursor didn't appear when i pasted a link (which also broke ctrl+e). Also made delete button delete the character in the cursor , rather than just do what the backspace does.


