### PR TITLE
feat: Added download folder specification in splash screen.

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -95,6 +95,7 @@ export function App({
     magnet: string;
     source?: SourceId;
     sizeBytes?: number;
+    returnToSplash?: boolean;
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -244,6 +245,7 @@ export function App({
       magnet: string;
       source?: SourceId;
       sizeBytes?: number;
+      returnToSplash?: boolean;
     }) => {
       setPendingDownload(input);
     },
@@ -251,8 +253,9 @@ export function App({
   );
 
   const closeDownloadToPrompt = useCallback(() => {
+    if (pendingDownload?.returnToSplash) setView("splash");
     setPendingDownload(null);
-  }, []);
+  }, [pendingDownload]);
 
   const startDownloadTo = useCallback(
     (raw: string) => {

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -64,6 +64,7 @@ export interface Store {
     magnet: string;
     source?: SourceId;
     sizeBytes?: number;
+    returnToSplash?: boolean;
   }) => void;
   copyMagnet: (input: { name: string; magnet: string }) => void;
   openDownloadFolder: (dir: string) => void;

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { Box, Text, useInput, useStdin } from "ink";
 import { Logo } from "../components/Logo";
 import { SearchBar } from "../components/SearchBar";
@@ -5,21 +6,61 @@ import { LOGO_WIDTH } from "../logo";
 import { useStore } from "../store";
 import { sourcesByGroup } from "../../sources/registry";
 import { COLOR, ICON } from "../theme";
+import { parseInput } from "../../sources/magnet";
 
 const CATEGORIES = sourcesByGroup()
   .map((g) => g.group.toLowerCase())
   .join(`  ${ICON.dot}  `);
 
 export function Splash() {
-  const { submitQuery, quitAll, cols, rows } = useStore();
+  const { submitQuery, startDownload, requestDownloadTo, setView, setRegion, quitAll, cols, rows } =
+    useStore();
   const { isRawModeSupported } = useStdin();
+
+  // Track the live text for processing.
+  const textRef = useRef("");
 
   useInput(
     (input, key) => {
       if (key.escape || (key.ctrl && input === "c")) quitAll();
+
+      // Ctrl+D: download magnet to a specific folder
+      if (key.ctrl && input === "d") {
+        const q = textRef.current.trim();
+        if (!q) return;
+        const magnet = parseInput(q);
+        if (!magnet) return;
+        requestDownloadTo({
+          id: magnet.infoHash,
+          name: magnet.name,
+          magnet: magnet.magnet,
+          returnToSplash: true,
+        });
+        setView("browser");
+      }
     },
     { isActive: isRawModeSupported },
   );
+
+  const handleSubmit = (raw: string) => {
+    const q = raw.trim();
+
+    
+    if (q) {
+      const magnet = parseInput(q);
+      if (magnet) {
+        startDownload({
+          id: magnet.infoHash,
+          name: magnet.name,
+          magnet: magnet.magnet,
+        });
+        setView("browser");
+        return;
+      }
+    }
+
+    submitQuery(raw);
+  };
 
   const showLogo = cols >= LOGO_WIDTH + 2;
   const barWidth = Math.max(24, Math.min(cols - 6, 62));
@@ -51,13 +92,17 @@ export function Splash() {
           value=""
           editing
           placeholder="Search or paste a magnet link…"
-          onSubmit={submitQuery}
+          onSubmit={handleSubmit}
+          onChange={(v) => { textRef.current = v; }}
         />
       </Box>
       <Box marginTop={1}>
         <Text>
           <Text color={COLOR.alt}>↵</Text>
-          <Text dimColor> search</Text>
+          <Text dimColor> search </Text>
+          <Text dimColor>{`  ${ICON.dot}  `}</Text>
+          <Text color={COLOR.alt}>^d</Text>
+          <Text dimColor> pick folder</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
           <Text dimColor>empty </Text>
           <Text color={COLOR.alt}>↵</Text>


### PR DESCRIPTION
The specifying download folder isn't a new feature, but I just added that to the splash screen for convenience , also aborting the specification of the download folder will just take you back to splash screen.

Ctrl d is used for specifying folder, because of the splash view doesn't use the general keymap, and can't interfere with the typing in search bar