### PR TITLE
feat: list torrent files and download files separately (#83)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "torlnk",
       "version": "1.4.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^4.0.0",

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -98,6 +98,7 @@ function makeStore(
     setSeedFocus: noop,
     startDownload: noop,
     requestDownloadTo: noop,
+    viewTorrentFiles: noop,
     copyMagnet: noop,
     openDownloadFolder: noop,
     exportTorrent: noop,

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -1,4 +1,7 @@
-import WebTorrent, { type Torrent } from "webtorrent";
+import { truncate } from "node:fs/promises";
+import path from "node:path";
+import WebTorrent, { type Torrent, type TorrentFile } from "webtorrent";
+import type { TorrentFileInfo } from "./types";
 
 export interface TorrentProgress {
   progress: number;
@@ -16,6 +19,7 @@ export interface TorrentMeta {
   name: string;
   total: number;
   files: number;
+  fileList?: TorrentFileInfo[];
   // The .torrent metadata (piece hashes), available once metadata arrives. We
   // persist it so a later re-seed can verify the on-disk file without having to
   // re-fetch metadata from the swarm (which a bare magnet would require).
@@ -26,6 +30,7 @@ export interface AddHandlers {
   onMetadata?: (meta: TorrentMeta) => void;
   onDone?: () => void;
   onError?: (message: string) => void;
+  onReady?: () => void;
 }
 
 function message(e: unknown): string {
@@ -35,6 +40,9 @@ function message(e: unknown): string {
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
+  // Indices of deselected files per torrent, so the download event can
+  // re-truncate files that receive data due to piece-boundary overlap.
+  private deselected = new Map<string, Set<number>>();
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
@@ -88,6 +96,11 @@ export class TorrentEngine {
         name: torrent.name,
         total: torrent.length,
         files: torrent.files?.length ?? 0,
+        fileList: (torrent.files ?? []).map((f) => ({
+          name: f.name,
+          path: f.path,
+          length: f.length,
+        })),
         torrentFile: torrent.torrentFile,
       });
     });
@@ -102,6 +115,9 @@ export class TorrentEngine {
       try {
         torrent.destroy();
       } catch {}
+    });
+    torrent.on("ready", () => {
+      handlers.onReady?.();
     });
   }
 
@@ -136,6 +152,90 @@ export class TorrentEngine {
     }
   }
 
+  // Select/deselect files at the piece level.
+  // Unselected files won't have their pieces requested, but piece-boundary
+  // overlap can still cause data to land in deselected files.
+  selectFiles(id: string, selectedIndices: number[]): void {
+    const t = this.torrents.get(id);
+    if (!t || !t.files) return;
+    const set = new Set(selectedIndices);
+    t.files.forEach((f, i) => {
+      if (set.has(i)) f.select();
+      else f.deselect();
+    });
+  }
+
+  // Wraps the torrent's store.put to zero out bytes belonging to unselected
+  // files. Combined with piece-level deselection (selectFiles), this ensures
+  // unselected file data never hits the disk, even when pieces span files.
+  applyFileFilter(id: string, selectedIndices: number[], dir: string): void {
+    const t = this.torrents.get(id);
+    if (!t || !t.files || !t.store) return;
+
+    const selectedSet = new Set(selectedIndices);
+    const deselectedSet = new Set<number>();
+    for (let i = 0; i < t.files.length; i++) {
+      if (!selectedSet.has(i)) deselectedSet.add(i);
+    }
+    this.deselected.set(id, deselectedSet);
+
+    // Truncate deselected files to 0 bytes (initial sparse files).
+    if (deselectedSet.size > 0) {
+      for (const i of deselectedSet) {
+        const full = path.join(dir, t.files[i]!.path);
+        truncate(full, 0).catch(() => {});
+      }
+    }
+
+    // Compute piece-to-byte-range mapping for unselected files.
+    // A piece at index p covers bytes [p * pieceLen, (p+1) * pieceLen).
+    const pieceLen = t.pieceLength;
+    if (!pieceLen || deselectedSet.size === 0) return;
+
+    const totalPieces = Math.ceil(t.length / pieceLen);
+    // Build file offset table: for each file, its byte range in the torrent.
+    const fileRanges: { idx: number; start: number; end: number }[] = [];
+    let fileOffset = 0;
+    for (let i = 0; i < t.files.length; i++) {
+      const end = fileOffset + t.files[i]!.length - 1;
+      fileRanges.push({ idx: i, start: fileOffset, end });
+      fileOffset = end + 1;
+    }
+
+    // Precompute zero-ranges per piece: byte ranges (within the piece buffer)
+    // that belong to unselected files.
+    const zeroRanges = new Map<number, { start: number; end: number }[]>();
+    for (let p = 0; p < totalPieces; p++) {
+      const pStart = p * pieceLen;
+      const pEnd = Math.min((p + 1) * pieceLen - 1, t.length - 1);
+      const ranges: { start: number; end: number }[] = [];
+      for (const fr of fileRanges) {
+        if (selectedSet.has(fr.idx)) continue;
+        const oStart = Math.max(fr.start, pStart);
+        const oEnd = Math.min(fr.end, pEnd);
+        if (oStart <= oEnd) {
+          ranges.push({ start: oStart - pStart, end: oEnd - pStart });
+        }
+      }
+      if (ranges.length > 0) zeroRanges.set(p, ranges);
+    }
+
+    if (zeroRanges.size === 0) return;
+
+    // Wrap store.put: zero out unselected file bytes before writing.
+    const originalPut = t.store.put.bind(t.store);
+    t.store.put = async (pieceIndex: number, buffer: Buffer) => {
+      const ranges = zeroRanges.get(pieceIndex);
+      if (ranges && Buffer.isBuffer(buffer)) {
+        buffer = Buffer.from(buffer);
+        for (const r of ranges) {
+          buffer.fill(0, r.start, r.end + 1);
+        }
+      }
+      return originalPut(pieceIndex, buffer);
+    };
+  }
+
   destroy(): void {
     this.torrents.clear();
     // Never block shutdown on webtorrent's async teardown: hand off the client
@@ -149,5 +249,69 @@ export class TorrentEngine {
         } catch {}
       });
     }
+  }
+
+  // Creates a temporary WebTorrent client, adds the magnet, waits for metadata,
+  // deselects all files (so no data downloads), extracts the file list, then
+  // destroys the temp client. Returns the file list or throws on error / timeout.
+  fetchFileList(
+    magnet: string,
+    announce?: string[],
+    timeoutMs = 30_000,
+  ): Promise<TorrentFileInfo[]> {
+    return new Promise((resolve, reject) => {
+      const opts = process.platform === "darwin" ? { natPmp: false } : {};
+      const client = new WebTorrent(opts);
+      client.on("error", () => {});
+
+      const addOpts = announce && announce.length > 0 ? { announce } : {};
+      let torrent: Torrent;
+      try {
+        torrent = client.add(magnet, addOpts);
+      } catch (e) {
+        setImmediate(() => {
+          try { client.destroy(); } catch {}
+        });
+        reject(e instanceof Error ? e : new Error(String(e)));
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        try { torrent.destroy(); } catch {}
+        setImmediate(() => {
+          try { client.destroy(); } catch {}
+        });
+        reject(new Error("Timed out fetching file list"));
+      }, timeoutMs);
+
+      torrent.on("metadata", () => {
+        clearTimeout(timer);
+        const files: TorrentFileInfo[] = (torrent.files ?? []).map(
+          (f: TorrentFile) => ({
+            name: f.name,
+            path: f.path,
+            length: f.length,
+          }),
+        );
+        // Deselect all so nothing downloads during the brief window before
+        // the temp client is destroyed.
+        for (const f of torrent.files ?? []) f.deselect();
+
+        setImmediate(() => {
+          try { torrent.destroy(); } catch {}
+          try { client.destroy(); } catch {}
+        });
+        resolve(files);
+      });
+
+      torrent.on("error", (err: unknown) => {
+        clearTimeout(timer);
+        setImmediate(() => {
+          try { torrent.destroy(); } catch {}
+          try { client.destroy(); } catch {}
+        });
+        reject(err instanceof Error ? err : new Error(String(err)));
+      });
+    });
   }
 }

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -13,7 +13,7 @@ import {
   type SeedRecord,
 } from "./persist";
 import { saveHistory, saveHistorySync, type HistoryItem } from "./history";
-import type { QueueItem, SeedItem } from "./types";
+import type { QueueItem, SeedItem, TorrentFileInfo } from "./types";
 import type { SourceId } from "../sources/types";
 
 /**
@@ -44,6 +44,7 @@ export interface AddInput {
   magnet: string;
   source?: SourceId;
   sizeBytes?: number;
+  selectedFiles?: number[];
 }
 
 export class DownloadQueue extends EventEmitter {
@@ -97,6 +98,7 @@ export class DownloadQueue extends EventEmitter {
           status: "downloading",
           error: undefined,
           speed: 0,
+          selectedFiles: input.selectedFiles,
           ...(existing.dir === dir
             ? {}
             : { progress: 0, downloadedBytes: 0, eta: undefined }),
@@ -113,6 +115,7 @@ export class DownloadQueue extends EventEmitter {
           downloadedBytes: 0,
           speed: 0,
           peers: 0,
+          selectedFiles: input.selectedFiles,
           addedAt: Date.now(),
         };
     this.items.set(item.id, item);
@@ -141,9 +144,19 @@ export class DownloadQueue extends EventEmitter {
         if (!it) return; // the rest only matters while still downloading
         if (meta.name) it.name = meta.name;
         if (meta.total) it.totalBytes = meta.total;
-        it.files = meta.files;
+        it.files = meta.fileList;
         this.changed();
         void this.persist();
+      },
+      onReady: () => {
+        // Apply file selection now that the store is ready and pieces
+        // have been selected by default. This runs BEFORE _updateSelections
+        // starts requesting pieces, so deselected files are never fetched.
+        const it = this.items.get(id);
+        if (it?.selectedFiles && it.files) {
+          this.engine.selectFiles(id, it.selectedFiles);
+          this.engine.applyFileFilter(id, it.selectedFiles, it.dir);
+        }
       },
       onDone: () => {
         const it = this.items.get(id);
@@ -317,6 +330,29 @@ export class DownloadQueue extends EventEmitter {
     if (!it) return;
     if (it.status === "downloading") this.pause(id);
     else if (it.status === "paused") this.resume(id);
+  }
+
+  // Fetch the file list for a magnet URI without starting a download.
+  // Uses a temporary WebTorrent client that is destroyed after metadata arrives.
+  async fetchFileList(magnet: string): Promise<TorrentFileInfo[]> {
+    return this.engine.fetchFileList(magnet, this.trackers);
+  }
+
+  // Update file selection for an already-queued item (changing which files
+  // to download mid-stream). The engine applies the change immediately if
+  // files are already known; otherwise the selection is applied when metadata
+  // arrives.
+  updateFileSelection(id: string, selectedFiles: number[]): void {
+    const it = this.items.get(id);
+    if (!it) return;
+    if (it.status === "completed" || it.status === "failed") return;
+    it.selectedFiles = selectedFiles;
+    if (it.files) {
+      this.engine.selectFiles(id, selectedFiles);
+      this.engine.applyFileFilter(id, selectedFiles, it.dir);
+    }
+    this.changed();
+    void this.persist();
   }
 
   exportTorrentFile(id: string): Promise<string | null> {

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -17,6 +17,12 @@ export interface SeedItem {
   peers: number;
 }
 
+export interface TorrentFileInfo {
+  name: string;
+  path: string;
+  length: number;
+}
+
 export interface QueueItem {
   id: string;
   name: string;
@@ -30,7 +36,8 @@ export interface QueueItem {
   speed: number;
   peers: number;
   eta?: number;
-  files?: number;
+  files?: TorrentFileInfo[];
+  selectedFiles?: number[];
   error?: string;
   addedAt: number;
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,6 +35,8 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { FilePicker } from "./components/FilePicker";
+import type { TorrentFileInfo } from "../download/types";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -97,6 +99,17 @@ export function App({
     sizeBytes?: number;
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
+  const [filePickerState, setFilePickerState] = useState<{
+    id: string;
+    name: string;
+    magnet: string;
+    source?: SourceId;
+    sizeBytes?: number;
+    status: "fetching" | "ready" | "error";
+    files: TorrentFileInfo[];
+    initialSelection?: number[];
+    error?: string;
+  } | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const booting = useRef(false);
 
@@ -226,11 +239,15 @@ export function App({
       magnet: string;
       source?: SourceId;
       sizeBytes?: number;
+      selectedFiles?: number[];
     }) => {
       if (!config || !queue) return;
       void fs.mkdir(config.downloadDir, { recursive: true }).catch(() => {});
       queue.add(input, config.downloadDir);
-      setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
+      const note = input.selectedFiles
+        ? `${truncate(cleanText(input.name), 28)} (${input.selectedFiles.length} files)`
+        : truncate(cleanText(input.name), 40);
+      setNotice(`Added: ${note}`);
       setSection("downloads");
       setRegion("content");
     },
@@ -284,6 +301,79 @@ export function App({
     },
     [queue, pendingDownload],
   );
+
+  const viewTorrentFiles = useCallback(
+    (input: {
+      id: string;
+      name: string;
+      magnet: string;
+      source?: SourceId;
+      sizeBytes?: number;
+    }) => {
+      if (!queue) return;
+      // If the torrent is already in the queue with a file list, use that
+      // instead of fetching metadata again from the swarm.
+      const existing = queue.getItems().find((it) => it.id === input.id);
+      if (existing?.files && existing.files.length > 0) {
+        setFilePickerState({
+          id: input.id,
+          name: existing.name,
+          magnet: input.magnet,
+          source: input.source,
+          sizeBytes: input.sizeBytes,
+          status: "ready",
+          files: existing.files,
+          initialSelection: existing.selectedFiles,
+        });
+        return;
+      }
+      // Torrent not in queue or no files yet — fetch metadata via temp client.
+      setFilePickerState({
+        id: input.id,
+        name: input.name,
+        magnet: input.magnet,
+        source: input.source,
+        sizeBytes: input.sizeBytes,
+        status: "fetching",
+        files: [],
+      });
+      queue.fetchFileList(input.magnet).then(
+        (files) => {
+          setFilePickerState((prev) =>
+            prev?.id === input.id
+              ? { ...prev, status: "ready", files }
+              : prev,
+          );
+        },
+        (err: Error) => {
+          setFilePickerState((prev) =>
+            prev?.id === input.id
+              ? { ...prev, status: "error", error: err.message, files: [] }
+              : prev,
+          );
+        },
+      );
+    },
+    [queue],
+  );
+
+  const downloadSelectedFiles = useCallback(
+    (input: { id: string; name: string; magnet: string; source?: SourceId; sizeBytes?: number }, selectedFiles: number[]) => {
+      setFilePickerState(null);
+      if (queue?.getItems().some((it) => it.id === input.id)) {
+        // Item already queued — update selection in-place without re-adding.
+        queue.updateFileSelection(input.id, selectedFiles);
+        setNotice(`Updated selection for ${truncate(cleanText(input.name), 28)}`);
+      } else {
+        startDownload({ ...input, selectedFiles });
+      }
+    },
+    [queue, startDownload],
+  );
+
+  const closeFilePicker = useCallback(() => {
+    setFilePickerState(null);
+  }, []);
 
   const copyMagnet = useCallback((input: { name: string; magnet: string }) => {
     void (async () => {
@@ -392,7 +482,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || pendingDownload || filePickerState ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -402,6 +492,7 @@ export function App({
       setSeedFocus,
       startDownload,
       requestDownloadTo,
+      viewTorrentFiles,
       copyMagnet,
       openDownloadFolder,
       exportTorrent,
@@ -426,11 +517,13 @@ export function App({
     editingFolder,
     editingTrackers,
     pendingDownload,
+    filePickerState,
     captureMode,
     downloadFocus,
     seedFocus,
     startDownload,
     requestDownloadTo,
+    viewTorrentFiles,
     copyMagnet,
     openDownloadFolder,
     exportTorrent,
@@ -450,7 +543,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || pendingDownload || filePickerState) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -576,10 +669,37 @@ export function App({
           </Box>
         ) : null}
 
+        {filePickerState ? (
+          <Box marginTop={1}>
+            <FilePicker
+              status={filePickerState.status}
+              files={filePickerState.files}
+              torrentName={filePickerState.name}
+              error={filePickerState.error}
+              width={Math.max(30, Math.min(cols - 2, 100))}
+              height={bodyH}
+              initialSelection={filePickerState.initialSelection}
+              onConfirm={(indices) =>
+                downloadSelectedFiles(
+                  {
+                    id: filePickerState.id,
+                    name: filePickerState.name,
+                    magnet: filePickerState.magnet,
+                    source: filePickerState.source,
+                    sizeBytes: filePickerState.sizeBytes,
+                  },
+                  indices,
+                )
+              }
+              onCancel={closeFilePicker}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || pendingDownload || filePickerState ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -595,7 +715,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload || filePickerState ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -50,6 +50,7 @@ export function Downloads() {
     contentWidth,
     listRows,
     startDownload,
+    viewTorrentFiles,
     openDownloadFolder,
     setDownloadFocus,
     exportTorrent,
@@ -81,6 +82,14 @@ export function Downloads() {
         if (!it) return;
         if (input === "c") queue.cancel(it.id);
         else if (input === "p") queue.togglePause(it.id);
+        else if (input === "v")
+          viewTorrentFiles({
+            id: it.id,
+            name: it.name,
+            magnet: it.magnet,
+            source: it.source,
+            sizeBytes: it.totalBytes,
+          });
       } else {
         const h = recent[recentCursor];
         if (!h) return;

--- a/src/ui/components/FilePicker.tsx
+++ b/src/ui/components/FilePicker.tsx
@@ -1,0 +1,281 @@
+import { useEffect, useMemo, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { Spinner } from "./Spinner";
+import { wrapStep, windowStart } from "../move";
+import { COLOR, ICON } from "../theme";
+import { formatBytes, cleanText, truncate } from "../../util/format";
+import type { TorrentFileInfo } from "../../download/types";
+
+interface FilePickerProps {
+  status: "fetching" | "ready" | "error";
+  files: TorrentFileInfo[];
+  torrentName: string;
+  error?: string;
+  width: number;
+  height: number;
+  initialSelection?: number[];
+  onConfirm: (selectedIndices: number[]) => void;
+  onCancel: () => void;
+}
+
+const MARK = 2;
+const CHK_W = 4;
+const SIZE_W = 10;
+
+function computeSelection(files: TorrentFileInfo[], initialSelection?: number[]): Set<number> {
+  if (initialSelection) return new Set(initialSelection.filter((i) => i >= 0 && i < files.length));
+  return new Set(files.map((_, i) => i));
+}
+
+interface DirGroup {
+  dir: string;
+  entries: { index: number; info: TorrentFileInfo }[];
+}
+
+// Strip the first path segment (usually the torrent root directory) so that
+// group headers show just the subfolder name. e.g. "Torrent/Subdir" → "Subdir".
+function stripRoot(dir: string): string {
+  if (!dir) return "";
+  const slash = dir.indexOf("/");
+  if (slash === -1) return "";
+  return dir.slice(slash + 1);
+}
+
+function groupFilesByDir(files: TorrentFileInfo[]): DirGroup[] {
+  const map = new Map<string, { index: number; info: TorrentFileInfo }[]>();
+  for (let i = 0; i < files.length; i++) {
+    const f = files[i]!;
+    const full = f.path.includes("/") ? f.path.slice(0, f.path.lastIndexOf("/")) : "";
+    const d = stripRoot(full);
+    if (!map.has(d)) map.set(d, []);
+    map.get(d)!.push({ index: i, info: f });
+  }
+  const groups: DirGroup[] = [];
+  for (const [dir, entries] of map) {
+    groups.push({ dir, entries });
+  }
+  groups.sort((a, b) => a.dir.localeCompare(b.dir));
+  return groups;
+}
+
+type Row =
+  | { kind: "dir"; path: string }
+  | { kind: "file"; index: number };
+
+export function FilePicker({
+  status,
+  files,
+  torrentName,
+  error,
+  width,
+  height,
+  initialSelection,
+  onConfirm,
+  onCancel,
+}: FilePickerProps) {
+  const [selected, setSelected] = useState<Set<number>>(() => computeSelection(files, initialSelection));
+  const [cursor, setCursor] = useState(0);
+
+  const groups = useMemo(() => groupFilesByDir(files), [files]);
+
+  const rows: Row[] = useMemo(() => {
+    const r: Row[] = [];
+    for (const g of groups) {
+      r.push({ kind: "dir", path: g.dir });
+      for (const e of g.entries) {
+        r.push({ kind: "file", index: e.index });
+      }
+    }
+    return r;
+  }, [groups]);
+
+  const rowCount = rows.length;
+
+  // Ensure cursor starts on a file row, not a dir header.
+  useEffect(() => {
+    if (rows.length > 0 && rows[0]?.kind === "dir") {
+      let n = 0;
+      while (n < rows.length && rows[n]!.kind === "dir") n++;
+      if (n < rows.length) setCursor(n);
+    }
+  }, [rows]);
+
+  const toggle = (i: number): void => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i);
+      else next.add(i);
+      return next;
+    });
+  };
+
+  // Always active: esc to cancel in any state.
+  useInput(
+    (_input, key) => {
+      if (key.escape) onCancel();
+    },
+    { isActive: true },
+  );
+
+  // Navigation and confirm: only when files are available.
+  useInput(
+    (input, key) => {
+      if (input === "d") {
+        if (selected.size === 0) return;
+        onConfirm([...selected]);
+        return;
+      }
+      if (key.upArrow || input === "k") {
+        setCursor((c) => {
+          let n = wrapStep(c, -1, rowCount);
+          while (n >= 0 && n < rowCount && rows[n]!.kind === "dir") n = wrapStep(n, -1, rowCount);
+          return n;
+        });
+        return;
+      }
+      if (key.downArrow || input === "j") {
+        setCursor((c) => {
+          let n = wrapStep(c, 1, rowCount);
+          while (n >= 0 && n < rowCount && rows[n]!.kind === "dir") n = wrapStep(n, 1, rowCount);
+          return n;
+        });
+        return;
+      }
+      if (input === " ") {
+        const row = rows[cursor];
+        if (row && row.kind === "file") toggle(row.index);
+        return;
+      }
+    },
+    { isActive: status === "ready" && files.length > 0 },
+  );
+
+  if (status === "fetching") {
+    return (
+      <Panel title="files" width={width} focused height={5}>
+        <Spinner label={`Fetching file list for ${truncate(cleanText(torrentName), 40)}…`} />
+      </Panel>
+    );
+  }
+
+  if (status === "error") {
+    return (
+      <Panel title="files" width={width} focused height={5}>
+        <Text color={COLOR.bad}>{error ?? "Could not fetch file list."}</Text>
+        <Box marginTop={1}>
+          <Text>
+            <Text color={COLOR.alt}>esc</Text>
+            <Text dimColor> back</Text>
+          </Text>
+        </Box>
+      </Panel>
+    );
+  }
+
+  if (files.length === 0) {
+    return (
+      <Panel title="files" width={width} focused height={5}>
+        <Text dimColor>No files found in this torrent.</Text>
+        <Box marginTop={1}>
+          <Text>
+            <Text color={COLOR.alt}>esc</Text>
+            <Text dimColor> back</Text>
+          </Text>
+        </Box>
+      </Panel>
+    );
+  }
+
+  const totalBytes = files.reduce((s, f) => s + f.length, 0);
+  const selectedBytes = files.reduce((s, f, i) => (selected.has(i) ? s + f.length : s), 0);
+  const chrome = 6;
+  const listH = Math.max(3, Math.min(rowCount, height - chrome));
+  const fileCount = files.length;
+  const inner = Math.max(10, width - 4);
+  const nameW = Math.max(10, inner - MARK - CHK_W - SIZE_W - 2);
+
+  const start = windowStart(cursor, rowCount, listH);
+  const visible = rows.slice(start, start + listH);
+  const currentCursorRow = rows[cursor];
+  const currentFileIndex = currentCursorRow && currentCursorRow.kind === "file" ? currentCursorRow.index : 0;
+
+  return (
+    <Panel title={`files  ${ICON.dot}  ${truncate(cleanText(torrentName), 50)}`} width={width} focused height={height}>
+      <Box>
+        <Box width={MARK} flexShrink={0}>
+          <Text bold dimColor />
+        </Box>
+        <Box width={CHK_W} flexShrink={0}>
+          <Text bold dimColor />
+        </Box>
+        <Box flexGrow={1} minWidth={0} marginLeft={1}>
+          <Text bold dimColor>Name</Text>
+        </Box>
+        <Box width={SIZE_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
+          <Text bold dimColor>Size</Text>
+        </Box>
+      </Box>
+
+      <Box flexDirection="column" marginTop={1}>
+        {visible.map((row, offset) => {
+          if (row.kind === "dir") {
+            const label = row.path || ".";
+            return (
+              <Box key={`dir:${row.path}`} marginLeft={MARK + CHK_W}>
+                <Text dimColor bold wrap="truncate-end">
+                  {label}/
+                </Text>
+              </Box>
+            );
+          }
+          const fi = files[row.index]!;
+          const here = row.index === currentFileIndex;
+          const chk = selected.has(row.index) ? ICON.done : " ";
+          return (
+            <Box key={`${fi.path}:${fi.name}`}>
+              <Box width={MARK} flexShrink={0}>
+                <Text color={COLOR.accent}>{here ? ICON.pointer : ""}</Text>
+              </Box>
+              <Box width={CHK_W} flexShrink={0}>
+                <Text color={selected.has(row.index) ? COLOR.good : COLOR.alt} bold={selected.has(row.index)}>
+                  [{chk}]
+                </Text>
+              </Box>
+              <Box flexGrow={1} minWidth={0} marginLeft={1}>
+                <Text
+                  wrap="truncate-end"
+                  color={here ? COLOR.accent : undefined}
+                  bold={here}
+                  dimColor={!here}
+                >
+                  {fi.path.includes("/") ? fi.path.slice(fi.path.lastIndexOf("/") + 1) : fi.name}
+                </Text>
+              </Box>
+              <Box width={SIZE_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
+                <Text dimColor>{fi.length > 0 ? formatBytes(fi.length) : "-"}</Text>
+              </Box>
+            </Box>
+          );
+        })}
+      </Box>
+
+      <Box marginTop={1}>
+        <Text dimColor>
+          {`${selected.size}/${fileCount} files  ${ICON.dot}  ${formatBytes(selectedBytes)} / ${formatBytes(totalBytes)}`}
+        </Text>
+      </Box>
+
+      <Box marginTop={1}>
+        <Text>
+          <Text color={COLOR.accent} bold>space</Text>
+          <Text dimColor> toggle  </Text>
+          <Text color={COLOR.accent} bold>d</Text>
+          <Text dimColor> download selected  </Text>
+          <Text color={COLOR.alt}>esc</Text>
+          <Text dimColor> back</Text>
+        </Text>
+      </Box>
+    </Panel>
+  );
+}

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -98,6 +98,11 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
         <Text color={COLOR.text}> Download</Text>
         <Text dimColor>{`  ${ICON.dot}  `}</Text>
         <Text color={COLOR.accent} bold>
+          v
+        </Text>
+        <Text color={COLOR.text}> Files</Text>
+        <Text dimColor>{`  ${ICON.dot}  `}</Text>
+        <Text color={COLOR.accent} bold>
           y
         </Text>
         <Text color={COLOR.text}> Copy</Text>
@@ -119,6 +124,7 @@ export function Results() {
     setCaptureMode,
     startDownload,
     requestDownloadTo,
+    viewTorrentFiles,
     copyMagnet,
     contentWidth,
     listRows,
@@ -226,6 +232,9 @@ export function Results() {
       } else if (input === "y") {
         const r = results[clamped];
         if (r) copyResultMagnet(r);
+      } else if (input === "v") {
+        const r = results[clamped];
+        if (r) viewTorrentFiles({ id: r.infoHash, name: r.name, magnet: r.magnet, source: r.source, sizeBytes: r.sizeBytes });
       } else if (input === "s") {
         setSort((cur) => nextSort(cur));
       } else if (input === "z") {
@@ -242,6 +251,7 @@ export function Results() {
         setDetail(null);
       } else if (input === "d" && detail) openDownload(detail);
       else if (input === "D" && detail) openDownloadTo(detail);
+      else if (input === "v" && detail) viewTorrentFiles({ id: detail.infoHash, name: detail.name, magnet: detail.magnet, source: detail.source, sizeBytes: detail.sizeBytes });
       else if (input === "y" && detail) copyResultMagnet(detail);
     },
     { isActive: focused && mode === "detail" },

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([122, 101, 65, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 12, 16, 30]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([9, 13, 17, 32]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -30,6 +30,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "d", label: "Download (shift+d picks folder)" },
       { keys: "s", label: "Sort results" },
       { keys: "z", label: "Hide dead torrents" },
+      { keys: "v", label: "View files" },
       { keys: "y", label: "Copy magnet" },
       { keys: "m", label: "Paste magnet" },
     ],
@@ -37,6 +38,7 @@ export const HELP_GROUPS: HelpGroup[] = [
   {
     title: "Downloads",
     hints: [
+      { keys: "v", label: "View files" },
       { keys: "p", label: "Pause/resume" },
       { keys: "c", label: "Cancel or remove" },
       { keys: "f", label: "Retry failed" },
@@ -91,10 +93,10 @@ export function footerHints(
   }
   if (section === "downloads") {
     if (downloadFocus === "paused") {
-      return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+      return [{ keys: "p", label: "Resume" }, { keys: "v", label: "Files" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
     }
     if (downloadFocus === "failed") {
-      return [{ keys: "f", label: "Retry" }, { keys: "c", label: "Remove" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+      return [{ keys: "f", label: "Retry" }, { keys: "v", label: "Files" }, { keys: "c", label: "Remove" }, FOLDER, TORRENT, SWITCH, ALWAYS];
     }
     if (downloadFocus === "recent") {
       return [
@@ -107,13 +109,14 @@ export function footerHints(
         ALWAYS,
       ];
     }
-    return [{ keys: "p", label: "Pause" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+    return [{ keys: "p", label: "Pause" }, { keys: "v", label: "Files" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
   }
   return [
     NAVIGATE,
     // The footer advertises only the default download key; D (download to a
     // chosen folder) stays bound but lives in the `?` sheet alone.
     { keys: "d", label: "Download" },
+    { keys: "v", label: "View" },
     { keys: "y", label: "Copy" },
     { keys: "s", label: "Sort" },
     { keys: "/", label: "Search" },

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -55,10 +55,19 @@ export interface Store {
     magnet: string;
     source?: SourceId;
     sizeBytes?: number;
+    selectedFiles?: number[];
   }) => void;
   // Opens the "download to" prompt (D) so this one download can land in a
   // folder other than the configured default.
   requestDownloadTo: (input: {
+    id: string;
+    name: string;
+    magnet: string;
+    source?: SourceId;
+    sizeBytes?: number;
+  }) => void;
+  // Opens the file picker overlay to view and select files before download.
+  viewTorrentFiles: (input: {
     id: string;
     name: string;
     magnet: string;

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,13 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    select(): void;
+    deselect(): void;
+  }
+
+  interface Store {
+    put(index: number, buffer: Buffer): Promise<void>;
+    get(index: number, cb: (err?: Error, buffer?: Buffer) => void): void;
   }
 
   interface Torrent extends EventEmitter {
@@ -25,6 +32,8 @@ declare module "webtorrent" {
     paused: boolean;
     path: string;
     files: TorrentFile[];
+    pieceLength: number;
+    store: Store;
     pause(): void;
     resume(): void;
     addPeer(peer: string): boolean;


### PR DESCRIPTION
- I saw #83 and thought this is a must needed feature so here it is.
- Adds key `v` (view files) it lists all the files of a torrent.
- Lets you select/deselect individual files with `space` spacebar key.
- Then downloads only the selected files with `d`. 

<img width="953" height="976" alt="image" src="https://github.com/user-attachments/assets/fb244ece-b319-48af-8f2c-763a70c20708" />

<img width="1123" height="461" alt="image" src="https://github.com/user-attachments/assets/c66d7d48-c05f-4114-ae18-733cde9fe36e" />


## Checklist

- [x] `npm run typecheck` is clean     
- [x] `npm test` passes
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [ ] OS-touching code works on Windows, macOS, and Linux:- I only use linux so can't say about other OS but it should work on those
- [x] One concern, with a Conventional Commits title:- (feat:list torrent files and download files separately (#83)
- [ ] New logic has a test (vitest; mock node built-ins for platform code):- fetchFileList/selectFiles/applyFileFilter methods passed in the test and I have tested it manually on many torrents file.

Share your thoughts. Also I hope for the PR to  get merged. 

Closes #83