### PR TITLE
build: node-datachannel build from source

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,61 +1,113 @@
 {
   lib,
+  stdenv,
   buildNpmPackage,
   fetchFromGitHub,
   # dependencies
-  fetchurl,
   nodejs_22,
   wl-clipboard,
   xclip,
+  cmake,
+  openssl,
+  cacert,
 }:
+
+let
+  libdatachannel = fetchFromGitHub {
+    owner = "paullouisageneau";
+    repo = "libdatachannel";
+    tag = "v0.24.5";
+    fetchSubmodules = true;
+    hash = "sha256-0Yrp9cZL8JvBD5YZYbJdmPpPSBHTM/5WXNNK/s+GkDI=";
+  };
+
+  libdatachannelBuildDeps = stdenv.mkDerivation {
+    name = "libdatachannel-build-deps";
+    nativeBuildInputs = [
+      nodejs_22
+      cacert
+    ];
+    # needs cert for registry to resolve
+    buildPhase = ''
+      export HOME=$(mktemp -d)
+      export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt
+      mkdir -p $out
+      npm install --prefix $out --no-save --ignore-scripts \
+        cmake-js@8.0.0 node-addon-api@8.9.0
+    '';
+
+    dontUnpack = true;
+    dontInstall = true;
+    outputHashMode = "recursive";
+    outputHash = "sha256-Haj527mURO7NAy3Xms7LEVvAKm314LDP2IeAYFYKMpw=";
+  };
+in
 
 buildNpmPackage (finalAttrs: {
   pname = "torlink";
   version = "1.4.0";
-  __structuredAttrs = true;
-  strictDeps = true;
-
   src = fetchFromGitHub {
     owner = "baairon";
     repo = "torlink";
     tag = "v${finalAttrs.version}";
     hash = "sha256-KeszeV9atSvaA9s7iDCl+Q1eDMSx7flnQuBE8t49IPY=";
   };
+  __structuredAttrs = true;
+  strictDeps = true;
 
   nodejs = nodejs_22;
   npmDepsHash = "sha256-nSHunmjZfr9oCygaLnHQxrXv7wuSa5ze7cQL7BrqfwQ=";
-  # ignore-scripts for ip-set broken preinstall
-  npmFlags = [ "--ignore-scripts" ];
+  npmFlags = [ "--ignore-scripts" ]; # ignore-scripts for ip-set broken preinstall
 
-  # node-datachannel binary tarball
-  nodeDatachannelPrebuilt = fetchurl {
-    url = "https://github.com/murat-dogan/node-datachannel/releases/download/v0.32.3/node-datachannel-v0.32.3-napi-v8-linux-x64.tar.gz";
-    sha256 = "4092afc9cd594a3326eb1bd823da452b227b742ea8222689b2cea6f7344cf67a";
-  };
+  nativeBuildInputs = [ cmake ];
+  buildInputs = [ openssl ];
+  dontUseCmakeConfigure = true; # override cmake default (no configure script)
 
-  # replicate postbuild from package.json
   postBuild = ''
     node scripts/postbuild.cjs
   '';
 
-  # extract node-datachannel tarball
-  # add wl-copy and xclip to nix readeable path
+  # build node-datachannel, and wrap clipboard
   postInstall = ''
-    tar -xzf ${finalAttrs.nodeDatachannelPrebuilt} \
-      -C $out/lib/node_modules/torlnk/node_modules/node-datachannel
-      wrapProgram $out/bin/torlnk \
-        --prefix PATH : ${
-          lib.makeBinPath [
-            wl-clipboard
-            xclip
-          ]
-        }
+    pushd $out/lib/node_modules/torlnk/node_modules/node-datachannel
+
+    # link shared nixpkgs openssl
+    substituteInPlace CMakeLists.txt \
+      --replace-fail \
+      'set(OPENSSL_USE_STATIC_LIBS TRUE)' \
+      'set(OPENSSL_USE_STATIC_LIBS FALSE)'
+
+    # merge build deps
+    mkdir -p node_modules
+    cp -r ${libdatachannelBuildDeps}/node_modules/. node_modules/
+    patchShebangs --build node_modules
+
+    export npm_config_nodedir=${lib.getDev nodejs_22}
+
+    # redirect node-datachannel
+    node_modules/.bin/cmake-js compile \
+        --CDFETCHCONTENT_SOURCE_DIR_LIBDATACHANNEL=${libdatachannel} \
+        --CDFETCHCONTENT_FULLY_DISCONNECTED=ON
+
+    # trim build tree
+    find build -mindepth 1 -maxdepth 1 -not -name Release -exec rm -rf {} +
+    find build/Release -mindepth 1 -not -name 'node_datachannel.node' -exec rm -rf {} +
+    popd
+
+    # wrap clipboard
+    wrapProgram $out/bin/torlnk \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          wl-clipboard
+          xclip
+        ]
+      }
   '';
 
   meta = {
     description = "Torlink is a torrent finder that lives in your terminal, with zero setup and nothing to configure.";
     homepage = "https://github.com/baairon/torlink";
-    changelog = "https://github.com/baairon/torlink/releases/tag/v${finalAttrs.src.tag}";
+    changelog = "https://github.com/baairon/torlink/releases/tag/${finalAttrs.src.tag}";
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ ghastrum ];
     mainProgram = "torlnk";


### PR DESCRIPTION
## What and why

Instead of fetching node-datachannel as a prebuilt binary it is now built from source. This was done because it was asked by a reviewer from the nixpkgs repository. Assuming this is because of security issues as a prebuilt binary is opaque and is more susceptible to dependency vulnerabilities. This change makes node-datachannel more transparent and able to automatically get security patches from Nixs packages.

**[Source-available software should be built from source where possible. Binary blobs risk supply chain attacks and vendored outdated libraries.](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md)**

<details><summary>nix run log</summary>

```
torlink> structuredAttrs is enabled
torlink> Running phase: unpackPhase
torlink> unpacking source archive /nix/store/hg4r5dqrqyldqv9svc256m2bghaxkvwh-source
torlink> source root is source
torlink> Running phase: patchPhase
torlink> Executing npmConfigHook
torlink> Configuring npm
torlink> Validating consistency between /build/source/package-lock.json and /nix/store/rhkhkixq07i5vfdqzv6453av7i5bszyh-torlink-1.4.0-npm-deps/package-lock.json
torlink> Setting npm_config_cache to /nix/store/rhkhkixq07i5vfdqzv6453av7i5bszyh-torlink-1.4.0-npm-deps
torlink> Installing dependencies
torlink> npm warn deprecated prebuild-install@7.1.3: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
torlink> npm warn deprecated node-domexception@1.0.0: Use your platform's native DOMException instead
torlink>
torlink> added 312 packages, and audited 313 packages in 2s
torlink>
torlink> 97 packages are looking for funding
torlink>   run `npm fund` for details
torlink>
torlink> found 0 vulnerabilities
torlink> patching script interpreter paths in node_modules
torlink> node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/utp-native/ucat.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-gyp-build/build-test.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-gyp-build/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-gyp-build/optional.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/acorn/bin/acorn: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/create-torrent/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/is-in-ci/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tree-kill/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/mime/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/parse-torrent/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/nanoid/bin/nanoid.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/sucrase/bin/sucrase: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/sucrase/bin/sucrase-node: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/vitest/vitest.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/typescript/bin/tsc: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/typescript/bin/tsserver: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rc/cli.js: interpreter directive changed from "#! /usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/vite/bin/vite.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsx/dist/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rolldown/bin/cli.mjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/which/bin/node-which: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/why-is-node-running/cli.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rollup/dist/bin/rollup: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/bittorrent-tracker/bin/cmd.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsup/node_modules/esbuild/bin/esbuild: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsup/dist/cli-default.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/tsup/dist/cli-node.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/prebuild-install/bin.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> rebuilt dependencies successfully
torlink> patching script interpreter paths in node_modules
torlink> Finished npmConfigHook
torlink> Running phase: updateAutotoolsGnuConfigScriptsPhase
torlink> Running phase: configurePhase
torlink> no configure script, doing nothing
torlink> Running phase: buildPhase
torlink> Executing npmBuildHook
torlink>
torlink> > torlnk@1.4.0 build
torlink> > tsup
torlink>
torlink> CLI Building entry: src/index.tsx
torlink> CLI Using tsconfig: tsconfig.json
torlink> CLI tsup v8.5.1
torlink> CLI Using tsup config: /build/source/tsup.config.ts
torlink> CLI Target: node22
torlink> CLI Cleaning output folder
torlink> ESM Build start
torlink> ESM dist/index.js 88.59 KB
torlink> ESM ⚡️ Build success in 26ms
torlink> postbuild: wrote dist/cli.cjs
torlink> Finished npmBuildHook
torlink> Running phase: installPhase
torlink> Executing npmInstallHook
torlink>
torlink> changed 1 package, and audited 223 packages in 324ms
torlink>
torlink> 75 packages are looking for funding
torlink>   run `npm fund` for details
torlink>
torlink> found 0 vulnerabilities
torlink> /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel ~/source
torlink> patching script interpreter paths in node_modules
torlink> node_modules/semver/bin/semver.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/url-join/bin/changelog: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/cmake-js/bin/cmake-js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/rc/cli.js: interpreter directive changed from "#! /usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/node-addon-api/tools/conversion.js: interpreter directive changed from "#! /usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> node_modules/which/bin/which.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> INFO TOOL Using Unix Makefiles generator.
torlink> INFO CMD CONFIGURE
torlink> INFO RUN [
torlink>   'cmake',
torlink>   '/nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel',
torlink>   '--no-warn-unused-cli',
torlink>   '-G',
torlink>   'Unix Makefiles',
torlink>   '-DCMAKE_JS_VERSION=8.0.0',
torlink>   '-DCMAKE_BUILD_TYPE=Release',
torlink>   '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=/nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel/build/Release',
torlink>   '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded$<$<CONFIG:Debug>:Debug>',
torlink>   '-DCMAKE_JS_INC=/nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel/node_modules/node-api-headers/include;/nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel/node_modules/node-addon-api',
torlink>   '-DCMAKE_JS_SRC=',
torlink>   '-DNODE_RUNTIME=node',
torlink>   '-DNODE_RUNTIMEVERSION=22.23.1',
torlink>   '-DNODE_ARCH=x64',
torlink>   '-DFETCHCONTENT_SOURCE_DIR_LIBDATACHANNEL=/nix/store/ix35pmq1mmgz8ivdnyr3h1sdmy9sg1k4-source',
torlink>   '-DFETCHCONTENT_FULLY_DISCONNECTED=ON',
torlink>   '-DCMAKE_JS_LIB=',
torlink>   '-DCMAKE_CXX_FLAGS=-DBUILDING_NODE_EXTENSION'
torlink> ]
torlink> Not searching for unused variables given on the command line.
torlink> -- The C compiler identification is GNU 15.2.0
torlink> -- The CXX compiler identification is GNU 15.2.0
torlink> -- Detecting C compiler ABI info
torlink> -- Detecting C compiler ABI info - done
torlink> -- Check for working C compiler: /nix/store/xcnqqnhw9hb4j5rjgds2yjryi8qki5f3-gcc-wrapper-15.2.0/bin/gcc - skipped
torlink> -- Detecting C compile features
torlink> -- Detecting C compile features - done
torlink> -- Detecting CXX compiler ABI info
torlink> -- Detecting CXX compiler ABI info - done
torlink> -- Check for working CXX compiler: /nix/store/xcnqqnhw9hb4j5rjgds2yjryi8qki5f3-gcc-wrapper-15.2.0/bin/g++ - skipped
torlink> -- Detecting CXX compile features
torlink> -- Detecting CXX compile features - done
torlink> -- Found OpenSSL: /nix/store/l0vl4dali2mvbpi30a8da1f71jl85myg-openssl-3.6.2/lib/libcrypto.so (found version "3.6.2")
torlink> CMake Warning (dev) at /nix/store/k1b82rs72af124wmq6nb00nhw5i7ikp7-cmake-4.1.2/share/cmake-4.1/Modules/FetchContent.cmake:1953 (message):
torlink>   Calling FetchContent_Populate(libdatachannel) is deprecated, call
torlink>   FetchContent_MakeAvailable(libdatachannel) instead.  Policy CMP0169 can be
torlink>   set to OLD to allow FetchContent_Populate(libdatachannel) to be called
torlink>   directly for now, but the ability to call it with declared details will be
torlink>   removed completely in a future version.
torlink> Call Stack (most recent call first):
torlink>   CMakeLists.txt:49 (FetchContent_Populate)
torlink> This warning is for project developers.  Use -Wno-dev to suppress it.
torlink>
torlink> -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
torlink> -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
torlink> -- Found Threads: TRUE
torlink> -- Looking for include file sys/queue.h
torlink> -- Looking for include file sys/queue.h - found
torlink> -- Looking for include files sys/socket.h, linux/if_addr.h
torlink> -- Looking for include files sys/socket.h, linux/if_addr.h - found
torlink> -- Looking for include files sys/socket.h, linux/rtnetlink.h
torlink> -- Looking for include files sys/socket.h, linux/rtnetlink.h - found
torlink> -- Looking for 4 include files sys/types.h, ..., netinet/ip_icmp.h
torlink> -- Looking for 4 include files sys/types.h, ..., netinet/ip_icmp.h - found
torlink> -- Looking for 3 include files sys/types.h, ..., net/route.h
torlink> -- Looking for 3 include files sys/types.h, ..., net/route.h - found
torlink> -- Looking for include file stdatomic.h
torlink> -- Looking for include file stdatomic.h - found
torlink> -- Looking for usrsctp.h
torlink> -- Looking for usrsctp.h - found
torlink> -- Performing Test have_sa_len
torlink> -- Performing Test have_sa_len - Failed
torlink> -- Performing Test have_sin_len
torlink> -- Performing Test have_sin_len - Failed
torlink> -- Performing Test have_sin6_len
torlink> -- Performing Test have_sin6_len - Failed
torlink> -- Performing Test have_sconn_len
torlink> -- Performing Test have_sconn_len - Failed
torlink> -- Performing Test has_wfloat_equal
torlink> -- Performing Test has_wfloat_equal - Success
torlink> -- Performing Test has_wshadow
torlink> -- Performing Test has_wshadow - Success
torlink> -- Performing Test has_wpointer_aritih
torlink> -- Performing Test has_wpointer_aritih - Success
torlink> -- Performing Test has_wunreachable_code
torlink> -- Performing Test has_wunreachable_code - Success
torlink> -- Performing Test has_winit_self
torlink> -- Performing Test has_winit_self - Success
torlink> -- Performing Test has_wno_unused_function
torlink> -- Performing Test has_wno_unused_function - Success
torlink> -- Performing Test has_wno_unused_parameter
torlink> -- Performing Test has_wno_unused_parameter - Success
torlink> -- Performing Test has_wno_unreachable_code
torlink> -- Performing Test has_wno_unreachable_code - Success
torlink> -- Performing Test has_wstrict_prototypes
torlink> -- Performing Test has_wstrict_prototypes - Success
torlink> -- Compiler flags (CMAKE_C_FLAGS):  -std=c99 -pedantic -Wall -Wextra -Wfloat-equal -Wshadow -Wpointer-arith -Wunreachable-code -Winit-self -Wno-unused-function -Wno-unused-parameter -Wno-unreachable-code -Wstrict-prototypes
torlink> -- Performing Test has_wno_address_of_packed_member
torlink> -- Performing Test has_wno_address_of_packed_member - Success
torlink> -- Performing Test has_wno_deprecated_declarations
torlink> -- Performing Test has_wno_deprecated_declarations - Success
torlink> -- Looking for arpa/inet.h
torlink> -- Looking for arpa/inet.h - found
torlink> -- Looking for byteswap.h
torlink> -- Looking for byteswap.h - found
torlink> -- Looking for inttypes.h
torlink> -- Looking for inttypes.h - found
torlink> -- Looking for machine/types.h
torlink> -- Looking for machine/types.h - not found
torlink> -- Looking for netinet/in.h
torlink> -- Looking for netinet/in.h - found
torlink> -- Looking for stdint.h
torlink> -- Looking for stdint.h - found
torlink> -- Looking for stdlib.h
torlink> -- Looking for stdlib.h - found
torlink> -- Looking for sys/int_types.h
torlink> -- Looking for sys/int_types.h - not found
torlink> -- Looking for sys/socket.h
torlink> -- Looking for sys/socket.h - found
torlink> -- Looking for sys/types.h
torlink> -- Looking for sys/types.h - found
torlink> -- Looking for unistd.h
torlink> -- Looking for unistd.h - found
torlink> -- Looking for windows.h
torlink> -- Looking for windows.h - not found
torlink> -- Looking for winsock2.h
torlink> -- Looking for winsock2.h - not found
torlink> -- Looking for sigaction
torlink> -- Looking for sigaction - found
torlink> -- Looking for inet_aton
torlink> -- Looking for inet_aton - found
torlink> -- Looking for inet_pton
torlink> -- Looking for inet_pton - found
torlink> -- Looking for usleep
torlink> -- Looking for usleep - found
torlink> -- Looking for stddef.h
torlink> -- Looking for stddef.h - found
torlink> -- Check size of uint8_t
torlink> -- Check size of uint8_t - done
torlink> -- Check size of uint16_t
torlink> -- Check size of uint16_t - done
torlink> -- Check size of uint32_t
torlink> -- Check size of uint32_t - done
torlink> -- Check size of uint64_t
torlink> -- Check size of uint64_t - done
torlink> -- Check size of int32_t
torlink> -- Check size of int32_t - done
torlink> -- Check size of unsigned long
torlink> -- Check size of unsigned long - done
torlink> -- Check size of unsigned long long
torlink> -- Check size of unsigned long long - done
torlink> -- Performing Test HAVE_INLINE
torlink> -- Performing Test HAVE_INLINE - Success
torlink> -- Found OpenSSL: /nix/store/l0vl4dali2mvbpi30a8da1f71jl85myg-openssl-3.6.2/lib/libcrypto.so (found suitable version "3.6.2", minimum required is "1.1.0")
torlink> -- Warnings Active for: srtp2
torlink> -- Warnings as Errors: ON
torlink> -- Could NOT find PCAP (missing: PCAP_LIBRARY)
torlink> -- Warnings Active for: datatypes_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: cipher_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: kernel_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: rdbx_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: replay_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: roc_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: srtp_driver
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: test_srtp
torlink> -- Warnings as Errors: ON
torlink> -- Warnings Active for: rtpw
torlink> -- Warnings as Errors: ON
torlink> -- Found OpenSSL: /nix/store/l0vl4dali2mvbpi30a8da1f71jl85myg-openssl-3.6.2/lib/libcrypto.so (found version "3.6.2")
torlink> -- Using the multi-header code from /nix/store/ix35pmq1mmgz8ivdnyr3h1sdmy9sg1k4-source/deps/json/include/
torlink> -- Configuring done (3.2s)
torlink> -- Generating done (0.1s)
torlink> -- Build files have been written to: /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel/build
torlink> INFO CMD BUILD
torlink> INFO RUN [
torlink>   'cmake',
torlink>   '--build',
torlink>   '/nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel/build',
torlink>   '--config',
torlink>   'Release'
torlink> ]
torlink> [  0%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/addr.c.o
torlink> [  0%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/agent.c.o
torlink> [  2%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/crc32.c.o
torlink> [  2%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/const_time.c.o
torlink> [  2%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/conn.c.o
torlink> [  2%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/conn_poll.c.o
torlink> [  4%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/conn_thread.c.o
torlink> [  4%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/conn_mux.c.o
torlink> [  4%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/base64.c.o
torlink> [  6%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/hash.c.o
torlink> [  6%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/hmac.c.o
torlink> [  6%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/ice.c.o
torlink> [  8%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/juice.c.o
torlink> [  8%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/log.c.o
torlink> [  8%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/random.c.o
torlink> [  8%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/server.c.o
torlink> [ 10%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/stun.c.o
torlink> [ 10%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/timestamp.c.o
torlink> [ 10%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/tcp.c.o
torlink> [ 12%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/turn.c.o
torlink> [ 12%] Building C object _deps/libdatachannel-build/deps/libjuice/CMakeFiles/juice-static.dir/src/udp.c.o
torlink> [ 12%] Linking C static library libjuice-static.a
torlink> [ 12%] Built target juice-static
torlink> [ 14%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_asconf.c.o
torlink> [ 14%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_auth.c.o
torlink> [ 14%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_bsd_addr.c.o
torlink> [ 14%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_callout.c.o
torlink> [ 17%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_cc_functions.c.o
torlink> [ 17%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_crc32.c.o
torlink> [ 17%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_indata.c.o
torlink> [ 19%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_input.c.o
torlink> [ 19%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_output.c.o
torlink> [ 19%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_pcb.c.o
torlink> [ 21%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_peeloff.c.o
torlink> [ 21%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_sha1.c.o
torlink> [ 21%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_ss_functions.c.o
torlink> [ 21%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_sysctl.c.o
torlink> [ 23%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_timer.c.o
torlink> [ 23%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_userspace.c.o
torlink> [ 23%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctp_usrreq.c.o
torlink> [ 25%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet/sctputil.c.o
torlink> [ 25%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/netinet6/sctp6_usrreq.c.o
torlink> [ 25%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/user_environment.c.o
torlink> [ 27%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/user_mbuf.c.o
torlink> [ 27%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/user_recv_thread.c.o
torlink> [ 27%] Building C object _deps/libdatachannel-build/deps/usrsctp/usrsctplib/CMakeFiles/usrsctp.dir/user_socket.c.o
torlink> [ 29%] Linking C static library libusrsctp.a
torlink> [ 29%] Built target usrsctp
torlink> [ 31%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/srtp/srtp.c.o
torlink> [ 31%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/cipher/cipher.c.o
torlink> [ 31%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/cipher/cipher_test_cases.c.o
torlink> [ 31%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/cipher/null_cipher.c.o
torlink> [ 34%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/cipher/aes_icm_ossl.c.o
torlink> [ 34%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/cipher/aes_gcm_ossl.c.o
torlink> [ 34%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/hash/auth.c.o
torlink> [ 36%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/hash/auth_test_cases.c.o
torlink> [ 36%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/hash/null_auth.c.o
torlink> [ 36%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/hash/hmac_ossl.c.o
torlink> [ 38%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/kernel/alloc.c.o
torlink> [ 38%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/kernel/crypto_kernel.c.o
torlink> [ 38%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/kernel/err.c.o
torlink> [ 40%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/kernel/key.c.o
torlink> [ 40%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/math/datatypes.c.o
torlink> [ 40%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/replay/rdb.c.o
torlink> [ 40%] Building C object _deps/libdatachannel-build/deps/libsrtp/CMakeFiles/srtp2.dir/crypto/replay/rdbx.c.o
torlink> [ 42%] Linking C static library libsrtp2.a
torlink> [ 42%] Built target srtp2
torlink> [ 42%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/candidate.cpp.o
torlink> [ 44%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/channel.cpp.o
torlink> [ 44%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/configuration.cpp.o
torlink> [ 44%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/datachannel.cpp.o
torlink> [ 46%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/dependencydescriptor.cpp.o
torlink> [ 46%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/description.cpp.o
torlink> [ 46%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/iceudpmuxlistener.cpp.o
torlink> [ 48%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/mediahandler.cpp.o
torlink> [ 48%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/global.cpp.o
torlink> [ 48%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/message.cpp.o
torlink> [ 48%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/peerconnection.cpp.o
torlink> [ 51%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtcpreceivingsession.cpp.o
torlink> [ 51%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/track.cpp.o
torlink> [ 51%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/websocket.cpp.o
torlink> [ 53%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/websocketserver.cpp.o
torlink> [ 53%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtppacketizationconfig.cpp.o
torlink> [ 53%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtcpsrreporter.cpp.o
torlink> [ 55%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtppacketizer.cpp.o
torlink> [ 55%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtpdepacketizer.cpp.o
torlink> [ 55%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/h264rtppacketizer.cpp.o
torlink> [ 55%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/h264rtpdepacketizer.cpp.o
torlink> [ 57%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/nalunit.cpp.o
torlink> [ 57%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/h265rtppacketizer.cpp.o
torlink> [ 57%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/h265rtpdepacketizer.cpp.o
torlink> [ 59%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/h265nalunit.cpp.o
torlink> [ 59%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/av1rtppacketizer.cpp.o
torlink> [ 59%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtcpnackresponder.cpp.o
torlink> [ 61%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rtp.cpp.o
torlink> [ 61%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/capi.cpp.o
torlink> [ 61%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/plihandler.cpp.o
torlink> [ 61%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/pacinghandler.cpp.o
torlink> [ 63%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/rembhandler.cpp.o
torlink> [ 63%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/certificate.cpp.o
torlink> [ 63%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/channel.cpp.o
torlink> [ 65%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/datachannel.cpp.o
torlink> [ 65%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/dtlssrtptransport.cpp.o
torlink> [ 65%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/dtlstransport.cpp.o
torlink> [ 68%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/icetransport.cpp.o
torlink> [ 68%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/iceudpmuxlistener.cpp.o
torlink> [ 68%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/init.cpp.o
torlink> [ 68%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/peerconnection.cpp.o
torlink> [ 70%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/logcounter.cpp.o
torlink> [ 70%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/sctptransport.cpp.o
torlink> [ 70%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/threadpool.cpp.o
torlink> [ 72%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/tls.cpp.o
torlink> [ 72%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/track.cpp.o
torlink> [ 72%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/utils.cpp.o
torlink> [ 74%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/processor.cpp.o
torlink> [ 74%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/sha.cpp.o
torlink> [ 74%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/pollinterrupter.cpp.o
torlink> [ 74%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/pollservice.cpp.o
torlink> [ 76%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/http.cpp.o
torlink> [ 76%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/httpproxytransport.cpp.o
torlink> [ 76%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/tcpserver.cpp.o
torlink> [ 78%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/tcptransport.cpp.o
torlink> [ 78%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/tlstransport.cpp.o
torlink> [ 78%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/transport.cpp.o
torlink> [ 80%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/verifiedtlstransport.cpp.o
torlink> [ 80%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/websocket.cpp.o
torlink> [ 80%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/websocketserver.cpp.o
torlink> [ 82%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/wstransport.cpp.o
torlink> [ 82%] Building CXX object _deps/libdatachannel-build/CMakeFiles/datachannel-static.dir/src/impl/wshandshake.cpp.o
torlink> [ 82%] Linking CXX static library libdatachannel-static.a
torlink> [ 82%] Built target datachannel-static
torlink> [ 82%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/rtc-wrapper.cpp.o
torlink> [ 85%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/data-channel-wrapper.cpp.o
torlink> [ 85%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/ice-udp-mux-listener-wrapper.cpp.o
torlink> [ 85%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/peer-connection-wrapper.cpp.o
torlink> [ 87%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/thread-safe-callback.cpp.o
torlink> [ 87%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/main.cpp.o
torlink> [ 87%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-av1packetization.cpp.o
torlink> [ 89%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-av1rtppacketizer-wrapper.cpp.o
torlink> [ 89%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-direction.cpp.o
torlink> [ 89%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-h26xseparator.cpp.o
torlink> [ 91%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-h264rtppacketizer-wrapper.cpp.o
torlink> [ 91%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-h265rtppacketizer-wrapper.cpp.o
torlink> [ 91%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-mediahandler-helper.cpp.o
torlink> [ 91%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-pacinghandler-wrapper.cpp.o
torlink> [ 93%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-rtcpnackresponder-wrapper.cpp.o
torlink> [ 93%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-rtcpreceivingsession-wrapper.cpp.o
torlink> [ 93%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-rtcpsrreporter-wrapper.cpp.o
torlink> [ 95%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-rtppacketizationconfig-wrapper.cpp.o
torlink> [ 95%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-rtppacketizer-wrapper.cpp.o
torlink> [ 95%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-track-wrapper.cpp.o
torlink> [ 97%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-audio-wrapper.cpp.o
torlink> [ 97%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/media-video-wrapper.cpp.o
torlink> [ 97%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/web-socket-wrapper.cpp.o
torlink> [ 97%] Building CXX object CMakeFiles/node_datachannel.dir/src/cpp/web-socket-server-wrapper.cpp.o
torlink> [100%] Linking CXX shared library Release/node_datachannel.node
torlink> [100%] Built target node_datachannel
torlink> ~/source
torlink> Finished npmInstallHook
torlink> installPhase completed in 2 minutes 27 seconds
torlink> Running phase: fixupPhase
torlink> shrinking RPATHs of ELF executables and libraries in /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/utp-native/prebuilds/linux-x64/node.napi.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/node-datachannel/build/Release/node_datachannel.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-ia32/fs-native-extensions.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-ia32/fs-native-extensions.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-x64/fs-native-extensions.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-x64/fs-native-extensions.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-arm64/fs-native-extensions.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/linux-arm64/fs-native-extensions.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm/fs-native-extensions.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm/fs-native-extensions.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm64/fs-native-extensions.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-arm64/fs-native-extensions.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-x64/fs-native-extensions.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/fs-native-extensions/prebuilds/android-x64/fs-native-extensions.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.musl.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/utf-8-validate/prebuilds/linux-x64/utf-8-validate.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bufferutil/prebuilds/linux-x64/bufferutil.node
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-ia32/bare-os.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/linux-x64/bare-os.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/linux-arm64/bare-os.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-arm/bare-os.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-arm64/bare-os.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-os/prebuilds/android-x64/bare-os.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-ia32/bare-fs.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/linux-x64/bare-fs.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/linux-arm64/bare-fs.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-arm/bare-fs.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-arm64/bare-fs.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-fs/prebuilds/android-x64/bare-fs.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-ia32/bare-url.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/linux-x64/bare-url.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/linux-arm64/bare-url.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-arm/bare-url.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-arm64/bare-url.bare
torlink> shrinking /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/node_modules/bare-url/prebuilds/android-x64/bare-url.bare
torlink> checking for references to /build/ in /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0...
torlink> patching script interpreter paths in /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0
torlink> /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/dist/index.js: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
torlink> /nix/store/i811kymb50g05mpy83bw5mnsfwc5h8kx-torlink-1.4.0/lib/node_modules/torlnk/dist/cli.cjs: interpreter directive changed from "#!/usr/bin/env node" to "/nix/store/znxrv89969njb8fxyyn8rz4ygmmcjpw9-nodejs-22.23.1/bin/node"
```

</details>
