### PR TITLE
fix: updated unknown hash mismatch in libdatachannel

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -18,7 +18,7 @@ let
     repo = "libdatachannel";
     tag = "v0.24.5";
     fetchSubmodules = true;
-    hash = "sha256-0Yrp9cZL8JvBD5YZYbJdmPpPSBHTM/5WXNNK/s+GkDI=";
+    hash = "sha256-rr3au3JMqLd/sjNtXtXY2mcuW0CeOgG+Xj2RgEQCWys=";
   };
 
   libdatachannelBuildDeps = stdenv.mkDerivation {


### PR DESCRIPTION
## What and why
For reasons unknown to me the hash updated even though there doesn't seem to have been any kind of update to v0.24.5 of libdatachannel. There shouldn't have been an update to the hash as it is not linked to libdatachannelBuildDeps hash or the new torlink 1.4.1 hash.
