### PR TITLE
feat: fetch matching subtitles automatically when a movie or show finishes

### DIFF
--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { defaultConfig, loadConfig, normalizeSubtitleLang, saveConfig } from "./config";
+
+describe("normalizeSubtitleLang", () => {
+  it("keeps a valid 2-3 letter code, lowercased and trimmed", () => {
+    expect(normalizeSubtitleLang("en")).toBe("en");
+    expect(normalizeSubtitleLang(" HE ")).toBe("he");
+    expect(normalizeSubtitleLang("SPA")).toBe("spa");
+  });
+
+  it("falls back to en for anything else", () => {
+    expect(normalizeSubtitleLang("")).toBe("en");
+    expect(normalizeSubtitleLang("e")).toBe("en");
+    expect(normalizeSubtitleLang("engl")).toBe("en");
+    expect(normalizeSubtitleLang("e1")).toBe("en");
+    expect(normalizeSubtitleLang(42)).toBe("en");
+    expect(normalizeSubtitleLang(null)).toBe("en");
+    expect(normalizeSubtitleLang(undefined)).toBe("en");
+  });
+});
+
+describe("config round-trip", () => {
+  it("defaults subtitleLang to en", () => {
+    expect(defaultConfig.subtitleLang).toBe("en");
+  });
+
+  it("persists subtitleLang through save and load", async () => {
+    await saveConfig({ ...defaultConfig, subtitleLang: "he" });
+    await expect(loadConfig()).resolves.toMatchObject({ subtitleLang: "he" });
+  });
+
+  it("rejects junk subtitleLang back to en on load", async () => {
+    await saveConfig({ ...defaultConfig, subtitleLang: "not-a-code" });
+    await expect(loadConfig()).resolves.toMatchObject({ subtitleLang: "en" });
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -14,12 +14,15 @@ export const defaultConfig: Config = {
   subtitleLang: "en",
 };
 
-// Accept only a plausible ISO 639 code (2-3 ASCII letters); anything else
-// falls back to English rather than poisoning every subtitle search.
+// A plausible ISO 639 code (2-3 ASCII letters) — the single home of the rule;
+// the TUI prompt validates against it too.
+export const SUBTITLE_LANG_RE = /^[a-z]{2,3}$/;
+
+// Anything else falls back to English rather than poisoning every subtitle search.
 export function normalizeSubtitleLang(value: unknown): string {
   if (typeof value !== "string") return "en";
   const lang = value.trim().toLowerCase();
-  return /^[a-z]{2,3}$/.test(lang) ? lang : "en";
+  return SUBTITLE_LANG_RE.test(lang) ? lang : "en";
 }
 
 export async function loadConfig(): Promise<Config> {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,12 +5,22 @@ import { serializeWrites, writeJsonAtomic } from "../util/atomic";
 export interface Config {
   downloadDir: string;
   trackers: string[];
+  subtitleLang: string;
 }
 
 export const defaultConfig: Config = {
   downloadDir: defaultDownloadDir,
   trackers: [],
+  subtitleLang: "en",
 };
+
+// Accept only a plausible ISO 639 code (2-3 ASCII letters); anything else
+// falls back to English rather than poisoning every subtitle search.
+export function normalizeSubtitleLang(value: unknown): string {
+  if (typeof value !== "string") return "en";
+  const lang = value.trim().toLowerCase();
+  return /^[a-z]{2,3}$/.test(lang) ? lang : "en";
+}
 
 export async function loadConfig(): Promise<Config> {
   let raw: string;
@@ -29,6 +39,7 @@ export async function loadConfig(): Promise<Config> {
       trackers: Array.isArray(parsed.trackers)
         ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
         : [],
+      subtitleLang: normalizeSubtitleLang(parsed.subtitleLang),
     };
     return cfg;
   } catch {

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -139,6 +139,18 @@ export class TorrentEngine {
     };
   }
 
+  // Relative paths (from the download dir) + sizes of the torrent's files.
+  files(id: string): { path: string; length: number }[] | null {
+    const t = this.torrents.get(id);
+    if (!t) return null;
+    try {
+      return t.files.map((f) => ({ path: f.path, length: f.length }));
+    } catch {
+      // webtorrent getters can throw before metadata is fully parsed
+      return null;
+    }
+  }
+
   remove(id: string): void {
     const t = this.torrents.get(id);
     this.torrents.delete(id);

--- a/src/download/history.ts
+++ b/src/download/history.ts
@@ -14,6 +14,7 @@ export interface HistoryItem {
   magnet: string;
   dir: string;
   completedAt: number;
+  subsLang?: string; // set once subtitles were fetched for this item
 }
 
 const write = serializeWrites();

--- a/src/download/queue.subtitles.test.ts
+++ b/src/download/queue.subtitles.test.ts
@@ -29,6 +29,13 @@ vi.mock("./engine", () => ({
 const fetchSubs = vi.hoisted(() => vi.fn(async (): Promise<number | null> => 2));
 vi.mock("../subtitles/index", () => ({ fetchSubtitlesForDownload: fetchSubs }));
 
+// History persistence is disk I/O; stub it so tests assert the save calls.
+const saveHistoryMock = vi.hoisted(() => vi.fn(async (): Promise<void> => {}));
+vi.mock("./history", () => ({
+  saveHistory: saveHistoryMock,
+  saveHistorySync: vi.fn(),
+}));
+
 const MAGNET = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000";
 
 function onDone(id: string): void {
@@ -37,6 +44,7 @@ function onDone(id: string): void {
 
 beforeEach(() => {
   fetchSubs.mockClear();
+  saveHistoryMock.mockClear();
   state.handlers.clear();
 });
 
@@ -70,6 +78,25 @@ describe("DownloadQueue subtitle hook", () => {
     q.suspend();
   });
 
+  it("a successful fetch tags the history entry with the lang and persists it", async () => {
+    const q = new DownloadQueue();
+    q.setSubtitleLang("he");
+    const events: unknown[] = [];
+    q.on("subtitles", (...args: unknown[]) => events.push(args));
+
+    q.add({ id: "t4", name: "Show.S01E03", magnet: MAGNET, source: "eztv" }, "/downloads/a");
+    onDone("t4");
+
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    expect(q.getHistory().find((h) => h.id === "t4")?.subsLang).toBe("he");
+    // The tag must reach disk: the last saveHistory call carries it.
+    const last = saveHistoryMock.mock.calls.at(-1) as unknown as [
+      Array<{ id: string; subsLang?: string }>,
+    ];
+    expect(last[0].find((h) => h.id === "t4")?.subsLang).toBe("he");
+    q.suspend();
+  });
+
   it("a null result (never searched) emits no subtitles event", async () => {
     fetchSubs.mockResolvedValueOnce(null);
     const q = new DownloadQueue();
@@ -86,6 +113,7 @@ describe("DownloadQueue subtitle hook", () => {
     await new Promise((r) => setImmediate(r));
     expect(events).toEqual([]);
     expect(completed).toEqual(["Elden.Ring.Repack"]);
+    expect(q.getHistory().find((h) => h.id === "t3")?.subsLang).toBeUndefined();
     q.suspend();
   });
 

--- a/src/download/queue.subtitles.test.ts
+++ b/src/download/queue.subtitles.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DownloadQueue } from "./queue";
+import type { AddHandlers } from "./engine";
+
+// Same stub approach as queue.add.test.ts, extended to capture the handlers
+// each add() registers so tests can fire onDone (completion) themselves, and
+// to serve a canned file list for the subtitle hook.
+const state = vi.hoisted(() => ({
+  handlers: new Map<string, unknown>(),
+  files: [{ path: "Show.S01E01.1080p.WEB.mkv", length: 300 * 1024 * 1024 }],
+}));
+
+vi.mock("./engine", () => ({
+  TorrentEngine: class {
+    add(id: string, _source: string, _dir: string, handlers: unknown): void {
+      state.handlers.set(id, handlers);
+    }
+    remove(): void {}
+    stats(): undefined {
+      return undefined;
+    }
+    files(): { path: string; length: number }[] {
+      return state.files;
+    }
+    destroy(): void {}
+  },
+}));
+
+const fetchSubs = vi.hoisted(() => vi.fn(async () => 2));
+vi.mock("../subtitles/index", () => ({ fetchSubtitlesForDownload: fetchSubs }));
+
+const MAGNET = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000";
+
+function onDone(id: string): void {
+  (state.handlers.get(id) as AddHandlers).onDone!();
+}
+
+beforeEach(() => {
+  fetchSubs.mockClear();
+  state.handlers.clear();
+});
+
+describe("DownloadQueue subtitle hook", () => {
+  it("complete() triggers exactly one subtitle fetch with the configured lang", async () => {
+    const q = new DownloadQueue();
+    q.setSubtitleLang("he");
+    const events: Array<[string, number, string]> = [];
+    q.on("subtitles", (name: string, count: number, lang: string) =>
+      events.push([name, count, lang]),
+    );
+
+    q.add({ id: "t1", name: "Show.S01E01", magnet: MAGNET, source: "eztv" }, "/downloads/a");
+    onDone("t1");
+
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    expect(fetchSubs).toHaveBeenCalledTimes(1);
+    expect(fetchSubs).toHaveBeenCalledWith({
+      name: "Show.S01E01",
+      dir: "/downloads/a",
+      source: "eztv",
+      files: state.files,
+      lang: "he",
+    });
+    expect(events).toEqual([["Show.S01E01", 2, "he"]]);
+
+    // A second onDone is the seed-verification path, never a second fetch.
+    onDone("t1");
+    await Promise.resolve();
+    expect(fetchSubs).toHaveBeenCalledTimes(1);
+    q.suspend();
+  });
+
+  it("a rejecting fetch leaves the item completed + seeding and emits count 0", async () => {
+    fetchSubs.mockRejectedValueOnce(new Error("boom"));
+    const q = new DownloadQueue();
+    const events: Array<[string, number, string]> = [];
+    q.on("subtitles", (name: string, count: number, lang: string) =>
+      events.push([name, count, lang]),
+    );
+    const completed: string[] = [];
+    q.on("completed", (name: string) => completed.push(name));
+
+    q.add({ id: "t2", name: "Show.S01E02", magnet: MAGNET, source: "eztv" }, "/downloads/a");
+    onDone("t2");
+
+    await vi.waitFor(() => expect(events).toHaveLength(1));
+    expect(events).toEqual([["Show.S01E02", 0, "en"]]);
+    expect(completed).toEqual(["Show.S01E02"]);
+    expect(q.has("t2")).toBe(false);
+    expect(q.getSeed("t2")?.status).toBe("seeding");
+    q.suspend();
+  });
+});

--- a/src/download/queue.subtitles.test.ts
+++ b/src/download/queue.subtitles.test.ts
@@ -26,7 +26,7 @@ vi.mock("./engine", () => ({
   },
 }));
 
-const fetchSubs = vi.hoisted(() => vi.fn(async () => 2));
+const fetchSubs = vi.hoisted(() => vi.fn(async (): Promise<number | null> => 2));
 vi.mock("../subtitles/index", () => ({ fetchSubtitlesForDownload: fetchSubs }));
 
 const MAGNET = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000";
@@ -67,6 +67,25 @@ describe("DownloadQueue subtitle hook", () => {
     onDone("t1");
     await Promise.resolve();
     expect(fetchSubs).toHaveBeenCalledTimes(1);
+    q.suspend();
+  });
+
+  it("a null result (never searched) emits no subtitles event", async () => {
+    fetchSubs.mockResolvedValueOnce(null);
+    const q = new DownloadQueue();
+    const events: unknown[] = [];
+    q.on("subtitles", (...args: unknown[]) => events.push(args));
+    const completed: string[] = [];
+    q.on("completed", (name: string) => completed.push(name));
+
+    q.add({ id: "t3", name: "Elden.Ring.Repack", magnet: MAGNET, source: "fitgirl" }, "/downloads/a");
+    onDone("t3");
+
+    await vi.waitFor(() => expect(fetchSubs).toHaveBeenCalledTimes(1));
+    // Let the async fetchSubs hook settle fully before asserting silence.
+    await new Promise((r) => setImmediate(r));
+    expect(events).toEqual([]);
+    expect(completed).toEqual(["Elden.Ring.Repack"]);
     q.suspend();
   });
 

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -218,6 +218,8 @@ export class DownloadQueue extends EventEmitter {
       files,
       lang: this.subtitleLang,
     }).catch(() => 0);
+    // null = never searched (not subtitle-applicable): no toast either way.
+    if (count === null) return;
     this.emit("subtitles", it.name, count, this.subtitleLang);
   }
 

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -220,6 +220,15 @@ export class DownloadQueue extends EventEmitter {
     }).catch(() => 0);
     // null = never searched (not subtitle-applicable): no toast either way.
     if (count === null) return;
+    if (count > 0) {
+      // Tag the history entry recordHistory just wrote so the UI can show it.
+      const h = this.history.find((x) => x.id === it.id);
+      if (h) {
+        h.subsLang = this.subtitleLang;
+        void saveHistory(this.history).catch(() => {});
+        this.changed();
+      }
+    }
     this.emit("subtitles", it.name, count, this.subtitleLang);
   }
 

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -13,6 +13,7 @@ import {
   type SeedRecord,
 } from "./persist";
 import { saveHistory, saveHistorySync, type HistoryItem } from "./history";
+import { fetchSubtitlesForDownload } from "../subtitles/index";
 import type { QueueItem, SeedItem } from "./types";
 import type { SourceId } from "../sources/types";
 
@@ -55,12 +56,18 @@ export class DownloadQueue extends EventEmitter {
   private strayHits = new Map<string, number>();
   private seedStartedAt = new Map<string, number>();
   private trackers: string[] = [];
+  private subtitleLang = "en";
 
   // Extra announce URLs appended to every torrent added from now on.
   // Existing running torrents aren't retro-updated — the change takes effect
   // for the next add / resume / re-seed.
   setTrackers(trackers: string[]): void {
     this.trackers = trackers;
+  }
+
+  // Language subtitles are fetched in for downloads completing from now on.
+  setSubtitleLang(lang: string): void {
+    this.subtitleLang = lang;
   }
 
   getItems(): QueueItem[] {
@@ -192,10 +199,26 @@ export class DownloadQueue extends EventEmitter {
     // Opt-out seeding: a finished download is already a complete, verified
     // torrent, so keep it alive and seeding instead of tearing it down.
     this.beginSeed(it);
+    // beginSeed keeps the torrent alive, so the engine can still list its files.
+    const files = this.engine.files(it.id) ?? [];
+    void this.fetchSubs(it, files);
     this.emit("completed", it.name);
     this.changed();
     void this.persist();
     this.maybeStopPoll();
+  }
+
+  // Best-effort side task: a subtitle failure must never affect the
+  // download/seed lifecycle, so every error collapses to count 0 here.
+  private async fetchSubs(it: QueueItem, files: { path: string; length: number }[]): Promise<void> {
+    const count = await fetchSubtitlesForDownload({
+      name: it.name,
+      dir: it.dir,
+      source: it.source,
+      files,
+      lang: this.subtitleLang,
+    }).catch(() => 0);
+    this.emit("subtitles", it.name, count, this.subtitleLang);
   }
 
   // Adopt the just-finished download's live torrent as a seed in place: no

--- a/src/subtitles/fetchSubtitle.test.ts
+++ b/src/subtitles/fetchSubtitle.test.ts
@@ -61,12 +61,14 @@ describe("downloadSubtitle", () => {
     expect(await readFile(dest, "utf8")).toBe(SRT);
   });
 
-  it("sends the yts-subs referer for yifysubtitles.ch downloads", async () => {
+  it("sends a same-origin referer for yifysubtitles.ch downloads", async () => {
+    // The host's hotlink check serves an HTML page (HTTP 200) to any
+    // cross-domain referer; only its own origin gets the zip.
     const f = vi.fn<typeof fetch>().mockResolvedValue(new Response(SRT));
     const dest = join(dir, "c.srt");
     await downloadSubtitle(candidate("https://yifysubtitles.ch/subtitle/x.zip"), dest, f);
     const headers = (f.mock.calls[0]![1]!.headers ?? {}) as Record<string, string>;
-    expect(headers["referer"]).toBe("https://yts-subs.com/");
+    expect(headers["referer"]).toBe("https://yifysubtitles.ch/");
   });
 
   it("aborts bodies over 2 MB without buffering them and returns false", async () => {
@@ -96,6 +98,16 @@ describe("downloadSubtitle", () => {
   it("rejects content without a timing arrow", async () => {
     const f = vi.fn<typeof fetch>().mockResolvedValue(new Response("<html>blocked</html>"));
     const dest = join(dir, "f.srt");
+    expect(await downloadSubtitle(candidate(), dest, f)).toBe(false);
+    expect(existsSync(dest)).toBe(false);
+  });
+
+  it("rejects HTML whose comments contain a bare arrow", async () => {
+    // A blocked-download page is HTTP 200 HTML; "<!-- ads -->" must not pass
+    // as a subtitle. Only a real timing line (hh:mm:ss,mmm --> ...) counts.
+    const html = "<!DOCTYPE html><html><!-- served by cdn --><body>blocked</body></html>";
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response(html));
+    const dest = join(dir, "f2.srt");
     expect(await downloadSubtitle(candidate(), dest, f)).toBe(false);
     expect(existsSync(dest)).toBe(false);
   });

--- a/src/subtitles/fetchSubtitle.test.ts
+++ b/src/subtitles/fetchSubtitle.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { deflateRawSync } from "node:zlib";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { downloadSubtitle } from "./fetchSubtitle";
+import type { SubtitleCandidate } from "./types";
+
+const SRT = "1\n00:00:01,000 --> 00:00:02,000\nhello\n";
+
+function candidate(downloadUrl = "https://api.gestdown.info/subtitles/download/x"): SubtitleCandidate {
+  return { releaseName: "Show.S01E01.720p", lang: "en", downloadUrl };
+}
+
+// Single-entry deflate zip with just the fields the extractor reads.
+function makeZip(name: string, data: Buffer): Buffer {
+  const comp = deflateRawSync(data);
+  const nameBuf = Buffer.from(name);
+  const local = Buffer.alloc(30);
+  local.writeUInt32LE(0x04034b50, 0);
+  local.writeUInt16LE(8, 8);
+  local.writeUInt32LE(comp.length, 18);
+  local.writeUInt32LE(data.length, 22);
+  local.writeUInt16LE(nameBuf.length, 26);
+  const cen = Buffer.alloc(46);
+  cen.writeUInt32LE(0x02014b50, 0);
+  cen.writeUInt16LE(8, 10);
+  cen.writeUInt32LE(comp.length, 20);
+  cen.writeUInt32LE(data.length, 24);
+  cen.writeUInt16LE(nameBuf.length, 28);
+  cen.writeUInt32LE(0, 42);
+  const cdOffset = 30 + nameBuf.length + comp.length;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(1, 8);
+  eocd.writeUInt16LE(1, 10);
+  eocd.writeUInt32LE(46 + nameBuf.length, 12);
+  eocd.writeUInt32LE(cdOffset, 16);
+  return Buffer.concat([local, nameBuf, comp, cen, nameBuf, eocd]);
+}
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "torlnk-subs-"));
+});
+
+describe("downloadSubtitle", () => {
+  it("writes plain srt bodies to destPath", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response("\uFEFF" + SRT));
+    const dest = join(dir, "a.srt");
+    expect(await downloadSubtitle(candidate(), dest, f)).toBe(true);
+    expect(await readFile(dest, "utf8")).toBe(SRT);
+  });
+
+  it("routes PK-magic bodies through zip extraction", async () => {
+    const zip = makeZip("movie.srt", Buffer.from(SRT));
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response(new Uint8Array(zip)));
+    const dest = join(dir, "b.srt");
+    expect(await downloadSubtitle(candidate(), dest, f)).toBe(true);
+    expect(await readFile(dest, "utf8")).toBe(SRT);
+  });
+
+  it("sends the yts-subs referer for yifysubtitles.ch downloads", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response(SRT));
+    const dest = join(dir, "c.srt");
+    await downloadSubtitle(candidate("https://yifysubtitles.ch/subtitle/x.zip"), dest, f);
+    const headers = (f.mock.calls[0]![1]!.headers ?? {}) as Record<string, string>;
+    expect(headers["referer"]).toBe("https://yts-subs.com/");
+  });
+
+  it("aborts bodies over 2 MB without buffering them and returns false", async () => {
+    let pulls = 0;
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls++;
+        controller.enqueue(new Uint8Array(256 * 1024));
+      },
+    });
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response(stream));
+    const dest = join(dir, "d.srt");
+    expect(await downloadSubtitle(candidate(), dest, f)).toBe(false);
+    expect(existsSync(dest)).toBe(false);
+    // The reader stops just past the cap instead of draining the stream.
+    expect(pulls).toBeLessThan(20);
+  });
+
+  it("never overwrites an existing file", async () => {
+    const dest = join(dir, "e.srt");
+    await writeFile(dest, "original");
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response(SRT));
+    expect(await downloadSubtitle(candidate(), dest, f)).toBe(false);
+    expect(await readFile(dest, "utf8")).toBe("original");
+  });
+
+  it("rejects content without a timing arrow", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response("<html>blocked</html>"));
+    const dest = join(dir, "f.srt");
+    expect(await downloadSubtitle(candidate(), dest, f)).toBe(false);
+    expect(existsSync(dest)).toBe(false);
+  });
+
+  it("returns false on non-OK responses and network errors", async () => {
+    const bad = vi.fn<typeof fetch>().mockResolvedValue(new Response("x", { status: 404 }));
+    expect(await downloadSubtitle(candidate(), join(dir, "g.srt"), bad)).toBe(false);
+    const boom = vi.fn<typeof fetch>().mockRejectedValue(new Error("boom"));
+    expect(await downloadSubtitle(candidate(), join(dir, "h.srt"), boom)).toBe(false);
+  });
+});

--- a/src/subtitles/fetchSubtitle.ts
+++ b/src/subtitles/fetchSubtitle.ts
@@ -1,4 +1,5 @@
 import { writeFile } from "node:fs/promises";
+import { fetchResilient } from "../util/net";
 import { extractSrtFromZip } from "./zip";
 import type { SubtitleCandidate } from "./types";
 
@@ -10,7 +11,8 @@ export const FETCH_TIMEOUT_MS = 10_000;
 
 const MAX_BYTES = 2 * 1024 * 1024;
 
-async function readCapped(res: Response): Promise<Buffer | null> {
+// Single body-cap implementation for all subtitle fetches (providers import it).
+export async function readCapped(res: Response): Promise<Buffer | null> {
   const contentLength = res.headers.get("content-length");
   if (contentLength && Number(contentLength) > MAX_BYTES) return null;
   if (!res.body) {
@@ -48,9 +50,12 @@ export async function downloadSubtitle(
     if (origin === "https://yifysubtitles.ch") {
       headers["referer"] = `${origin}/`;
     }
-    const res = await fetchImpl(candidate.downloadUrl, {
+    // retries: 1 keeps this background hook polite to the subtitle hosts.
+    const res = await fetchResilient(candidate.downloadUrl, {
       headers,
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      retries: 1,
+      fetchImpl,
     });
     if (!res.ok) return false;
 

--- a/src/subtitles/fetchSubtitle.ts
+++ b/src/subtitles/fetchSubtitle.ts
@@ -1,0 +1,70 @@
+import { writeFile } from "node:fs/promises";
+import { extractSrtFromZip } from "./zip";
+import type { SubtitleCandidate } from "./types";
+
+// Subtitle sites block non-browser user agents, so the torlink UA won't do.
+export const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36";
+
+export const FETCH_TIMEOUT_MS = 10_000;
+
+const MAX_BYTES = 2 * 1024 * 1024;
+
+async function readCapped(res: Response): Promise<Buffer | null> {
+  const contentLength = res.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_BYTES) return null;
+  if (!res.body) {
+    const ab = await res.arrayBuffer();
+    return ab.byteLength > MAX_BYTES ? null : Buffer.from(ab);
+  }
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    total += value.byteLength;
+    if (total > MAX_BYTES) {
+      // Abort mid-stream so an oversized body is never fully buffered.
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function downloadSubtitle(
+  candidate: SubtitleCandidate,
+  destPath: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const headers: Record<string, string> = { "user-agent": BROWSER_UA };
+    // yifysubtitles.ch returns 403 for zip downloads without the page referer.
+    if (new URL(candidate.downloadUrl).host === "yifysubtitles.ch") {
+      headers["referer"] = "https://yts-subs.com/";
+    }
+    const res = await fetchImpl(candidate.downloadUrl, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return false;
+
+    const buf = await readCapped(res);
+    if (!buf) return false;
+
+    const isZip = buf.length >= 4 && buf.readUInt32LE(0) === 0x04034b50;
+    const text = isZip
+      ? extractSrtFromZip(buf, MAX_BYTES)
+      : buf.toString("utf8").replace(/^\uFEFF/, "");
+    if (!text || !text.includes("-->")) return false;
+
+    // "wx" so a subtitle the user already has (or edited) is never clobbered.
+    await writeFile(destPath, text, { flag: "wx" });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/subtitles/fetchSubtitle.ts
+++ b/src/subtitles/fetchSubtitle.ts
@@ -42,9 +42,11 @@ export async function downloadSubtitle(
 ): Promise<boolean> {
   try {
     const headers: Record<string, string> = { "user-agent": BROWSER_UA };
-    // yifysubtitles.ch returns 403 for zip downloads without the page referer.
-    if (new URL(candidate.downloadUrl).host === "yifysubtitles.ch") {
-      headers["referer"] = "https://yts-subs.com/";
+    // yifysubtitles.ch hotlink-checks the referer: absent is a 403, a
+    // cross-domain one is a 200 HTML page. Only its own origin gets the zip.
+    const origin = new URL(candidate.downloadUrl).origin;
+    if (origin === "https://yifysubtitles.ch") {
+      headers["referer"] = `${origin}/`;
     }
     const res = await fetchImpl(candidate.downloadUrl, {
       headers,
@@ -59,7 +61,9 @@ export async function downloadSubtitle(
     const text = isZip
       ? extractSrtFromZip(buf, MAX_BYTES)
       : buf.toString("utf8").replace(/^\uFEFF/, "");
-    if (!text || !text.includes("-->")) return false;
+    // A real timing line, not any "-->": blocked-download pages are HTTP 200
+    // HTML whose comments ("<!-- ... -->") satisfy a bare-arrow check.
+    if (!text || !/\d{2}:\d{2}:\d{2}[,.]\d{3}\s*-->/.test(text)) return false;
 
     // "wx" so a subtitle the user already has (or edited) is never clobbered.
     await writeFile(destPath, text, { flag: "wx" });

--- a/src/subtitles/gestdown.test.ts
+++ b/src/subtitles/gestdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { searchTv } from "./gestdown";
 import { parseRelease } from "./parse";
+import { pickBest } from "./score";
 
 function json(body: unknown): Response {
   return new Response(JSON.stringify(body), { status: 200 });
@@ -52,9 +53,16 @@ describe("searchTv", () => {
       .mockResolvedValueOnce(json(SHOWS))
       .mockResolvedValueOnce(json(SUBS));
     const out = await searchTv("severance", 1, 2, "en", f);
+    // One candidate per quality: parseRelease keeps only the first resolution
+    // token, so a combined "720p.1080p" name would hide the 1080p variant.
     expect(out).toEqual([
       {
-        releaseName: "Severance.S01E02.720p.1080p-MiNX",
+        releaseName: "Severance.S01E02.720p-MiNX",
+        lang: "en",
+        downloadUrl: "https://api.gestdown.info/subtitles/download/019474c9-aaaa",
+      },
+      {
+        releaseName: "Severance.S01E02.1080p-MiNX",
         lang: "en",
         downloadUrl: "https://api.gestdown.info/subtitles/download/019474c9-aaaa",
       },
@@ -71,6 +79,17 @@ describe("searchTv", () => {
     expect(String(f.mock.calls[1]![0])).toBe(
       "https://api.gestdown.info/subtitles/get/31437de3-1234/1/2/en",
     );
+  });
+
+  it("a 1080p video with a non-matching group still picks the 1080p variant", async () => {
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(SHOWS))
+      .mockResolvedValueOnce(json(SUBS));
+    const out = await searchTv("severance", 1, 2, "en", f);
+    const video = parseRelease("Severance.S01E02.1080p.WEB.h264-NTb.mkv");
+    // Resolution alone (2 points) clears pickBest's >= 2 floor.
+    expect(pickBest(video, out, "en")?.releaseName).toBe("Severance.S01E02.1080p-MiNX");
   });
 
   it("returns [] when no show name matches the title, without a subtitles request", async () => {

--- a/src/subtitles/gestdown.test.ts
+++ b/src/subtitles/gestdown.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+import { searchTv } from "./gestdown";
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+const SHOWS = {
+  shows: [
+    {
+      id: "31437de3-1234",
+      name: "Severance",
+      nbSeasons: 2,
+      seasons: [1, 2],
+      tvDbId: 371980,
+      tmdbId: 95396,
+      slug: "severance",
+    },
+  ],
+};
+
+const SUBS = {
+  matchingSubtitles: [
+    {
+      subtitleId: "019474c9-aaaa",
+      version: "MiNX",
+      completed: true,
+      hearingImpaired: false,
+      downloadUri: "/subtitles/download/019474c9-aaaa",
+      language: "English",
+      qualities: ["720p", "1080p"],
+      release: null,
+    },
+    {
+      subtitleId: "019474c9-bbbb",
+      version: "WIP",
+      completed: false,
+      hearingImpaired: false,
+      downloadUri: "/subtitles/download/019474c9-bbbb",
+      language: "English",
+      qualities: ["720p"],
+      release: null,
+    },
+  ],
+};
+
+describe("searchTv", () => {
+  it("maps completed subtitles to candidates with a synthesized release name", async () => {
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(SHOWS))
+      .mockResolvedValueOnce(json(SUBS));
+    const out = await searchTv("severance", 1, 2, "en", f);
+    expect(out).toEqual([
+      {
+        releaseName: "Severance.S01E02.720p.1080p.MiNX",
+        lang: "en",
+        downloadUrl: "https://api.gestdown.info/subtitles/download/019474c9-aaaa",
+      },
+    ]);
+    expect(f).toHaveBeenCalledTimes(2);
+    expect(String(f.mock.calls[1]![0])).toBe(
+      "https://api.gestdown.info/subtitles/get/31437de3-1234/1/2/en",
+    );
+  });
+
+  it("returns [] when no show name matches the title, without a subtitles request", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValueOnce(json(SHOWS));
+    expect(await searchTv("the bear", 1, 1, "en", f)).toEqual([]);
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a show whose name starts with the title", async () => {
+    const shows = {
+      shows: [
+        { id: "aaa", name: "Star Trek: Discovery", slug: "star-trek-discovery" },
+        { id: "bbb", name: "Star Trek", slug: "star-trek" },
+      ],
+    };
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(shows))
+      .mockResolvedValueOnce(json({ matchingSubtitles: [] }));
+    expect(await searchTv("star trek discovery", 1, 1, "en", f)).toEqual([]);
+    expect(String(f.mock.calls[1]![0])).toContain("/subtitles/get/aaa/");
+  });
+
+  it("returns [] on a non-OK response", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValue(new Response("nope", { status: 500 }));
+    expect(await searchTv("severance", 1, 2, "en", f)).toEqual([]);
+  });
+
+  it("returns [] on network error instead of throwing", async () => {
+    const f = vi.fn<typeof fetch>().mockRejectedValue(new Error("boom"));
+    expect(await searchTv("severance", 1, 2, "en", f)).toEqual([]);
+  });
+});

--- a/src/subtitles/gestdown.test.ts
+++ b/src/subtitles/gestdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { searchTv } from "./gestdown";
+import { parseRelease } from "./parse";
 
 function json(body: unknown): Response {
   return new Response(JSON.stringify(body), { status: 200 });
@@ -53,11 +54,19 @@ describe("searchTv", () => {
     const out = await searchTv("severance", 1, 2, "en", f);
     expect(out).toEqual([
       {
-        releaseName: "Severance.S01E02.720p.1080p.MiNX",
+        releaseName: "Severance.S01E02.720p.1080p-MiNX",
         lang: "en",
         downloadUrl: "https://api.gestdown.info/subtitles/download/019474c9-aaaa",
       },
     ]);
+    // The hyphen matters: parseRelease only reads a group off a hyphen tail,
+    // and pickBest's top weight rides on .group.
+    expect(parseRelease(out[0]!.releaseName)).toMatchObject({
+      title: "severance",
+      season: 1,
+      episode: 2,
+      group: "minx",
+    });
     expect(f).toHaveBeenCalledTimes(2);
     expect(String(f.mock.calls[1]![0])).toBe(
       "https://api.gestdown.info/subtitles/get/31437de3-1234/1/2/en",

--- a/src/subtitles/gestdown.ts
+++ b/src/subtitles/gestdown.ts
@@ -1,4 +1,6 @@
-import { BROWSER_UA, FETCH_TIMEOUT_MS } from "./fetchSubtitle";
+import { fetchResilient } from "../util/net";
+import { BROWSER_UA, FETCH_TIMEOUT_MS, readCapped } from "./fetchSubtitle";
+import { normalizeTitle } from "./parse";
 import type { SubtitleCandidate } from "./types";
 
 const BASE = "https://api.gestdown.info";
@@ -15,24 +17,22 @@ interface GdSubtitle {
   qualities: string[];
 }
 
-function norm(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
-}
-
 function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
 async function getJson<T>(url: string, fetchImpl: typeof fetch): Promise<T | null> {
-  const res = await fetchImpl(url, {
+  // retries: 1 keeps this background hook polite to the subtitle hosts.
+  const res = await fetchResilient(url, {
     headers: { "user-agent": BROWSER_UA },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    retries: 1,
+    fetchImpl,
   });
   if (!res.ok) return null;
-  return (await res.json()) as T;
+  const buf = await readCapped(res);
+  if (!buf) return null;
+  return JSON.parse(buf.toString("utf8")) as T;
 }
 
 export async function searchTv(
@@ -48,10 +48,10 @@ export async function searchTv(
       fetchImpl,
     );
     const shows = found?.shows ?? [];
-    const want = norm(title);
+    const want = normalizeTitle(title);
     const show =
-      shows.find((s) => norm(s.name) === want) ??
-      shows.find((s) => norm(s.name).startsWith(want));
+      shows.find((s) => normalizeTitle(s.name) === want) ??
+      shows.find((s) => normalizeTitle(s.name).startsWith(want));
     if (!show) return [];
 
     const subs = await getJson<{ matchingSubtitles?: GdSubtitle[] }>(
@@ -66,7 +66,9 @@ export async function searchTv(
     return (subs.matchingSubtitles ?? [])
       .filter((s) => s.completed)
       .map((s) => ({
-        releaseName: `${show.name}.${se}.${s.qualities.join(".")}.${s.version}`,
+        // Hyphen before the version: parseRelease only reads a release group
+        // off a "-GROUP" tail, and pickBest's top weight rides on it.
+        releaseName: `${show.name}.${se}.${s.qualities.join(".")}-${s.version}`,
         lang,
         downloadUrl: BASE + s.downloadUri,
       }));

--- a/src/subtitles/gestdown.ts
+++ b/src/subtitles/gestdown.ts
@@ -1,0 +1,76 @@
+import { BROWSER_UA, FETCH_TIMEOUT_MS } from "./fetchSubtitle";
+import type { SubtitleCandidate } from "./types";
+
+const BASE = "https://api.gestdown.info";
+
+interface GdShow {
+  id: string;
+  name: string;
+}
+
+interface GdSubtitle {
+  version: string;
+  completed: boolean;
+  downloadUri: string;
+  qualities: string[];
+}
+
+function norm(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+async function getJson<T>(url: string, fetchImpl: typeof fetch): Promise<T | null> {
+  const res = await fetchImpl(url, {
+    headers: { "user-agent": BROWSER_UA },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) return null;
+  return (await res.json()) as T;
+}
+
+export async function searchTv(
+  title: string,
+  season: number,
+  episode: number,
+  lang: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SubtitleCandidate[]> {
+  try {
+    const found = await getJson<{ shows?: GdShow[] }>(
+      `${BASE}/shows/search/${encodeURIComponent(title)}`,
+      fetchImpl,
+    );
+    const shows = found?.shows ?? [];
+    const want = norm(title);
+    const show =
+      shows.find((s) => norm(s.name) === want) ??
+      shows.find((s) => norm(s.name).startsWith(want));
+    if (!show) return [];
+
+    const subs = await getJson<{ matchingSubtitles?: GdSubtitle[] }>(
+      `${BASE}/subtitles/get/${show.id}/${season}/${episode}/${lang}`,
+      fetchImpl,
+    );
+    if (!subs) return [];
+
+    // Gestdown has no release name; synthesize one so the scorer can gate on
+    // title+episode and score resolution/group.
+    const se = `S${pad2(season)}E${pad2(episode)}`;
+    return (subs.matchingSubtitles ?? [])
+      .filter((s) => s.completed)
+      .map((s) => ({
+        releaseName: `${show.name}.${se}.${s.qualities.join(".")}.${s.version}`,
+        lang,
+        downloadUrl: BASE + s.downloadUri,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/src/subtitles/gestdown.ts
+++ b/src/subtitles/gestdown.ts
@@ -65,13 +65,21 @@ export async function searchTv(
     const se = `S${pad2(season)}E${pad2(episode)}`;
     return (subs.matchingSubtitles ?? [])
       .filter((s) => s.completed)
-      .map((s) => ({
+      .flatMap((s) => {
         // Hyphen before the version: parseRelease only reads a release group
         // off a "-GROUP" tail, and pickBest's top weight rides on it.
-        releaseName: `${show.name}.${se}.${s.qualities.join(".")}-${s.version}`,
-        lang,
-        downloadUrl: BASE + s.downloadUri,
-      }));
+        // One candidate per quality: parseRelease keeps only the first
+        // resolution token, so a combined "720p.1080p" name hides the rest.
+        const names =
+          s.qualities.length > 0
+            ? s.qualities.map((q) => `${show.name}.${se}.${q}-${s.version}`)
+            : [`${show.name}.${se}-${s.version}`];
+        return names.map((releaseName) => ({
+          releaseName,
+          lang,
+          downloadUrl: BASE + s.downloadUri,
+        }));
+      });
   } catch {
     return [];
   }

--- a/src/subtitles/index.test.ts
+++ b/src/subtitles/index.test.ts
@@ -124,7 +124,7 @@ describe("fetchSubtitlesForDownload", () => {
     await fs.rm(dir, { recursive: true, force: true });
   });
 
-  it("classify-null (games source): zero writes and zero fetch calls", async () => {
+  it("classify-null (games source): null, zero writes and zero fetch calls", async () => {
     const files = [{ path: "Elden.Ring.2022/setup.mkv", length: 900 * MB }];
     const dir = await makeDir(files);
     const fetchImpl = vi.fn() as unknown as typeof fetch;
@@ -138,9 +138,31 @@ describe("fetchSubtitlesForDownload", () => {
       fetchImpl,
     });
 
-    expect(count).toBe(0);
+    expect(count).toBeNull();
     expect(fetchImpl).not.toHaveBeenCalled();
     expect(await exists(path.join(dir, "Elden.Ring.2022", "setup.en.srt"))).toBe(false);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("no qualifying video files: null without any fetch (nothing to subtitle)", async () => {
+    const files = [
+      { path: path.join(TV_NAME, "sample.mkv"), length: 20 * MB },
+      { path: path.join(TV_NAME, "info.nfo"), length: 300 * MB },
+    ];
+    const dir = await makeDir(files);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const count = await fetchSubtitlesForDownload({
+      name: TV_NAME,
+      dir,
+      source: "eztv",
+      files,
+      lang: "en",
+      fetchImpl,
+    });
+
+    expect(count).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
     await fs.rm(dir, { recursive: true, force: true });
   });
 

--- a/src/subtitles/index.test.ts
+++ b/src/subtitles/index.test.ts
@@ -144,6 +144,28 @@ describe("fetchSubtitlesForDownload", () => {
     await fs.rm(dir, { recursive: true, force: true });
   });
 
+  it("release ships its own subs (Subs/English.srt): null, zero fetch calls", async () => {
+    const files = [
+      { path: path.join("Inception (2010)", `${MOVIE_NAME}.mkv`), length: 900 * MB },
+      { path: path.join("Inception (2010)", "Subs", "English.srt"), length: 100 * 1024 },
+    ];
+    const dir = await makeDir(files);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const count = await fetchSubtitlesForDownload({
+      name: MOVIE_NAME,
+      dir,
+      source: "yts",
+      files,
+      lang: "en",
+      fetchImpl,
+    });
+
+    expect(count).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
   it("no qualifying video files: null without any fetch (nothing to subtitle)", async () => {
     const files = [
       { path: path.join(TV_NAME, "sample.mkv"), length: 20 * MB },

--- a/src/subtitles/index.test.ts
+++ b/src/subtitles/index.test.ts
@@ -1,0 +1,178 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, expect, vi } from "vitest";
+import { fetchSubtitlesForDownload } from "./index";
+
+const SRT = "1\n00:00:01,000 --> 00:00:02,000\nhello\n";
+const MB = 1024 * 1024;
+
+function router(routes: Array<[string, () => Response]>): typeof fetch {
+  return vi.fn(async (input: Parameters<typeof fetch>[0]) => {
+    const url = String(input);
+    const hit = routes.find(([frag]) => url.includes(frag));
+    if (!hit) throw new Error(`unrouted fetch: ${url}`);
+    return hit[1]();
+  }) as unknown as typeof fetch;
+}
+
+async function makeDir(files: { path: string; length: number }[]): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-subs-"));
+  for (const f of files) {
+    await fs.mkdir(path.dirname(path.join(dir, f.path)), { recursive: true });
+    await fs.writeFile(path.join(dir, f.path), "x");
+  }
+  return dir;
+}
+
+async function exists(p: string): Promise<boolean> {
+  return fs.access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+const MOVIE_NAME = "Inception.2010.1080p.BluRay.x264-REFiNED";
+
+const MOVIE_SEARCH_HTML =
+  `<li class="media"><a href="/movie-imdb/tt1375666">` +
+  `<h3 class="media-heading">Inception</h3><small>2010</small></a></li>`;
+
+const MOVIE_PAGE_HTML =
+  `<table><tbody><tr><td><span class="sub-lang">English</span></td>` +
+  `<td><a href="/subtitles/inception-2010-english-yify-90112">` +
+  `<span class="text-muted">subtitle</span> ${MOVIE_NAME}</a></td></tr></tbody></table>`;
+
+const TV_NAME = "Severance.S01E01-E02.1080p.WEB.h264";
+
+function tvShows(): Response {
+  return new Response(JSON.stringify({ shows: [{ id: "sev-1", name: "Severance" }] }));
+}
+
+function tvSubs(uri: string): Response {
+  return new Response(
+    JSON.stringify({
+      matchingSubtitles: [
+        { version: "h264", completed: true, downloadUri: uri, qualities: ["1080p", "WEB"] },
+      ],
+    }),
+  );
+}
+
+describe("fetchSubtitlesForDownload", () => {
+  it("movie: writes <video-basename>.<lang>.srt next to the largest video file", async () => {
+    const files = [
+      { path: path.join("Inception (2010)", `${MOVIE_NAME}.mkv`), length: 900 * MB },
+      { path: path.join("Inception (2010)", "Sample", "sample.mkv"), length: 20 * MB },
+      { path: path.join("Inception (2010)", "info.nfo"), length: 900 * MB },
+    ];
+    const dir = await makeDir(files);
+    const fetchImpl = router([
+      ["yts-subs.com/search/", () => new Response(MOVIE_SEARCH_HTML)],
+      ["yts-subs.com/movie-imdb/tt1375666", () => new Response(MOVIE_PAGE_HTML)],
+      ["yifysubtitles.ch/subtitle/", () => new Response(SRT)],
+    ]);
+
+    const count = await fetchSubtitlesForDownload({
+      name: MOVIE_NAME,
+      dir,
+      source: "yts",
+      files,
+      lang: "en",
+      fetchImpl,
+    });
+
+    expect(count).toBe(1);
+    const srt = path.join(dir, "Inception (2010)", `${MOVIE_NAME}.en.srt`);
+    await expect(fs.readFile(srt, "utf8")).resolves.toContain("-->");
+    expect(await exists(path.join(dir, "Inception (2010)", "Sample", "sample.en.srt"))).toBe(
+      false,
+    );
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("tv: writes one srt per episode file in a season pack", async () => {
+    const files = [
+      { path: path.join(TV_NAME, "Severance.S01E01.1080p.WEB.h264.mkv"), length: 300 * MB },
+      { path: path.join(TV_NAME, "Severance.S01E02.1080p.WEB.h264.mkv"), length: 300 * MB },
+    ];
+    const dir = await makeDir(files);
+    const fetchImpl = router([
+      ["/shows/search/", tvShows],
+      ["/subtitles/get/sev-1/1/1/en", () => tvSubs("/subtitles/download/ep1")],
+      ["/subtitles/get/sev-1/1/2/en", () => tvSubs("/subtitles/download/ep2")],
+      ["/subtitles/download/ep1", () => new Response(SRT)],
+      ["/subtitles/download/ep2", () => new Response(SRT)],
+    ]);
+
+    const count = await fetchSubtitlesForDownload({
+      name: TV_NAME,
+      dir,
+      source: "eztv",
+      files,
+      lang: "en",
+      fetchImpl,
+    });
+
+    expect(count).toBe(2);
+    expect(await exists(path.join(dir, TV_NAME, "Severance.S01E01.1080p.WEB.h264.en.srt"))).toBe(
+      true,
+    );
+    expect(await exists(path.join(dir, TV_NAME, "Severance.S01E02.1080p.WEB.h264.en.srt"))).toBe(
+      true,
+    );
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("classify-null (games source): zero writes and zero fetch calls", async () => {
+    const files = [{ path: "Elden.Ring.2022/setup.mkv", length: 900 * MB }];
+    const dir = await makeDir(files);
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+
+    const count = await fetchSubtitlesForDownload({
+      name: "Elden.Ring.2022.Repack",
+      dir,
+      source: "fitgirl",
+      files,
+      lang: "en",
+      fetchImpl,
+    });
+
+    expect(count).toBe(0);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(await exists(path.join(dir, "Elden.Ring.2022", "setup.en.srt"))).toBe(false);
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("tv: one episode's provider failure does not block the other", async () => {
+    const files = [
+      { path: path.join(TV_NAME, "Severance.S01E01.1080p.WEB.h264.mkv"), length: 300 * MB },
+      { path: path.join(TV_NAME, "Severance.S01E02.1080p.WEB.h264.mkv"), length: 300 * MB },
+    ];
+    const dir = await makeDir(files);
+    const fetchImpl = router([
+      ["/shows/search/", tvShows],
+      ["/subtitles/get/sev-1/1/1/en", () => new Response("boom", { status: 500 })],
+      ["/subtitles/get/sev-1/1/2/en", () => tvSubs("/subtitles/download/ep2")],
+      ["/subtitles/download/ep2", () => new Response(SRT)],
+    ]);
+
+    const count = await fetchSubtitlesForDownload({
+      name: TV_NAME,
+      dir,
+      source: "eztv",
+      files,
+      lang: "en",
+      fetchImpl,
+    });
+
+    expect(count).toBe(1);
+    expect(await exists(path.join(dir, TV_NAME, "Severance.S01E01.1080p.WEB.h264.en.srt"))).toBe(
+      false,
+    );
+    expect(await exists(path.join(dir, TV_NAME, "Severance.S01E02.1080p.WEB.h264.en.srt"))).toBe(
+      true,
+    );
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+});

--- a/src/subtitles/index.ts
+++ b/src/subtitles/index.ts
@@ -16,6 +16,8 @@ function srtPath(dir: string, videoPath: string, lang: string): string {
 }
 
 // Best-effort: never throws, returns how many .srt files were written.
+// null = never searched (not subtitle-applicable / nothing to subtitle),
+// 0 = searched and found nothing — callers must not warn on null.
 export async function fetchSubtitlesForDownload(opts: {
   name: string;
   dir: string;
@@ -23,12 +25,12 @@ export async function fetchSubtitlesForDownload(opts: {
   files: { path: string; length: number }[];
   lang: string;
   fetchImpl?: typeof fetch;
-}): Promise<number> {
+}): Promise<number | null> {
   const { name, dir, source, files, lang, fetchImpl = fetch } = opts;
   const kind = classifyForSubtitles(source, name);
-  if (!kind) return 0;
+  if (!kind) return null;
   const videos = files.filter((f) => isVideoFile(f.path) && f.length >= MIN_VIDEO_BYTES);
-  if (videos.length === 0) return 0;
+  if (videos.length === 0) return null;
 
   if (kind === "movie") {
     try {

--- a/src/subtitles/index.ts
+++ b/src/subtitles/index.ts
@@ -1,0 +1,63 @@
+import { basename, dirname, extname, join } from "node:path";
+import type { SourceId } from "../sources/types";
+import { downloadSubtitle } from "./fetchSubtitle";
+import { searchTv } from "./gestdown";
+import { isVideoFile, parseRelease } from "./parse";
+import { pickBest } from "./score";
+import { classifyForSubtitles } from "./trigger";
+import { searchMovie } from "./ytssubs";
+
+// Files below this are samples/extras, never the actual movie or episode.
+const MIN_VIDEO_BYTES = 50 * 1024 * 1024;
+
+function srtPath(dir: string, videoPath: string, lang: string): string {
+  const base = basename(videoPath, extname(videoPath));
+  return join(dir, dirname(videoPath), `${base}.${lang}.srt`);
+}
+
+// Best-effort: never throws, returns how many .srt files were written.
+export async function fetchSubtitlesForDownload(opts: {
+  name: string;
+  dir: string;
+  source?: SourceId;
+  files: { path: string; length: number }[];
+  lang: string;
+  fetchImpl?: typeof fetch;
+}): Promise<number> {
+  const { name, dir, source, files, lang, fetchImpl = fetch } = opts;
+  const kind = classifyForSubtitles(source, name);
+  if (!kind) return 0;
+  const videos = files.filter((f) => isVideoFile(f.path) && f.length >= MIN_VIDEO_BYTES);
+  if (videos.length === 0) return 0;
+
+  if (kind === "movie") {
+    try {
+      const target = videos.reduce((a, b) => (b.length > a.length ? b : a));
+      const parsed = parseRelease(name);
+      const candidates = await searchMovie(parsed.title, parsed.year, lang, fetchImpl);
+      const best = pickBest(parsed, candidates, lang);
+      if (!best) return 0;
+      return (await downloadSubtitle(best, srtPath(dir, target.path, lang), fetchImpl)) ? 1 : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  const torrentTitle = parseRelease(name).title;
+  let count = 0;
+  // Sequential on purpose: one show, polite to the provider, and one file's
+  // failure must never abort the rest.
+  for (const f of videos) {
+    try {
+      const p = parseRelease(basename(f.path));
+      if (p.season === undefined || p.episode === undefined) continue;
+      const title = p.title || torrentTitle;
+      const candidates = await searchTv(title, p.season, p.episode, lang, fetchImpl);
+      const best = pickBest({ ...p, title }, candidates, lang);
+      if (best && (await downloadSubtitle(best, srtPath(dir, f.path, lang), fetchImpl))) {
+        count++;
+      }
+    } catch {}
+  }
+  return count;
+}

--- a/src/subtitles/index.ts
+++ b/src/subtitles/index.ts
@@ -2,7 +2,7 @@ import { basename, dirname, extname, join } from "node:path";
 import type { SourceId } from "../sources/types";
 import { downloadSubtitle } from "./fetchSubtitle";
 import { searchTv } from "./gestdown";
-import { isVideoFile, parseRelease } from "./parse";
+import { isSubtitleFile, isVideoFile, parseRelease } from "./parse";
 import { pickBest } from "./score";
 import { classifyForSubtitles } from "./trigger";
 import { searchMovie } from "./ytssubs";
@@ -27,6 +27,8 @@ export async function fetchSubtitlesForDownload(opts: {
   fetchImpl?: typeof fetch;
 }): Promise<number | null> {
   const { name, dir, source, files, lang, fetchImpl = fetch } = opts;
+  // Release-group subs are synced to the release; fetching beside them is redundant or worse.
+  if (files.some((f) => isSubtitleFile(f.path))) return null;
   const kind = classifyForSubtitles(source, name);
   if (!kind) return null;
   const videos = files.filter((f) => isVideoFile(f.path) && f.length >= MIN_VIDEO_BYTES);

--- a/src/subtitles/parse.test.ts
+++ b/src/subtitles/parse.test.ts
@@ -31,6 +31,9 @@ describe("parseRelease", () => {
     ["The Prestige (2006) 720p BRRip x265", { title: "the prestige", year: 2006, source: "bluray", codec: "x265" }],
     ["Some_Movie_2019_WEB-DL_H.265-GRP.mp4", { title: "some movie", year: 2019, source: "web", codec: "h265", group: "grp" }],
     ["Plain.Title.S01E05.WEBRip", { title: "plain title", season: 1, episode: 5, source: "web" }],
+    // A year-shaped token at position 0 is the title, not the release year.
+    ["1917.2019.1080p.BluRay", { title: "1917", year: 2019, resolution: "1080p", source: "bluray" }],
+    ["2012.2009.720p", { title: "2012", year: 2009, resolution: "720p" }],
   ];
 
   for (const [name, want] of cases) {

--- a/src/subtitles/parse.test.ts
+++ b/src/subtitles/parse.test.ts
@@ -82,3 +82,22 @@ describe("parseRelease season-only forms", () => {
     expect(p.episode).toBeUndefined();
   });
 });
+
+// Modern streaming-service tags all mean a web rip; bare "max" is deliberately
+// NOT a source tag — it collides with titles (Mad Max) and would truncate them.
+describe("parseRelease streaming-service source tags", () => {
+  it.each([
+    ["The.Bear.S02E01.1080p.DSNP.x264", "web"],
+    ["Show.S01E01.720p.HULU.h264", "web"],
+    ["Series.S03E02.2160p.ATVP.x265", "web"],
+    ["Movie.2023.1080p.HMAX.x264", "web"],
+    ["Show.S01E05.1080p.PCOK.h264", "web"],
+  ])("%s → source %s", (name, source) => {
+    expect(parseRelease(name).source).toBe(source);
+  });
+  it("keeps 'max' as title text, not a source marker", () => {
+    const p = parseRelease("Mad.Max.Fury.Road.2015.1080p.BluRay.x264");
+    expect(p.title).toBe("mad max fury road");
+    expect(p.year).toBe(2015);
+  });
+});

--- a/src/subtitles/parse.test.ts
+++ b/src/subtitles/parse.test.ts
@@ -61,3 +61,21 @@ describe("isVideoFile", () => {
     expect(isVideoFile("movie")).toBe(false);
   });
 });
+
+// Season-only pack names: a torrent named for the whole season carries S01 or
+// "Season 1" with no episode; the per-file parse supplies episodes later.
+describe("parseRelease season-only forms", () => {
+  it("parses bare S01 as season without episode", () => {
+    const p = parseRelease("Severance.S01.1080p.WEB.h264");
+    expect(p.title).toBe("severance");
+    expect(p.season).toBe(1);
+    expect(p.episode).toBeUndefined();
+    expect(p.resolution).toBe("1080p");
+  });
+  it("parses 'Season 2' word form", () => {
+    const p = parseRelease("The.Bear.Season.2.Complete.720p.WEB");
+    expect(p.title).toBe("the bear");
+    expect(p.season).toBe(2);
+    expect(p.episode).toBeUndefined();
+  });
+});

--- a/src/subtitles/parse.test.ts
+++ b/src/subtitles/parse.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parseRelease, isVideoFile } from "./parse";
+import type { ParsedRelease } from "./types";
+
+describe("parseRelease", () => {
+  const cases: Array<[string, Partial<ParsedRelease>]> = [
+    [
+      "Inception.2010.1080p.BluRay.x264-YIFY",
+      {
+        title: "inception",
+        year: 2010,
+        resolution: "1080p",
+        source: "bluray",
+        codec: "x264",
+        group: "yify",
+      },
+    ],
+    [
+      "Severance.S02E01.1080p.WEB.H264-NTb.mkv",
+      {
+        title: "severance",
+        season: 2,
+        episode: 1,
+        resolution: "1080p",
+        source: "web",
+        codec: "h264",
+        group: "ntb",
+      },
+    ],
+    ["Show 1x02 720p HDTV", { title: "show", season: 1, episode: 2, resolution: "720p", source: "hdtv" }],
+    ["The Prestige (2006) 720p BRRip x265", { title: "the prestige", year: 2006, source: "bluray", codec: "x265" }],
+    ["Some_Movie_2019_WEB-DL_H.265-GRP.mp4", { title: "some movie", year: 2019, source: "web", codec: "h265", group: "grp" }],
+    ["Plain.Title.S01E05.WEBRip", { title: "plain title", season: 1, episode: 5, source: "web" }],
+  ];
+
+  for (const [name, want] of cases) {
+    it(`parses ${name}`, () => {
+      expect(parseRelease(name)).toMatchObject(want);
+    });
+  }
+
+  it("strips video/subtitle extensions before parsing", () => {
+    expect(parseRelease("Movie.2020.720p.srt").title).toBe("movie");
+    expect(parseRelease("Movie.2020.720p.avi").resolution).toBe("720p");
+  });
+
+  it("has no year/season for a bare title", () => {
+    const p = parseRelease("Just_A_Title");
+    expect(p.title).toBe("just a title");
+    expect(p.year).toBeUndefined();
+    expect(p.season).toBeUndefined();
+  });
+});
+
+describe("isVideoFile", () => {
+  it("accepts video extensions, rejects others", () => {
+    expect(isVideoFile("a/b/movie.MKV")).toBe(true);
+    expect(isVideoFile("movie.mp4")).toBe(true);
+    expect(isVideoFile("movie.srt")).toBe(false);
+    expect(isVideoFile("movie.txt")).toBe(false);
+    expect(isVideoFile("movie")).toBe(false);
+  });
+});

--- a/src/subtitles/parse.ts
+++ b/src/subtitles/parse.ts
@@ -21,6 +21,7 @@ const RESOLUTION = /^(2160|1080|720|480)p$/;
 const CODEC = /^[xh]26[45]$/;
 const SE = /^s(\d{1,2})e(\d{1,3})$/;
 const NXN = /^(\d{1,2})x(\d{2,3})$/;
+const S_ONLY = /^s(\d{1,2})$/;
 const YEAR = /^(19|20)\d{2}$/;
 
 // A trailing -TOKEN is only a release group when it isn't an attribute word.
@@ -63,6 +64,13 @@ export function parseRelease(name: string): ParsedRelease {
     if ((m = t.match(SE)) || (m = t.match(NXN))) {
       parsed.season ??= parseInt(m[1]!, 10);
       parsed.episode ??= parseInt(m[2]!, 10);
+    } else if ((m = t.match(S_ONLY))) {
+      // A season pack ("Show.S01.1080p") names the season with no episode.
+      parsed.season ??= parseInt(m[1]!, 10);
+    } else if (t === "season" && /^\d{1,2}$/.test(tokens[i + 1] ?? "")) {
+      // Mark at "season", not the digit it consumes, so the title stops here.
+      if (markerIdx === -1) markerIdx = i;
+      parsed.season ??= parseInt(tokens[++i]!, 10);
     } else if (YEAR.test(t)) {
       parsed.year ??= parseInt(t, 10);
     } else if (RESOLUTION.test(t)) {

--- a/src/subtitles/parse.ts
+++ b/src/subtitles/parse.ts
@@ -3,12 +3,20 @@ import type { ParsedRelease } from "./types";
 const VIDEO_EXT = /\.(mkv|mp4|avi|m4v|mov|wmv)$/i;
 const STRIP_EXT = /\.(mkv|mp4|avi|m4v|mov|wmv|srt)$/i;
 
+// Scene vocabulary has no platform source, so this stays hand-curated. Bare
+// "max" is deliberately absent: it collides with titles (Mad Max) and a match
+// here truncates the parsed title.
 const SOURCES: Record<string, string> = {
   web: "web",
   webdl: "web",
   webrip: "web",
   amzn: "web",
   nf: "web",
+  dsnp: "web",
+  hulu: "web",
+  atvp: "web",
+  hmax: "web",
+  pcok: "web",
   bluray: "bluray",
   bdrip: "bluray",
   brrip: "bluray",

--- a/src/subtitles/parse.ts
+++ b/src/subtitles/parse.ts
@@ -31,6 +31,14 @@ export function isVideoFile(path: string): boolean {
   return VIDEO_EXT.test(path);
 }
 
+// Loose title comparison shared by the providers: case/punctuation-insensitive.
+export function normalizeTitle(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
 export function parseRelease(name: string): ParsedRelease {
   let s = name.replace(STRIP_EXT, "");
   s = s.replace(/([xh])\.(26[45])/gi, "$1$2");
@@ -71,7 +79,8 @@ export function parseRelease(name: string): ParsedRelease {
       // Mark at "season", not the digit it consumes, so the title stops here.
       if (markerIdx === -1) markerIdx = i;
       parsed.season ??= parseInt(tokens[++i]!, 10);
-    } else if (YEAR.test(t)) {
+    } else if (YEAR.test(t) && i > 0) {
+      // A year at token 0 is a title ("1917", "2012"), not the release year.
       parsed.year ??= parseInt(t, 10);
     } else if (RESOLUTION.test(t)) {
       parsed.resolution ??= t;

--- a/src/subtitles/parse.ts
+++ b/src/subtitles/parse.ts
@@ -1,0 +1,82 @@
+import type { ParsedRelease } from "./types";
+
+const VIDEO_EXT = /\.(mkv|mp4|avi|m4v|mov|wmv)$/i;
+const STRIP_EXT = /\.(mkv|mp4|avi|m4v|mov|wmv|srt)$/i;
+
+const SOURCES: Record<string, string> = {
+  web: "web",
+  webdl: "web",
+  webrip: "web",
+  amzn: "web",
+  nf: "web",
+  bluray: "bluray",
+  bdrip: "bluray",
+  brrip: "bluray",
+  hdtv: "hdtv",
+  dvd: "dvd",
+  dvdrip: "dvd",
+};
+
+const RESOLUTION = /^(2160|1080|720|480)p$/;
+const CODEC = /^[xh]26[45]$/;
+const SE = /^s(\d{1,2})e(\d{1,3})$/;
+const NXN = /^(\d{1,2})x(\d{2,3})$/;
+const YEAR = /^(19|20)\d{2}$/;
+
+// A trailing -TOKEN is only a release group when it isn't an attribute word.
+const NOT_GROUP = /^(dl|rip|web|hdtv|dvd|bluray|[xh]26[45]|\d{3,4}p)$/i;
+
+export function isVideoFile(path: string): boolean {
+  return VIDEO_EXT.test(path);
+}
+
+export function parseRelease(name: string): ParsedRelease {
+  let s = name.replace(STRIP_EXT, "");
+  s = s.replace(/([xh])\.(26[45])/gi, "$1$2");
+
+  let group: string | undefined;
+  const bracket = s.match(/^\[([^\]]+)\]\s*/);
+  if (bracket) {
+    group = bracket[1]!.toLowerCase();
+    s = s.slice(bracket[0].length);
+  }
+  const tail = s.match(/-([A-Za-z0-9]+)\s*$/);
+  if (tail && !NOT_GROUP.test(tail[1]!)) {
+    group ??= tail[1]!.toLowerCase();
+    s = s.slice(0, tail.index);
+  }
+
+  const tokens = s
+    .toLowerCase()
+    .replace(/[()[\]]/g, " ")
+    .split(/[\s._-]+/)
+    .filter(Boolean);
+
+  const parsed: ParsedRelease = { title: "" };
+  if (group) parsed.group = group;
+  let markerIdx = -1;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i]!;
+    let isMarker = true;
+    let m: RegExpMatchArray | null;
+    if ((m = t.match(SE)) || (m = t.match(NXN))) {
+      parsed.season ??= parseInt(m[1]!, 10);
+      parsed.episode ??= parseInt(m[2]!, 10);
+    } else if (YEAR.test(t)) {
+      parsed.year ??= parseInt(t, 10);
+    } else if (RESOLUTION.test(t)) {
+      parsed.resolution ??= t;
+    } else if (SOURCES[t]) {
+      parsed.source ??= SOURCES[t];
+    } else if (CODEC.test(t)) {
+      parsed.codec ??= t;
+    } else {
+      isMarker = false;
+    }
+    if (isMarker && markerIdx === -1) markerIdx = i;
+  }
+
+  parsed.title = (markerIdx === -1 ? tokens : tokens.slice(0, markerIdx)).join(" ");
+  return parsed;
+}

--- a/src/subtitles/parse.ts
+++ b/src/subtitles/parse.ts
@@ -31,6 +31,12 @@ export function isVideoFile(path: string): boolean {
   return VIDEO_EXT.test(path);
 }
 
+const SUBTITLE_EXT = /\.(srt|ass|ssa|sub|vtt|idx)$/i;
+
+export function isSubtitleFile(path: string): boolean {
+  return SUBTITLE_EXT.test(path);
+}
+
 // Loose title comparison shared by the providers: case/punctuation-insensitive.
 export function normalizeTitle(s: string): string {
   return s

--- a/src/subtitles/score.test.ts
+++ b/src/subtitles/score.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { pickBest } from "./score";
+import { parseRelease } from "./parse";
+import type { SubtitleCandidate } from "./types";
+
+function cand(releaseName: string, lang = "en"): SubtitleCandidate {
+  return { releaseName, lang, downloadUrl: `http://x/${releaseName}` };
+}
+
+const tv = parseRelease("Severance.S02E01.1080p.WEB.H264-NTb.mkv");
+const movie = parseRelease("Inception.2010.1080p.BluRay.x264-YIFY");
+
+describe("pickBest gates", () => {
+  it("excludes wrong lang", () => {
+    expect(pickBest(tv, [cand("Severance.S02E01.1080p.WEB.H264-NTb", "fr")], "en")).toBeNull();
+  });
+
+  it("matches lang case-insensitively", () => {
+    const c = cand("Severance.S02E01.1080p.WEB.H264-NTb", "EN");
+    expect(pickBest(tv, [c], "en")).toBe(c);
+  });
+
+  it("excludes title mismatch", () => {
+    expect(pickBest(tv, [cand("Shrinking.S02E01.1080p.WEB.H264-NTb")], "en")).toBeNull();
+  });
+
+  it("excludes wrong episode", () => {
+    expect(pickBest(tv, [cand("Severance.S02E02.1080p.WEB.H264-NTb")], "en")).toBeNull();
+  });
+
+  it("excludes wrong year for movies", () => {
+    expect(pickBest(movie, [cand("Inception.2011.1080p.BluRay.x264-YIFY")], "en")).toBeNull();
+  });
+
+  it("candidate without a year passes the year gate", () => {
+    const c = cand("Inception.1080p.BluRay.x264-YIFY");
+    expect(pickBest(movie, [c], "en")).toBe(c);
+  });
+});
+
+describe("pickBest scoring", () => {
+  it("group match (8) outranks source+resolution+codec (7)", () => {
+    const groupOnly = cand("Inception.2010.480p.HDTV.x265-YIFY");
+    const rest = cand("Inception.2010.1080p.BluRay.x264-OTHER");
+    expect(pickBest(movie, [rest, groupOnly], "en")).toBe(groupOnly);
+  });
+
+  it("source (4) outranks resolution+codec (3)", () => {
+    const sourceOnly = cand("Inception.2010.480p.BluRay.x265-A");
+    const resCodec = cand("Inception.2010.1080p.HDTV.x264-B");
+    expect(pickBest(movie, [resCodec, sourceOnly], "en")).toBe(sourceOnly);
+  });
+
+  it("resolution (2) outranks codec (1)", () => {
+    const resOnly = cand("Inception.2010.1080p.HDTV.x265-A");
+    const codecOnly = cand("Inception.2010.480p.HDTV.x264-B");
+    expect(pickBest(movie, [codecOnly, resOnly], "en")).toBe(resOnly);
+  });
+
+  it("treats x264 and h264 as equivalent codecs", () => {
+    const h264 = cand("Inception.2010.1080p.HDTV.h264-A");
+    const x265 = cand("Inception.2010.1080p.HDTV.x265-B");
+    expect(pickBest(movie, [x265, h264], "en")).toBe(h264);
+  });
+
+  it("accepts a sole TV survivor at score 0", () => {
+    const c = cand("Severance S02E01");
+    expect(pickBest(tv, [c], "en")).toBe(c);
+  });
+
+  it("rejects a movie at score below 2", () => {
+    expect(pickBest(movie, [cand("Inception.2010")], "en")).toBeNull();
+    expect(pickBest(movie, [cand("Inception.2010.x264")], "en")).toBeNull();
+  });
+
+  it("accepts a movie at score >= 2", () => {
+    const c = cand("Inception.2010.1080p");
+    expect(pickBest(movie, [c], "en")).toBe(c);
+  });
+
+  it("breaks ties by input order", () => {
+    const a = cand("Inception.2010.1080p.A");
+    const b = cand("Inception.2010.1080p.B");
+    expect(pickBest(movie, [a, b], "en")).toBe(a);
+  });
+
+  it("returns null for empty candidates", () => {
+    expect(pickBest(movie, [], "en")).toBeNull();
+  });
+});

--- a/src/subtitles/score.test.ts
+++ b/src/subtitles/score.test.ts
@@ -63,9 +63,8 @@ describe("pickBest scoring", () => {
     expect(pickBest(movie, [x265, h264], "en")).toBe(h264);
   });
 
-  it("accepts a sole TV survivor at score 0", () => {
-    const c = cand("Severance S02E01");
-    expect(pickBest(tv, [c], "en")).toBe(c);
+  it("rejects a sole TV survivor at score 0 (floor applies to TV too)", () => {
+    expect(pickBest(tv, [cand("Severance S02E01")], "en")).toBeNull();
   });
 
   it("rejects a movie at score below 2", () => {

--- a/src/subtitles/score.ts
+++ b/src/subtitles/score.ts
@@ -37,7 +37,7 @@ export function pickBest(
   let best = survivors[0]!;
   for (const s of survivors) if (s.score > best.score) best = s;
 
-  const isTv = video.season !== undefined && video.episode !== undefined;
-  if (best.score >= 2 || (isTv && survivors.length === 1)) return best.cand;
-  return null;
+  // Contract floor: no candidate at >= 2 means nothing is downloaded, TV and
+  // movies alike (gestdown names carry group/resolution, so real matches clear it).
+  return best.score >= 2 ? best.cand : null;
 }

--- a/src/subtitles/score.ts
+++ b/src/subtitles/score.ts
@@ -1,0 +1,43 @@
+import { parseRelease } from "./parse";
+import type { ParsedRelease, SubtitleCandidate } from "./types";
+
+function normCodec(codec: string | undefined): string | undefined {
+  return codec?.replace(/^x/, "h");
+}
+
+function score(video: ParsedRelease, cand: ParsedRelease): number {
+  let n = 0;
+  if (video.group && video.group === cand.group) n += 8;
+  if (video.source && video.source === cand.source) n += 4;
+  if (video.resolution && video.resolution === cand.resolution) n += 2;
+  if (video.codec && normCodec(video.codec) === normCodec(cand.codec)) n += 1;
+  return n;
+}
+
+export function pickBest(
+  video: ParsedRelease,
+  candidates: SubtitleCandidate[],
+  lang: string,
+): SubtitleCandidate | null {
+  const wanted = lang.toLowerCase();
+  const survivors: Array<{ cand: SubtitleCandidate; score: number }> = [];
+
+  for (const cand of candidates) {
+    if (cand.lang.toLowerCase() !== wanted) continue;
+    const p = parseRelease(cand.releaseName);
+    if (p.title !== video.title) continue;
+    if (video.season !== undefined && video.episode !== undefined) {
+      if (p.season !== video.season || p.episode !== video.episode) continue;
+    }
+    if (video.year !== undefined && p.year !== undefined && p.year !== video.year) continue;
+    survivors.push({ cand, score: score(video, p) });
+  }
+
+  if (survivors.length === 0) return null;
+  let best = survivors[0]!;
+  for (const s of survivors) if (s.score > best.score) best = s;
+
+  const isTv = video.season !== undefined && video.episode !== undefined;
+  if (best.score >= 2 || (isTv && survivors.length === 1)) return best.cand;
+  return null;
+}

--- a/src/subtitles/trigger.test.ts
+++ b/src/subtitles/trigger.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { classifyForSubtitles } from "./trigger";
+
+describe("classifyForSubtitles", () => {
+  it("movie source with a year", () => {
+    expect(classifyForSubtitles("yts", "Inception.2010.1080p.BluRay.x264-REFiNED")).toBe("movie");
+  });
+
+  it("movie source without a year still classifies as movie (title-only search)", () => {
+    expect(classifyForSubtitles("yts", "Inception.1080p.BluRay.x264")).toBe("movie");
+  });
+
+  it("tv source with SxxEyy", () => {
+    expect(classifyForSubtitles("eztv", "Severance.S02E03.1080p.WEB.h264")).toBe("tv");
+  });
+
+  it("tv source without an episode marker", () => {
+    expect(classifyForSubtitles("eztv", "Severance.1080p.WEB.h264")).toBe(null);
+  });
+
+  it("games source is never classified, even with a year", () => {
+    expect(classifyForSubtitles("fitgirl", "Elden.Ring.2022.Repack")).toBe(null);
+  });
+
+  it("anime sources are never classified", () => {
+    expect(classifyForSubtitles("nyaa", "[SubsPlease] Frieren - S01E05 (1080p)")).toBe(null);
+    expect(classifyForSubtitles("subsplease", "[SubsPlease] Frieren S01E05 (1080p)")).toBe(null);
+  });
+
+  it("undefined source with SxxEyy", () => {
+    expect(classifyForSubtitles(undefined, "Severance.S01E02.720p.HDTV.x264")).toBe("tv");
+  });
+
+  it("undefined source with a year", () => {
+    expect(classifyForSubtitles(undefined, "Oldboy.2003.1080p.BluRay")).toBe("movie");
+  });
+
+  it("undefined source with neither episode nor year", () => {
+    expect(classifyForSubtitles(undefined, "Some Random Bundle")).toBe(null);
+  });
+});
+
+// A season pack from a TV source (or pasted) has no SxxEyy in the torrent
+// name; season alone must classify tv so per-episode fetching can run.
+describe("classifyForSubtitles season packs", () => {
+  it("eztv season-only pack is tv", () => {
+    expect(classifyForSubtitles("eztv", "Severance.S01.1080p.WEB.h264")).toBe("tv");
+  });
+  it("pasted Season-word pack is tv", () => {
+    expect(classifyForSubtitles(undefined, "The.Bear.Season.2.Complete.720p.WEB")).toBe("tv");
+  });
+});

--- a/src/subtitles/trigger.ts
+++ b/src/subtitles/trigger.ts
@@ -1,0 +1,20 @@
+import { getSource } from "../sources/registry";
+import type { SourceId } from "../sources/types";
+import { parseRelease } from "./parse";
+
+// Decides whether a finished download is worth a subtitle search. Games and
+// Anime sources are always out (no provider covers them); otherwise the
+// release name decides, with a Movies-source fallback for year-less names
+// (title-only movie search still works). Season alone is enough for tv: a
+// season pack's torrent name has no episode, the per-file parse supplies it.
+export function classifyForSubtitles(
+  source: SourceId | undefined,
+  name: string,
+): "tv" | "movie" | null {
+  const groups = source ? (getSource(source).groups ?? []) : [];
+  if (groups.includes("Games") || groups.includes("Anime")) return null;
+  const p = parseRelease(name);
+  if (p.season !== undefined) return "tv";
+  if (p.year !== undefined) return "movie";
+  return groups.includes("Movies") ? "movie" : null;
+}

--- a/src/subtitles/types.ts
+++ b/src/subtitles/types.ts
@@ -1,0 +1,16 @@
+export interface ParsedRelease {
+  title: string;
+  year?: number;
+  season?: number;
+  episode?: number;
+  resolution?: string;
+  source?: string;
+  codec?: string;
+  group?: string;
+}
+
+export interface SubtitleCandidate {
+  releaseName: string;
+  lang: string;
+  downloadUrl: string;
+}

--- a/src/subtitles/ytssubs.test.ts
+++ b/src/subtitles/ytssubs.test.ts
@@ -8,8 +8,8 @@ function html(body: string): Response {
 // Real pages are one long line; fixtures model the row shapes without newlines.
 const SEARCH_HTML =
   `<html><body><ul class="media-list"><li class="media">` +
-  `<a href="/movie-imdb/tt1375666"><div class="media-body"><h3 class="media-heading">Inception</h3><small>year 2010</small></div></a></li>` +
-  `<li class="media"><a href="/movie-imdb/tt9999999"><div class="media-body"><h3 class="media-heading">Inception Deux</h3><small>year 2024</small></div></a></li>` +
+  `<a href="/movie-imdb/tt1375666"><div class="media-body"><h3 class="media-heading" itemprop="name">Inception</h3><small>year 2010</small></div></a></li>` +
+  `<li class="media"><a href="/movie-imdb/tt9999999"><div class="media-body"><h3 class="media-heading" itemprop="name">Inception Deux</h3><small>year 2024</small></div></a></li>` +
   `</ul></body></html>`;
 
 const MOVIE_HTML =

--- a/src/subtitles/ytssubs.test.ts
+++ b/src/subtitles/ytssubs.test.ts
@@ -67,3 +67,38 @@ describe("searchMovie", () => {
     expect(await searchMovie("inception", 2010, "en", f)).toEqual([]);
   });
 });
+
+// The language map must cover any ISO code the config accepts, not a
+// hand-picked subset — Swedish is outside the old hardcoded list and its
+// English name doesn't share a prefix with "sv".
+describe("searchMovie language coverage", () => {
+  const SWEDISH_HTML =
+    `<table class="table"><tbody>` +
+    `<tr><td class="flag-cell"><span class="sub-lang">Swedish</span></td>` +
+    `<td><a href="/subtitles/inception-2010-swedish-yify-77777"><span class="text-muted">subtitle</span> Inception.2010.1080p.BluRay.x264</a></td></tr>` +
+    `</tbody></table>`;
+  const FARSI_HTML =
+    `<table class="table"><tbody>` +
+    `<tr><td class="flag-cell"><span class="sub-lang">Farsi/Persian</span></td>` +
+    `<td><a href="/subtitles/inception-2010-farsi-persian-yify-88888"><span class="text-muted">subtitle</span> Inception.2010.720p</a></td></tr>` +
+    `</tbody></table>`;
+  it("matches compound site labels by slash segment (fa -> Farsi/Persian)", async () => {
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(html(SEARCH_HTML))
+      .mockResolvedValueOnce(html(FARSI_HTML));
+    const out = await searchMovie("inception", 2010, "fa", f);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.downloadUrl).toContain("farsi-persian-yify-88888");
+  });
+  it("matches languages beyond the legacy hardcoded set", async () => {
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(html(SEARCH_HTML))
+      .mockResolvedValueOnce(html(SWEDISH_HTML));
+    const out = await searchMovie("inception", 2010, "sv", f);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.lang).toBe("sv");
+    expect(out[0]!.downloadUrl).toContain("inception-2010-swedish-yify-77777");
+  });
+});

--- a/src/subtitles/ytssubs.test.ts
+++ b/src/subtitles/ytssubs.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { searchMovie } from "./ytssubs";
+
+function html(body: string): Response {
+  return new Response(body, { status: 200 });
+}
+
+// Real pages are one long line; fixtures model the row shapes without newlines.
+const SEARCH_HTML =
+  `<html><body><ul class="media-list"><li class="media">` +
+  `<a href="/movie-imdb/tt1375666"><div class="media-body"><h3 class="media-heading">Inception</h3><small>year 2010</small></div></a></li>` +
+  `<li class="media"><a href="/movie-imdb/tt9999999"><div class="media-body"><h3 class="media-heading">Inception Deux</h3><small>year 2024</small></div></a></li>` +
+  `</ul></body></html>`;
+
+const MOVIE_HTML =
+  `<table class="table"><tbody>` +
+  `<tr data-id="90112"><td class="rating-cell">7</td><td class="flag-cell"><span class="sub-lang">English</span></td>` +
+  `<td><a href="/subtitles/inception-2010-english-yify-90112"><span class="text-muted">subtitle</span> Inception.2010.1080p.BluRay.x264-REFiNED</a></td></tr>` +
+  `<tr data-id="55555"><td class="rating-cell">3</td><td class="flag-cell"><span class="sub-lang">Hebrew</span></td>` +
+  `<td><a href="/subtitles/inception-2010-hebrew-yify-55555"><span class="text-muted">subtitle</span> Inception 2010 720p BrRip</a></td></tr>` +
+  `</tbody></table>`;
+
+describe("searchMovie", () => {
+  it("parses search + movie page into candidates with a yifysubtitles zip url", async () => {
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(html(SEARCH_HTML))
+      .mockResolvedValueOnce(html(MOVIE_HTML));
+    const out = await searchMovie("inception", 2010, "en", f);
+    expect(out).toEqual([
+      {
+        releaseName: "Inception.2010.1080p.BluRay.x264-REFiNED",
+        lang: "en",
+        downloadUrl: "https://yifysubtitles.ch/subtitle/inception-2010-english-yify-90112.zip",
+      },
+    ]);
+    expect(String(f.mock.calls[0]![0])).toContain("https://yts-subs.com/search/");
+    expect(String(f.mock.calls[1]![0])).toBe("https://yts-subs.com/movie-imdb/tt1375666");
+  });
+
+  it("filters rows to the requested language", async () => {
+    const f = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(html(SEARCH_HTML))
+      .mockResolvedValueOnce(html(MOVIE_HTML));
+    const out = await searchMovie("inception", 2010, "he", f);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.downloadUrl).toBe(
+      "https://yifysubtitles.ch/subtitle/inception-2010-hebrew-yify-55555.zip",
+    );
+    expect(out[0]!.lang).toBe("he");
+  });
+
+  it("returns [] when no search row matches the title, without a movie-page request", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValueOnce(html(SEARCH_HTML));
+    expect(await searchMovie("oldboy", 2003, "en", f)).toEqual([]);
+    expect(f).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips rows whose year does not match", async () => {
+    const f = vi.fn<typeof fetch>().mockResolvedValueOnce(html(SEARCH_HTML));
+    expect(await searchMovie("inception", 1999, "en", f)).toEqual([]);
+  });
+
+  it("returns [] on network error instead of throwing", async () => {
+    const f = vi.fn<typeof fetch>().mockRejectedValue(new Error("boom"));
+    expect(await searchMovie("inception", 2010, "en", f)).toEqual([]);
+  });
+});

--- a/src/subtitles/ytssubs.ts
+++ b/src/subtitles/ytssubs.ts
@@ -8,21 +8,17 @@ const PAGE_BASE = "https://yts-subs.com";
 // downloadSubtitle).
 const ZIP_BASE = "https://yifysubtitles.ch";
 
-// The site labels rows with full language names; map ISO codes to them.
-const LANG_NAMES: Record<string, string> = {
-  en: "english",
-  he: "hebrew",
-  es: "spanish",
-  fr: "french",
-  de: "german",
-  it: "italian",
-  pt: "portuguese",
-  ar: "arabic",
-  ru: "russian",
-  nl: "dutch",
-  pl: "polish",
-  tr: "turkish",
-};
+// The site labels rows with full English language names ("Swedish", not
+// "sv"); Intl covers every ISO 639 code without a hand-kept map. An unknown
+// code comes back as itself, which degrades to the prefix-match fallback.
+function langName(code: string): string | undefined {
+  try {
+    const name = new Intl.DisplayNames(["en"], { type: "language" }).of(code);
+    return name && name !== code ? name.toLowerCase() : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function stripTags(s: string): string {
   return s
@@ -77,14 +73,19 @@ export async function searchMovie(
     if (!movieHtml) return [];
 
     const code = lang.toLowerCase();
-    const wantName = LANG_NAMES[code];
+    const wantName = langName(code);
     const out: SubtitleCandidate[] = [];
     for (const row of movieHtml.split(/<tr[\s>]/i).slice(1)) {
       const span = row.match(/<span class="sub-lang">([^<]*)<\/span>/i)?.[1]?.trim();
       const anchor = row.match(/<a href="\/subtitles\/([^"]+)"[^>]*>([\s\S]*?)<\/a>/i);
       if (!span || !anchor) continue;
       const spanLower = span.toLowerCase();
-      if (wantName ? spanLower !== wantName : !spanLower.startsWith(code)) continue;
+      // Slash-compound labels ("Farsi/Persian") match on either segment;
+      // space-compounds ("Brazilian Portuguese") stay distinct from the base.
+      const labelMatches = wantName
+        ? spanLower.split("/").some((seg) => seg.trim() === wantName)
+        : spanLower.startsWith(code);
+      if (!labelMatches) continue;
       const slug = anchor[1]!.split("/").pop()!;
       const caption = stripTags(anchor[2]!).replace(/^subtitle\s+/i, "");
       out.push({

--- a/src/subtitles/ytssubs.ts
+++ b/src/subtitles/ytssubs.ts
@@ -1,4 +1,6 @@
-import { BROWSER_UA, FETCH_TIMEOUT_MS } from "./fetchSubtitle";
+import { fetchResilient } from "../util/net";
+import { BROWSER_UA, FETCH_TIMEOUT_MS, readCapped } from "./fetchSubtitle";
+import { normalizeTitle } from "./parse";
 import type { SubtitleCandidate } from "./types";
 
 const PAGE_BASE = "https://yts-subs.com";
@@ -22,13 +24,6 @@ const LANG_NAMES: Record<string, string> = {
   tr: "turkish",
 };
 
-function norm(s: string): string {
-  return s
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
-    .trim();
-}
-
 function stripTags(s: string): string {
   return s
     .replace(/<[^>]*>/g, " ")
@@ -37,22 +32,26 @@ function stripTags(s: string): string {
 }
 
 async function getHtml(url: string, fetchImpl: typeof fetch): Promise<string | null> {
-  const res = await fetchImpl(url, {
+  // retries: 1 keeps this background hook polite to the subtitle hosts.
+  const res = await fetchResilient(url, {
     headers: { "user-agent": BROWSER_UA },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    retries: 1,
+    fetchImpl,
   });
   if (!res.ok) return null;
-  return res.text();
+  const buf = await readCapped(res);
+  return buf ? buf.toString("utf8") : null;
 }
 
 // The pages arrive as one long line, so rows are found by splitting on their
 // anchors rather than line-based matching.
 function findImdbId(html: string, title: string, year: number | undefined): string | null {
-  const want = norm(title);
+  const want = normalizeTitle(title);
   for (const seg of html.split('href="/movie-imdb/').slice(1)) {
     const id = seg.match(/^(tt\d+)"/)?.[1];
     const heading = seg.match(/<h3 class="media-heading"[^>]*>([^<]*)<\/h3>/)?.[1];
-    if (!id || !heading || norm(heading) !== want) continue;
+    if (!id || !heading || normalizeTitle(heading) !== want) continue;
     if (year !== undefined && !seg.includes(String(year))) continue;
     return id;
   }

--- a/src/subtitles/ytssubs.ts
+++ b/src/subtitles/ytssubs.ts
@@ -1,0 +1,101 @@
+import { BROWSER_UA, FETCH_TIMEOUT_MS } from "./fetchSubtitle";
+import type { SubtitleCandidate } from "./types";
+
+const PAGE_BASE = "https://yts-subs.com";
+// Zip downloads live on the sister domain (and need its referer, see
+// downloadSubtitle).
+const ZIP_BASE = "https://yifysubtitles.ch";
+
+// The site labels rows with full language names; map ISO codes to them.
+const LANG_NAMES: Record<string, string> = {
+  en: "english",
+  he: "hebrew",
+  es: "spanish",
+  fr: "french",
+  de: "german",
+  it: "italian",
+  pt: "portuguese",
+  ar: "arabic",
+  ru: "russian",
+  nl: "dutch",
+  pl: "polish",
+  tr: "turkish",
+};
+
+function norm(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function stripTags(s: string): string {
+  return s
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+async function getHtml(url: string, fetchImpl: typeof fetch): Promise<string | null> {
+  const res = await fetchImpl(url, {
+    headers: { "user-agent": BROWSER_UA },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) return null;
+  return res.text();
+}
+
+// The pages arrive as one long line, so rows are found by splitting on their
+// anchors rather than line-based matching.
+function findImdbId(html: string, title: string, year: number | undefined): string | null {
+  const want = norm(title);
+  for (const seg of html.split('href="/movie-imdb/').slice(1)) {
+    const id = seg.match(/^(tt\d+)"/)?.[1];
+    const heading = seg.match(/<h3 class="media-heading">([^<]*)<\/h3>/)?.[1];
+    if (!id || !heading || norm(heading) !== want) continue;
+    if (year !== undefined && !seg.includes(String(year))) continue;
+    return id;
+  }
+  return null;
+}
+
+export async function searchMovie(
+  title: string,
+  year: number | undefined,
+  lang: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SubtitleCandidate[]> {
+  try {
+    const searchHtml = await getHtml(
+      `${PAGE_BASE}/search/${encodeURIComponent(title)}`,
+      fetchImpl,
+    );
+    if (!searchHtml) return [];
+    const imdbId = findImdbId(searchHtml, title, year);
+    if (!imdbId) return [];
+
+    const movieHtml = await getHtml(`${PAGE_BASE}/movie-imdb/${imdbId}`, fetchImpl);
+    if (!movieHtml) return [];
+
+    const code = lang.toLowerCase();
+    const wantName = LANG_NAMES[code];
+    const out: SubtitleCandidate[] = [];
+    for (const row of movieHtml.split(/<tr[\s>]/i).slice(1)) {
+      const span = row.match(/<span class="sub-lang">([^<]*)<\/span>/i)?.[1]?.trim();
+      const anchor = row.match(/<a href="\/subtitles\/([^"]+)"[^>]*>([\s\S]*?)<\/a>/i);
+      if (!span || !anchor) continue;
+      const spanLower = span.toLowerCase();
+      if (wantName ? spanLower !== wantName : !spanLower.startsWith(code)) continue;
+      const slug = anchor[1]!.split("/").pop()!;
+      const caption = stripTags(anchor[2]!).replace(/^subtitle\s+/i, "");
+      out.push({
+        releaseName: caption || slug.replace(/-/g, "."),
+        lang,
+        downloadUrl: `${ZIP_BASE}/subtitle/${slug}.zip`,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/src/subtitles/ytssubs.ts
+++ b/src/subtitles/ytssubs.ts
@@ -51,7 +51,7 @@ function findImdbId(html: string, title: string, year: number | undefined): stri
   const want = norm(title);
   for (const seg of html.split('href="/movie-imdb/').slice(1)) {
     const id = seg.match(/^(tt\d+)"/)?.[1];
-    const heading = seg.match(/<h3 class="media-heading">([^<]*)<\/h3>/)?.[1];
+    const heading = seg.match(/<h3 class="media-heading"[^>]*>([^<]*)<\/h3>/)?.[1];
     if (!id || !heading || norm(heading) !== want) continue;
     if (year !== undefined && !seg.includes(String(year))) continue;
     return id;

--- a/src/subtitles/zip.test.ts
+++ b/src/subtitles/zip.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { deflateRawSync } from "node:zlib";
+import { extractSrtFromZip } from "./zip";
+
+interface Entry {
+  name: string;
+  data: Buffer;
+  store?: boolean;
+}
+
+// Hand-rolled zip: only the fields the extractor reads are filled (crc stays 0).
+function makeZip(entries: Entry[]): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+  for (const e of entries) {
+    const method = e.store ? 0 : 8;
+    const comp = e.store ? e.data : deflateRawSync(e.data);
+    const name = Buffer.from(e.name);
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(comp.length, 18);
+    local.writeUInt32LE(e.data.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    locals.push(local, name, comp);
+    const cen = Buffer.alloc(46);
+    cen.writeUInt32LE(0x02014b50, 0);
+    cen.writeUInt16LE(method, 10);
+    cen.writeUInt32LE(comp.length, 20);
+    cen.writeUInt32LE(e.data.length, 24);
+    cen.writeUInt16LE(name.length, 28);
+    cen.writeUInt32LE(offset, 42);
+    centrals.push(cen, name);
+    offset += 30 + name.length + comp.length;
+  }
+  const cd = Buffer.concat(centrals);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(cd.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...locals, cd, eocd]);
+}
+
+const SRT = "1\n00:00:01,000 --> 00:00:02,000\nhello\n";
+const MAX = 2 * 1024 * 1024;
+
+describe("extractSrtFromZip", () => {
+  it("extracts a deflated .srt entry", () => {
+    const zip = makeZip([{ name: "movie.srt", data: Buffer.from(SRT) }]);
+    expect(extractSrtFromZip(zip, MAX)).toBe(SRT);
+  });
+
+  it("picks the .srt entry among others and strips a BOM", () => {
+    const zip = makeZip([
+      { name: "readme.txt", data: Buffer.from("not subs") },
+      { name: "Movie.SRT", data: Buffer.from("\uFEFF" + SRT) },
+      { name: "other.srt", data: Buffer.from("second") },
+    ]);
+    expect(extractSrtFromZip(zip, MAX)).toBe(SRT);
+  });
+
+  it("handles method 0 (store)", () => {
+    const zip = makeZip([{ name: "movie.srt", data: Buffer.from(SRT), store: true }]);
+    expect(extractSrtFromZip(zip, MAX)).toBe(SRT);
+  });
+
+  it("returns null when there is no .srt entry", () => {
+    const zip = makeZip([{ name: "readme.txt", data: Buffer.from("hi") }]);
+    expect(extractSrtFromZip(zip, MAX)).toBeNull();
+  });
+
+  it("returns null for malformed buffers instead of throwing", () => {
+    expect(extractSrtFromZip(Buffer.alloc(0), MAX)).toBeNull();
+    expect(extractSrtFromZip(Buffer.from("PK\x03\x04garbage"), MAX)).toBeNull();
+    const truncated = makeZip([{ name: "movie.srt", data: Buffer.from(SRT) }]).subarray(0, 40);
+    expect(extractSrtFromZip(Buffer.from(truncated), MAX)).toBeNull();
+  });
+
+  it("returns null when inflated output would exceed maxBytes (zip bomb)", () => {
+    const zip = makeZip([{ name: "bomb.srt", data: Buffer.alloc(1024 * 1024) }]);
+    expect(extractSrtFromZip(zip, 1024)).toBeNull();
+  });
+});

--- a/src/subtitles/zip.ts
+++ b/src/subtitles/zip.ts
@@ -1,0 +1,59 @@
+import { inflateRawSync } from "node:zlib";
+
+const EOCD_SIG = 0x06054b50;
+const CENTRAL_SIG = 0x02014b50;
+const LOCAL_SIG = 0x04034b50;
+
+// Minimal zip reader: enough to pull the first .srt out of a subtitle archive.
+// Entry names are only ever matched, never used as a filesystem path. Any
+// malformed input (bad signatures, truncated buffers, oversized output) lands
+// in the catch and returns null.
+export function extractSrtFromZip(buf: Buffer, maxBytes: number): string | null {
+  try {
+    let eocd = -1;
+    for (let i = buf.length - 22; i >= 0; i--) {
+      if (buf.readUInt32LE(i) === EOCD_SIG) {
+        eocd = i;
+        break;
+      }
+    }
+    if (eocd < 0) return null;
+
+    const count = buf.readUInt16LE(eocd + 10);
+    let off = buf.readUInt32LE(eocd + 16);
+    for (let i = 0; i < count; i++) {
+      if (buf.readUInt32LE(off) !== CENTRAL_SIG) return null;
+      const method = buf.readUInt16LE(off + 10);
+      const compSize = buf.readUInt32LE(off + 20);
+      const nameLen = buf.readUInt16LE(off + 28);
+      const extraLen = buf.readUInt16LE(off + 30);
+      const commentLen = buf.readUInt16LE(off + 32);
+      const localOff = buf.readUInt32LE(off + 42);
+      const name = buf.toString("utf8", off + 46, off + 46 + nameLen);
+      off += 46 + nameLen + extraLen + commentLen;
+
+      if (!name.toLowerCase().endsWith(".srt")) continue;
+      if (buf.readUInt32LE(localOff) !== LOCAL_SIG) return null;
+      // The local header's own name/extra lengths can differ from the central
+      // directory's, so the data offset comes from here.
+      const dataStart =
+        localOff + 30 + buf.readUInt16LE(localOff + 26) + buf.readUInt16LE(localOff + 28);
+      if (dataStart + compSize > buf.length) return null;
+      const data = buf.subarray(dataStart, dataStart + compSize);
+
+      let out: Buffer;
+      if (method === 8) {
+        out = inflateRawSync(data, { maxOutputLength: maxBytes });
+      } else if (method === 0) {
+        if (compSize > maxBytes) return null;
+        out = data;
+      } else {
+        return null;
+      }
+      return out.toString("utf8").replace(/^\uFEFF/, "");
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -35,6 +35,7 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { SubtitleLangPrompt } from "./components/SubtitleLangPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -86,6 +87,7 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  const [editingSubtitleLang, setEditingSubtitleLang] = useState(false);
   // A result waiting on the "download to" prompt (D); null when the prompt is
   // closed. lastDownloadToDir pre-fills the next prompt so queueing a batch
   // into the same alternate folder only costs one typed path per session.
@@ -108,6 +110,7 @@ export function App({
       const cfg = await loadConfig();
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
+      q.setSubtitleLang(cfg.subtitleLang);
       q.restore(reconcileQueue(await loadQueue()));
       q.restoreHistory(await loadHistory());
       q.restoreSeeds(await loadSeeds());
@@ -142,9 +145,17 @@ export function App({
     if (!queue) return;
     const onCompleted = (name: string): void =>
       setNotice(`${ICON.done} ${truncate(cleanText(name), 40)}`);
+    const onSubtitles = (_name: string, count: number, lang: string): void =>
+      setNotice(
+        count > 0
+          ? `${ICON.done} Subtitles (${lang}): ${count} saved`
+          : `${ICON.warn} No ${lang} subtitles found`,
+      );
     queue.on("completed", onCompleted);
+    queue.on("subtitles", onSubtitles);
     return () => {
       queue.off("completed", onCompleted);
+      queue.off("subtitles", onSubtitles);
     };
   }, [queue]);
 
@@ -167,6 +178,7 @@ export function App({
     (c: Config) => {
       setConfigState(c);
       queue?.setTrackers(c.trackers);
+      queue?.setSubtitleLang(c.subtitleLang);
       void saveConfig(c);
     },
     [queue],
@@ -179,6 +191,24 @@ export function App({
   const closeTrackersPrompt = useCallback(() => {
     setEditingTrackers(false);
   }, []);
+
+  const closeSubtitleLangPrompt = useCallback(() => {
+    setEditingSubtitleLang(false);
+  }, []);
+
+  const setSubtitleLang = useCallback(
+    (lang: string) => {
+      closeSubtitleLangPrompt();
+      if (!config) return;
+      if (lang === config.subtitleLang) {
+        setNotice("Subtitle language unchanged.");
+        return;
+      }
+      setConfig({ ...config, subtitleLang: lang });
+      setNotice(`Subtitle language: ${lang}`);
+    },
+    [config, setConfig, closeSubtitleLangPrompt],
+  );
 
   const setTrackers = useCallback(
     (list: string[]) => {
@@ -392,7 +422,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || editingSubtitleLang || pendingDownload ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -425,6 +455,7 @@ export function App({
     showHelp,
     editingFolder,
     editingTrackers,
+    editingSubtitleLang,
     pendingDownload,
     captureMode,
     downloadFocus,
@@ -450,7 +481,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || editingSubtitleLang || pendingDownload) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -468,6 +499,11 @@ export function App({
       if (input === "t") {
         setShowHelp(false);
         setEditingTrackers(true);
+        return;
+      }
+      if (input === "u") {
+        setShowHelp(false);
+        setEditingSubtitleLang(true);
         return;
       }
       if (input === "m") {
@@ -568,6 +604,17 @@ export function App({
           </Box>
         ) : null}
 
+        {editingSubtitleLang ? (
+          <Box marginTop={1}>
+            <SubtitleLangPrompt
+              width={Math.max(24, Math.min(cols - 4, 62))}
+              value={store.config.subtitleLang}
+              onSubmit={setSubtitleLang}
+              onCancel={closeSubtitleLangPrompt}
+            />
+          </Box>
+        ) : null}
+
         {pendingDownload ? (
           <Box marginTop={1}>
             <FolderPrompt
@@ -589,7 +636,7 @@ export function App({
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || editingSubtitleLang || pendingDownload ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -605,7 +652,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || editingSubtitleLang || pendingDownload ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/Downloads.subs.test.tsx
+++ b/src/ui/components/Downloads.subs.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { render } from "ink-testing-library";
+import { Downloads } from "./Downloads";
+import { StoreContext, type Store } from "../store";
+import { DownloadQueue } from "../../download/queue";
+import type { HistoryItem } from "../../download/history";
+
+function historyItem(subsLang?: string): HistoryItem {
+  return {
+    id: "abc",
+    name: "Inception.2010.1080p.BluRay.x264-YIFY",
+    source: "yts",
+    sizeBytes: 2_000_000_000,
+    magnet: "magnet:?xt=urn:btih:abc",
+    dir: "/tmp/dl",
+    completedAt: 1_700_000_000_000,
+    ...(subsLang ? { subsLang } : {}),
+  };
+}
+
+// Only the fields Downloads reads; the cast mirrors render-previews-impl's
+// partial-store precedent.
+function storeWith(queue: DownloadQueue): Store {
+  return {
+    queue,
+    region: "content",
+    contentWidth: 100,
+    listRows: 12,
+    startDownload: () => {},
+    openDownloadFolder: () => {},
+    setDownloadFocus: () => {},
+    exportTorrent: () => {},
+  } as unknown as Store;
+}
+
+function renderRecent(item: HistoryItem): string {
+  const queue = new DownloadQueue();
+  queue.restoreHistory([item]);
+  const { lastFrame, unmount } = render(
+    <StoreContext.Provider value={storeWith(queue)}>
+      <Downloads />
+    </StoreContext.Provider>,
+  );
+  const frame = lastFrame() ?? "";
+  unmount();
+  return frame;
+}
+
+describe("Downloads recent-row subtitle tag", () => {
+  it("renders subs · <lang> when the entry has one", () => {
+    expect(renderRecent(historyItem("en"))).toContain("subs · en");
+  });
+
+  it("renders no tag when the entry has none", () => {
+    expect(renderRecent(historyItem())).not.toContain("subs ·");
+  });
+});

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -240,6 +240,11 @@ export function Downloads() {
                 {cleanText(h.name)}
               </Text>
             </Box>
+            {h.subsLang ? (
+              <Box flexShrink={0} marginLeft={1}>
+                <Text dimColor>{`subs · ${h.subsLang}`}</Text>
+              </Box>
+            ) : null}
             <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
               <Text dimColor>{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
             </Box>

--- a/src/ui/components/SubtitleLangPrompt.test.tsx
+++ b/src/ui/components/SubtitleLangPrompt.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import { SubtitleLangPrompt } from "./SubtitleLangPrompt";
+
+// Ink batches stdin handling; give it a tick between writes.
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+function mount() {
+  const onSubmit = vi.fn();
+  const onCancel = vi.fn();
+  const instance = render(
+    <SubtitleLangPrompt width={40} value="" onSubmit={onSubmit} onCancel={onCancel} />,
+  );
+  return { instance, onSubmit, onCancel };
+}
+
+describe("SubtitleLangPrompt", () => {
+  it("submits a valid 2-letter code on enter", async () => {
+    const { instance, onSubmit } = mount();
+    instance.stdin.write("he");
+    await tick();
+    instance.stdin.write("\r");
+    await tick();
+    expect(onSubmit).toHaveBeenCalledWith("he");
+  });
+
+  it("does not submit invalid input and shows the error hint", async () => {
+    const { instance, onSubmit, onCancel } = mount();
+    instance.stdin.write("x1!");
+    await tick();
+    instance.stdin.write("\r");
+    await tick();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(instance.lastFrame()).toContain("Use a 2-3 letter code");
+
+    // Still mounted and correctable: a single letter is also rejected.
+    instance.stdin.write("\x15"); // ctrl+u clears the field
+    await tick();
+    instance.stdin.write("q");
+    await tick();
+    instance.stdin.write("\r");
+    await tick();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("calls onCancel on escape", async () => {
+    const { instance, onSubmit, onCancel } = mount();
+    instance.stdin.write("\x1B");
+    // Ink holds a lone ESC ~20ms to see if an escape sequence follows.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(onCancel).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/components/SubtitleLangPrompt.tsx
+++ b/src/ui/components/SubtitleLangPrompt.tsx
@@ -4,6 +4,7 @@ import { TextField } from "./TextField";
 import { Panel } from "./Panel";
 import { PromptHints } from "./PromptHints";
 import { COLOR, ICON } from "../theme";
+import { SUBTITLE_LANG_RE } from "../../config/config";
 
 interface SubtitleLangPromptProps {
   width: number;
@@ -37,7 +38,7 @@ export function SubtitleLangPrompt({ width, value, onSubmit, onCancel }: Subtitl
               onChange={() => setInvalid(false)}
               onSubmit={(raw) => {
                 const lang = raw.trim().toLowerCase();
-                if (/^[a-z]{2,3}$/.test(lang)) onSubmit(lang);
+                if (SUBTITLE_LANG_RE.test(lang)) onSubmit(lang);
                 else setInvalid(true);
               }}
             />

--- a/src/ui/components/SubtitleLangPrompt.tsx
+++ b/src/ui/components/SubtitleLangPrompt.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { COLOR, ICON } from "../theme";
+
+interface SubtitleLangPromptProps {
+  width: number;
+  value: string;
+  onSubmit: (lang: string) => void;
+  onCancel: () => void;
+}
+
+export function SubtitleLangPrompt({ width, value, onSubmit, onCancel }: SubtitleLangPromptProps) {
+  const [invalid, setInvalid] = useState(false);
+
+  useInput((_input, key) => {
+    if (key.escape) onCancel();
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="subtitle language" width={width} focused height={3}>
+        <Box>
+          <Text color={invalid ? COLOR.warn : undefined} dimColor={!invalid} wrap="truncate-end">
+            {invalid ? "Use a 2-3 letter code, e.g. en, he, es" : "ISO code, e.g. en, he, es"}
+          </Text>
+        </Box>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <TextField
+              defaultValue={value}
+              placeholder="en"
+              width={Math.max(1, width - 6)}
+              onChange={() => setInvalid(false)}
+              onSubmit={(raw) => {
+                const lang = raw.trim().toLowerCase();
+                if (/^[a-z]{2,3}$/.test(lang)) onSubmit(lang);
+                else setInvalid(true);
+              }}
+            />
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <PromptHints submitLabel="save" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([122, 101, 65, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 12, 16, 30]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([9, 12, 17, 31]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -20,6 +20,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "esc", label: "Back" },
       { keys: "o", label: "Default download folder" },
       { keys: "t", label: "Extra trackers" },
+      { keys: "u", label: "Subtitle language" },
       { keys: "q", label: "Quit" },
     ],
   },


### PR DESCRIPTION
## What and why

Watching a downloaded movie or show usually means leaving the terminal to hunt a subtitle
site, guessing which file matches the release, and dropping it next to the video by hand.
torlink already owns the whole download flow, so it can finish the job: when a Movies/TV
download completes (pasted magnets included, when their name parses like a movie or an
episode), it now searches for a subtitle in your preferred language and saves it as
`<video>.<lang>.srt` beside the video — the name players auto-load. Season packs get one
subtitle per episode file. Press `u` to set the language (default `en`).

Zero-setup is preserved: both providers are keyless. TV subtitles come from Gestdown
(the Addic7ed proxy, JSON API); movie subtitles from yts-subs/yifysubtitles (scraped, the
same pattern as the existing sources). Candidates are matched by parsing release tokens
from both sides — title and episode/year are hard gates, then release group outranks
source, resolution, and codec, with a minimum floor below which nothing is downloaded: a
group-matched subtitle was timed against the same rip, so wrong-sync subs are the
exception rather than the rule, and no subtitle beats a wrong one.

A release that already ships its own subtitles is left alone — the release group's subs
are synced to the release, so torlink searches only when the torrent carries none.
Downloads that did get a subtitle keep a persistent `subs · en` tag on their Recently
downloaded row, alongside the transient completion notice.

The fetch is best-effort by construction: it runs fire-and-forget after the download
completes, every provider failure collapses to "no subtitles found" in the completion
notice, and nothing can touch the download or seeding lifecycle. Games and Anime sources
never trigger a search (hardsubs/no subs) and get no notice. Safety at the trust
boundary: response bodies are hard-capped at 2 MB, zip archives are read with a minimal
stdlib extractor whose entry names never touch the filesystem, written content must
contain a real `hh:mm:ss,mmm -->` timing line (a blocked-download HTML page does not
pass), and an existing `.srt` is never overwritten.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (293 tests, 42 files)
- [x] New logic has a test (pure functions table-tested; network via injected `fetchImpl`
      mocks; zip against hand-built byte fixtures incl. a bomb; the prompt via
      ink-testing-library)
- [x] Key added: `u` is in `HELP_GROUPS`; it has no `footerHints` entry deliberately,
      matching the `o`/`t` settings keys and the "?-sheet-only" carve-out documented in
      `keymap.ts` — flagging rather than hiding the deviation from the letter of the rule
- [x] No new `Store` field (previews unaffected)
- [x] OS-touching code: paths built exclusively with `node:path`; no platform branches
      needed
- [x] One concern, Conventional Commits throughout

## Notes for reviewers

- **No new dependencies.** Zip extraction uses `node:zlib`'s `inflateRawSync` with
  `maxOutputLength` (~50 lines) instead of adding a zip library.
- **Network etiquette:** all requests go through the house `fetchResilient` with
  `retries: 1`, a 10 s timeout, and capped bodies. A browser UA (and, for
  yifysubtitles.ch, a same-origin referer) is required by the subtitle hosts.
- **Known limitation, accepted:** name-based matching can still fetch a subtitle that
  drifts out of sync when no group/resolution match exists; deleting the `.srt` is the
  recovery, and a manual picker is a natural follow-up.
- **README** doesn't yet mention the feature or the `u` key — happy to add a line to
  "Your downloads" in whatever voice you prefer, or in this PR if you point me at the
  wording.
- Privacy note: searched titles are sent to the subtitle sites, the same exposure class
  as the existing search sources.
