### PR TITLE
feat: self-update command and an update-available banner

### DIFF
--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -36,6 +36,10 @@ describe("parseCliArgs", () => {
   it("parses attach", () => {
     expect(parseCliArgs(["attach"])).toEqual({ kind: "attach" });
   });
+  it("parses update, with and without --force", () => {
+    expect(parseCliArgs(["update"])).toEqual({ kind: "update", force: false });
+    expect(parseCliArgs(["update", "--force"])).toEqual({ kind: "update", force: true });
+  });
   it("parses watch with a directory", () => {
     expect(parseCliArgs(["watch", "/srv/blackhole"])).toEqual({
       kind: "watch",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -25,6 +25,7 @@ export type CliCommand =
     }
   | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
   | { kind: "attach" }
+  | { kind: "update"; force?: boolean }
   | { kind: "invalid"; arg: string };
 
 // Valueless boolean flags for the headless subcommands (everything else is a
@@ -75,6 +76,7 @@ export function parseCliArgs(argv: string[]): CliCommand {
   if (a === "--version" || a === "-v") return { kind: "version" };
   if (a === "--help" || a === "-h") return { kind: "help" };
   if (a === "attach") return { kind: "attach" };
+  if (a === "update") return { kind: "update", force: args.slice(1).includes("--force") };
   if (a === "watch") {
     const { bools, rest: r0 } = splitBooleans(args.slice(1));
     const { flags, rest } = readFlags(r0);
@@ -131,6 +133,8 @@ usage
   torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk files                headless: serve downloads over HTTP on :9160
   torlnk attach               open/reattach the TUI in a persistent tmux session
+  torlnk update [--force]     update to the latest release and restart any daemon
+                              (--force rebuilds/restarts even if already current)
   torlnk --version            print the version
 
 once open: type to search every source at once, enter to run, arrows to move,

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -1,6 +1,10 @@
 // Self-backgrounding for the headless commands: `--daemon` re-spawns this exact
 // command detached from the terminal (own session, stdio to a log file), writes
-// a pidfile, and exits the parent. You can then log out and it keeps running.
+// a pidfile plus a run descriptor, and exits the parent. You can then log out and
+// it keeps running.
+//
+// The run descriptor is what lets `torlnk update` relaunch a daemon on its exact
+// original command after rebuilding.
 //
 // NOTE: on a box with systemd, a `systemctl --user` service with linger is a
 // sturdier way to run these (auto-restart, boot-start). This is the no-systemd
@@ -19,27 +23,52 @@ export function logPathFor(name: string): string {
 export function pidPathFor(name: string): string {
   return path.join(logsDir, `${name}.pid`);
 }
+export function runPathFor(name: string): string {
+  return path.join(logsDir, `${name}.run.json`);
+}
+
+export interface RunDescriptor {
+  name: string;
+  pid: number;
+  argv: string[]; // args to node (script path + subcommand + flags)
+  cwd: string;
+  startedAt: number;
+}
+
+// Spawn `node <argv>` detached with its own session and stdio pointed at the log,
+// then record the pid and enough to relaunch it later. Shared by the initial
+// --daemon fork and by a post-update restart, so both write the pidfile and
+// descriptor the same way.
+export function spawnDaemon(name: string, argv: string[], cwd: string): number {
+  fs.mkdirSync(logsDir, { recursive: true });
+  const out = fs.openSync(logPathFor(name), "a");
+  const child = spawn(process.execPath, argv, {
+    cwd,
+    detached: true,
+    stdio: ["ignore", out, out],
+    env: { ...process.env, [MARKER]: "1" },
+  });
+  child.unref();
+  const pid = child.pid ?? 0;
+  if (pid) {
+    fs.writeFileSync(pidPathFor(name), `${pid}\n`);
+    const desc: RunDescriptor = { name, pid, argv, cwd, startedAt: Date.now() };
+    fs.writeFileSync(runPathFor(name), `${JSON.stringify(desc, null, 2)}\n`);
+  }
+  return pid;
+}
 
 // In the parent: fork a detached child and exit. In the already-detached child
 // (marker set): return so the caller keeps running normally.
 export function daemonize(name: string): void {
   if (process.env[MARKER] === "1") return;
 
-  fs.mkdirSync(logsDir, { recursive: true });
+  const pid = spawnDaemon(name, process.argv.slice(1), process.cwd());
   const logPath = logPathFor(name);
   const pidPath = pidPathFor(name);
-  const out = fs.openSync(logPath, "a");
 
-  const child = spawn(process.execPath, process.argv.slice(1), {
-    detached: true,
-    stdio: ["ignore", out, out],
-    env: { ...process.env, [MARKER]: "1" },
-  });
-  child.unref();
-  if (child.pid) fs.writeFileSync(pidPath, `${child.pid}\n`);
-
-  console.log(`torlink ${name} daemon started (pid ${child.pid}).`);
+  console.log(`torlink ${name} daemon started (pid ${pid}).`);
   console.log(`  logs: ${logPath}`);
-  console.log(`  stop: kill ${child.pid}   (or: kill $(cat ${pidPath}))`);
+  console.log(`  stop: kill ${pid}   (or: kill $(cat ${pidPath}))`);
   process.exit(0);
 }

--- a/src/daemon/restart.test.ts
+++ b/src/daemon/restart.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs";
+import { isAlive, listRunDescriptors, restartDaemon } from "./restart";
+import type { RunDescriptor } from "./daemonize";
+
+describe("isAlive", () => {
+  it("is true for this process and false for a free pid", () => {
+    expect(isAlive(process.pid)).toBe(true);
+    expect(isAlive(2 ** 30)).toBe(false); // no process owns this
+    expect(isAlive(0)).toBe(false);
+    expect(isAlive(-1)).toBe(false);
+  });
+});
+
+describe("listRunDescriptors", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "torlink-restart-"));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const write = (name: string, body: unknown): void =>
+    fs.writeFileSync(path.join(dir, `${name}.run.json`), JSON.stringify(body));
+
+  it("reads valid descriptors and skips everything else", () => {
+    write("watch", { name: "watch", pid: 111, argv: ["a", "watch", "/srv"], cwd: "/srv", startedAt: 1 });
+    write("serve", { name: "serve", pid: 222, argv: ["a", "serve"], cwd: "/opt" });
+    fs.writeFileSync(path.join(dir, "watch.log"), "noise");
+    fs.writeFileSync(path.join(dir, "broken.run.json"), "{ not json");
+
+    const got = listRunDescriptors(dir).sort((a, b) => a.pid - b.pid);
+    expect(got.map((d) => d.name)).toEqual(["watch", "serve"]);
+    expect(got[0]).toMatchObject({ pid: 111, cwd: "/srv" });
+    expect(got[1]!.startedAt).toBe(0); // missing startedAt defaults to 0
+  });
+
+  it("returns [] when the directory is absent", () => {
+    expect(listRunDescriptors(path.join(dir, "nope"))).toEqual([]);
+  });
+});
+
+describe("restartDaemon", () => {
+  it("returns null when the recorded process is already gone", async () => {
+    const dead: RunDescriptor = {
+      name: "watch",
+      pid: 2 ** 30,
+      argv: ["a", "watch", "/srv"],
+      cwd: "/srv",
+      startedAt: 0,
+    };
+    expect(await restartDaemon(dead)).toBeNull();
+  });
+});

--- a/src/daemon/restart.ts
+++ b/src/daemon/restart.ts
@@ -1,0 +1,83 @@
+// Restart the --daemon processes after an update. We only know about daemons that
+// went through daemonize (they leave a run descriptor next to their log); a
+// systemd unit or a foreground run manages its own lifecycle and is left alone.
+
+import fs from "node:fs";
+import path from "node:path";
+import { logsDir } from "../config/paths";
+import { runPathFor, spawnDaemon, type RunDescriptor } from "./daemonize";
+
+// `kill -0` only checks whether we may signal the pid. ESRCH means it's gone;
+// EPERM means it's alive but owned by someone else, so still alive.
+export function isAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function readDescriptor(file: string): RunDescriptor | null {
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<RunDescriptor>;
+    if (
+      typeof raw.name === "string" &&
+      typeof raw.pid === "number" &&
+      Array.isArray(raw.argv) &&
+      typeof raw.cwd === "string"
+    ) {
+      return {
+        name: raw.name,
+        pid: raw.pid,
+        argv: raw.argv.filter((a): a is string => typeof a === "string"),
+        cwd: raw.cwd,
+        startedAt: typeof raw.startedAt === "number" ? raw.startedAt : 0,
+      };
+    }
+  } catch {
+    // A partial/corrupt descriptor just means we can't restart that one.
+  }
+  return null;
+}
+
+export function listRunDescriptors(dir: string = logsDir): RunDescriptor[] {
+  let files: string[];
+  try {
+    files = fs.readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: RunDescriptor[] = [];
+  for (const file of files) {
+    if (!file.endsWith(".run.json")) continue;
+    const desc = readDescriptor(path.join(dir, file));
+    if (desc) out.push(desc);
+  }
+  return out;
+}
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Stop a running daemon and start it again from its recorded command so it comes
+// back on the freshly built code. Returns the new pid, or null if it wasn't
+// running (nothing to restart). Waits for the old process to exit first so the
+// two never fight over the same state files.
+export async function restartDaemon(
+  desc: RunDescriptor,
+  opts: { sleep?: (ms: number) => Promise<void>; waitMs?: number } = {},
+): Promise<number | null> {
+  const sleep = opts.sleep ?? realSleep;
+  const waitMs = opts.waitMs ?? 100;
+  if (!isAlive(desc.pid)) return null;
+
+  try {
+    process.kill(desc.pid, "SIGTERM");
+  } catch {
+    // Already gone between the check and the signal; fine, we'll re-spawn.
+  }
+  for (let i = 0; i < 20 && isAlive(desc.pid); i++) await sleep(waitMs);
+
+  return spawnDaemon(desc.name, desc.argv, desc.cwd);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,9 @@ function failHeadless(err: unknown): never {
   process.exit(1);
 }
 
-if (cmd.kind === "watch") {
+if (cmd.kind === "update") {
+  void import("./update/run").then(({ runUpdate }) => runUpdate({ force: cmd.force }).catch(failHeadless));
+} else if (cmd.kind === "watch") {
   if (cmd.daemon) daemonize("watch"); // parent exits here; the detached child continues
   const { dir, downloadDir, seedTimeMs, deleteFiles } = cmd;
   void import("./daemon/watch").then(({ runWatch }) =>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -23,6 +23,7 @@ import {
   type View,
 } from "./store";
 import { Logo } from "./components/Logo";
+import { UpdateBanner } from "./components/UpdateBanner";
 import { Sidebar, RAIL_WIDTH } from "./components/Sidebar";
 import { Rule } from "./components/Rule";
 import { Footer } from "./components/Footer";
@@ -38,6 +39,8 @@ import { TrackersPrompt } from "./components/TrackersPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
+import { VERSION } from "../version";
+import { fetchLatestVersion, isNewer } from "../update/version";
 import type { SourceId } from "../sources/types";
 
 export function App({
@@ -98,6 +101,7 @@ export function App({
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
+  const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const booting = useRef(false);
 
   useEffect(() => {
@@ -137,6 +141,20 @@ export function App({
       alive = false;
     };
   }, [initialMagnet, initialTorrent]);
+
+  // Best-effort, once per launch, off the hot path: if a newer release exists,
+  // surface a quiet banner. Any failure (offline, opt-out) just leaves it hidden.
+  useEffect(() => {
+    if (process.env.TORLINK_NO_UPDATE_CHECK) return;
+    let alive = true;
+    void (async () => {
+      const latest = await fetchLatestVersion();
+      if (alive && latest && isNewer(VERSION, latest)) setUpdateVersion(latest);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!queue) return;
@@ -515,7 +533,7 @@ export function App({
     return (
       <StoreContext.Provider value={store}>
         <TabTitle />
-        <Splash />
+        <Splash updateVersion={updateVersion} />
       </StoreContext.Provider>
     );
   }
@@ -527,7 +545,8 @@ export function App({
         <Box justifyContent="space-between">
           {/* The wordmark never shrinks: without these constraints a long notice
               squeezes the logo box and wraps its own text through the art. */}
-          <Box flexShrink={0}>
+          <Box flexShrink={0} flexDirection="column">
+            <UpdateBanner latest={updateVersion} />
             <Logo />
           </Box>
           {notice ? (

--- a/src/ui/components/UpdateBanner.tsx
+++ b/src/ui/components/UpdateBanner.tsx
@@ -1,0 +1,8 @@
+import { Text } from "ink";
+
+// A quiet one-liner above the wordmark when a newer release exists. Passive by
+// design: it never steals focus or a key, it just points at `torlnk update`.
+export function UpdateBanner({ latest }: { latest: string | null }) {
+  if (!latest) return null;
+  return <Text dimColor>{`↑ torlink v${latest} available · torlnk update`}</Text>;
+}

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -1,5 +1,6 @@
 import { Box, Text, useInput, useStdin } from "ink";
 import { Logo } from "../components/Logo";
+import { UpdateBanner } from "../components/UpdateBanner";
 import { SearchBar } from "../components/SearchBar";
 import { LOGO_WIDTH } from "../logo";
 import { useStore } from "../store";
@@ -10,7 +11,7 @@ const CATEGORIES = sourcesByGroup()
   .map((g) => g.group.toLowerCase())
   .join(`  ${ICON.dot}  `);
 
-export function Splash() {
+export function Splash({ updateVersion }: { updateVersion?: string | null } = {}) {
   const { submitQuery, quitAll, cols, rows } = useStore();
   const { isRawModeSupported } = useStdin();
 
@@ -31,6 +32,7 @@ export function Splash() {
       justifyContent="center"
       alignItems="center"
     >
+      <UpdateBanner latest={updateVersion ?? null} />
       {showLogo ? (
         <Logo />
       ) : (

--- a/src/update/run.ts
+++ b/src/update/run.ts
@@ -1,0 +1,109 @@
+// `torlnk update`: fetch the latest release, apply it, and bring any --daemon
+// process back on the new code. Two install shapes are handled: a git checkout
+// (pull, install, build) and a global npm install (npm i -g), chosen by whether
+// the package root is a git working tree.
+
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { VERSION } from "../version";
+import { fetchLatestVersion, isNewer } from "./version";
+import { isAlive, listRunDescriptors, restartDaemon } from "../daemon/restart";
+
+// npm is a shell script on Windows (npm.cmd), and spawning a .cmd there needs a
+// shell; git is a real binary everywhere.
+const IS_WIN = process.platform === "win32";
+const NPM = IS_WIN ? "npm.cmd" : "npm";
+
+// Walk up from this module to the torlnk package root. Robust across the bundled
+// dist (dist/index.js -> ..), the tsx dev tree (src/update -> ../..), and a
+// global install, instead of hard-coding a depth that only one of them matches.
+function packageRoot(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 6; i++) {
+    const pkg = path.join(dir, "package.json");
+    try {
+      if ((JSON.parse(fs.readFileSync(pkg, "utf8")) as { name?: string }).name === "torlnk") {
+        return dir;
+      }
+    } catch {
+      // no package.json here, or not ours, so keep walking up
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+}
+
+function run(cmd: string, args: string[], cwd: string): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, { cwd, stdio: "inherit", shell: IS_WIN });
+    child.on("error", () => resolve(-1)); // e.g. command not found
+    child.on("exit", (code) => resolve(code ?? -1));
+  });
+}
+
+async function gitUpdate(root: string, force: boolean): Promise<boolean> {
+  console.log("Pulling latest (git)…");
+  if ((await run("git", ["-C", root, "pull", "--ff-only"], root)) !== 0) {
+    // No upstream, a diverged branch, or a dirty tree. A plain update can't get
+    // latest, so it stops; --force means "rebuild and restart what's here", so
+    // it presses on with the current checkout.
+    if (!force) return false;
+    console.log("Pull skipped; rebuilding the current checkout (--force).");
+  }
+  console.log("Installing dependencies…");
+  if ((await run(NPM, ["install"], root)) !== 0) return false;
+  console.log("Building…");
+  return (await run(NPM, ["run", "build"], root)) === 0;
+}
+
+async function npmGlobalUpdate(): Promise<boolean> {
+  console.log("Installing the latest release (npm -g)…");
+  return (await run(NPM, ["install", "-g", "torlnk@latest"], process.cwd())) === 0;
+}
+
+async function restartDaemons(): Promise<void> {
+  const running = listRunDescriptors().filter((d) => isAlive(d.pid));
+  if (running.length === 0) {
+    console.log("No running daemon to restart.");
+    return;
+  }
+  for (const d of running) {
+    process.stdout.write(`Restarting ${d.name} daemon (pid ${d.pid})… `);
+    const pid = await restartDaemon(d);
+    console.log(pid ? `now pid ${pid}.` : "it had already stopped.");
+  }
+}
+
+export async function runUpdate(opts: { force?: boolean } = {}): Promise<void> {
+  console.log(`torlink v${VERSION}`);
+
+  const latest = await fetchLatestVersion();
+  if (!opts.force && latest && !isNewer(VERSION, latest)) {
+    console.log(`Already on the latest release (v${latest}). Use --force to rebuild and restart anyway.`);
+    return;
+  }
+  console.log(
+    opts.force
+      ? "Forcing a reinstall and restart…"
+      : latest
+        ? `Updating to v${latest}…`
+        : "Couldn't reach the registry; updating from source anyway…",
+  );
+
+  const root = packageRoot();
+  const isGitCheckout = fs.existsSync(path.join(root, ".git"));
+  const ok = isGitCheckout ? await gitUpdate(root, opts.force ?? false) : await npmGlobalUpdate();
+
+  if (!ok) {
+    console.error("Update failed; nothing was restarted.");
+    process.exitCode = 1;
+    return;
+  }
+
+  await restartDaemons();
+  console.log("Update complete.");
+}

--- a/src/update/version.test.ts
+++ b/src/update/version.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { compareVersions, isNewer, fetchLatestVersion } from "./version";
+
+describe("compareVersions", () => {
+  it("orders by major, minor, then patch", () => {
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.2.0", "1.1.9")).toBeGreaterThan(0);
+    expect(compareVersions("1.4.1", "1.4.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.4.1", "1.4.1")).toBe(0);
+  });
+  it("tolerates a leading v and uneven lengths", () => {
+    expect(compareVersions("v1.4", "1.4.0")).toBe(0);
+    expect(compareVersions("1.4.1", "1.4")).toBeGreaterThan(0);
+  });
+  it("ignores pre-release and build suffixes", () => {
+    expect(compareVersions("1.4.1-rc.2", "1.4.1")).toBe(0);
+    expect(compareVersions("1.5.0+build9", "1.4.9")).toBeGreaterThan(0);
+  });
+});
+
+describe("isNewer", () => {
+  it("is true only when the candidate is ahead of current", () => {
+    expect(isNewer("1.4.0", "1.4.1")).toBe(true);
+    expect(isNewer("1.4.1", "1.4.1")).toBe(false);
+    expect(isNewer("1.4.1", "1.4.0")).toBe(false);
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  const okResponse = (version: unknown): Response =>
+    ({ ok: true, json: async () => ({ version }) }) as unknown as Response;
+
+  it("returns the version string from the registry", async () => {
+    const v = await fetchLatestVersion({ fetchImpl: async () => okResponse("1.5.0") });
+    expect(v).toBe("1.5.0");
+  });
+  it("returns null on a non-ok response", async () => {
+    const v = await fetchLatestVersion({
+      fetchImpl: async () => ({ ok: false, status: 404 }) as unknown as Response,
+    });
+    expect(v).toBeNull();
+  });
+  it("returns null when the network throws", async () => {
+    const v = await fetchLatestVersion({
+      fetchImpl: async () => {
+        throw new Error("offline");
+      },
+    });
+    expect(v).toBeNull();
+  });
+  it("returns null when the payload has no version", async () => {
+    const v = await fetchLatestVersion({ fetchImpl: async () => okResponse(undefined) });
+    expect(v).toBeNull();
+  });
+});

--- a/src/update/version.ts
+++ b/src/update/version.ts
@@ -1,0 +1,55 @@
+import { fetchResilient, USER_AGENT, type FetchImpl } from "../util/net";
+
+// Compare two dotted versions numerically. Pre-release / build suffixes (-rc.1,
+// +build) are dropped before comparing; torlink ships plain x.y.z releases, and
+// a half-parsed suffix is worse than ignoring it. Returns <0, 0, >0 like a
+// sort comparator (a older, equal, a newer).
+export function compareVersions(a: string, b: string): number {
+  const parts = (v: string): number[] =>
+    v
+      .trim()
+      .replace(/^v/i, "")
+      .split(/[-+]/, 1)[0]!
+      .split(".")
+      .map((n) => Number.parseInt(n, 10) || 0);
+  const pa = parts(a);
+  const pb = parts(b);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+export function isNewer(current: string, candidate: string): boolean {
+  return compareVersions(candidate, current) > 0;
+}
+
+const REGISTRY_URL = "https://registry.npmjs.org/torlnk/latest";
+
+// Ask the npm registry for the published version. Works no matter how torlink was
+// installed (npm, nix, a git checkout), since they all track the same release.
+// Never throws: the caller is either a background banner or a one-shot command,
+// and neither should care that the network was down.
+export async function fetchLatestVersion(opts: {
+  fetchImpl?: FetchImpl;
+  timeoutMs?: number;
+} = {}): Promise<string | null> {
+  const { fetchImpl, timeoutMs = 4000 } = opts;
+  try {
+    const res = await fetchResilient(REGISTRY_URL, {
+      // One shot: this feeds a background banner and a re-runnable command, so a
+      // flaky moment should fail soft, not sit through a backoff.
+      retries: 0,
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: AbortSignal.timeout(timeoutMs),
+      fetchImpl,
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { version?: unknown };
+    return typeof body.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What this does

`torlnk update` updates torlink in place and restarts any running `--daemon` onto the new code. It picks the method that matches how torlink was installed: a git checkout pulls, installs, and rebuilds; a global install goes through `npm -g`. `torlnk update --force` reruns the rebuild and restart even when already current, which covers redeploying a local change without cutting a release.

A quiet "update available" line also sits above the wordmark in the TUI when a newer release exists. It checks the npm registry in the background on launch, never blocks startup, never takes a key, and `TORLINK_NO_UPDATE_CHECK` turns it off.

## Why

Running torlink on a seedbox means it sits behind whatever release was current the day it was installed. This closes that gap and bounces the daemon, so a headless box does not keep serving the old build until someone remembers to restart it.

## Notes

To restart cleanly, `daemonize` now writes a small run descriptor (argv and cwd) next to the pidfile; the pidfile itself stays pid-only for the documented kill-by-pidfile flow. The restart only touches daemons started with `--daemon`; a systemd unit or a foreground run manages its own lifecycle.

## Testing

`npm run typecheck` and `npm test` are clean, with new tests for the version compare, the registry check, and the restart helpers. Verified `update --force` end to end against a running `serve --daemon`: it rebuilt `dist` and restarted the daemon onto a new pid.
