### PR TITLE
feat: optional Discord control and notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,37 @@ torlink also runs without the TUI, for servers and seedboxes:
     torlnk watch <dir>    download anything dropped into a folder
     torlnk serve          take magnets over HTTP
     torlnk files          stream finished downloads over HTTP
+    torlnk discord        report to a Discord channel and take commands from it
     torlnk attach         keep the TUI alive across ssh sessions
 
-Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
+Add `--daemon` to keep watch, serve, files, or discord running after you log out; `torlnk --help` has the full list of modes and flags.
+
+## Discord
+
+torlink can post to a Discord channel and take commands from it, so a seedbox is a search box and a status page without opening a terminal.
+
+Notifications need only a **webhook**. Make one under the channel's Integrations settings, and torlink posts there when a download finishes or fails.
+
+Commands need a **bot** too. Create an application in the [Discord developer portal](https://discord.com/developers/applications), add a bot, and invite it to the server with the `bot` and `applications.commands` scopes. torlink registers five slash commands:
+
+    /search   pick a category, then type a query
+    /add      download a result, or paste a magnet
+    /status   active downloads and seeds, with progress
+    /cancel   stop a download
+    /help     the command list
+
+Search results come with a dropdown, so downloading a pick is one click, and pages of results have prev/next buttons. Commands run only for the user ids you allowlist; an empty allowlist leaves notifications on and commands off.
+
+Set it up in the TUI (press `g`), in the config file, or with environment variables. The last is handiest on a server, and keeps the secrets out of the config file:
+
+    TORLINK_DISCORD_WEBHOOK        channel webhook URL
+    TORLINK_DISCORD_BOT_TOKEN      bot token, for commands
+    TORLINK_DISCORD_CHANNEL        channel id, for commands
+    TORLINK_DISCORD_ALLOWED_USERS  comma-separated user ids allowed to run commands
+
+Then start it:
+
+    torlnk discord --daemon
 
 ## Contributing
 

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -167,4 +167,24 @@ describe("parseCliArgs", () => {
       daemon: true,
     });
   });
+  it("parses discord with defaults", () => {
+    expect(parseCliArgs(["discord"])).toEqual({
+      kind: "discord",
+      downloadDir: undefined,
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+  });
+  it("parses discord flags", () => {
+    expect(
+      parseCliArgs(["discord", "--to", "/mnt/media", "--seed-time", "1h", "--delete-files", "--daemon"]),
+    ).toEqual({
+      kind: "discord",
+      downloadDir: "/mnt/media",
+      seedTimeMs: 3_600_000,
+      deleteFiles: true,
+      daemon: true,
+    });
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -24,6 +24,13 @@ export type CliCommand =
       daemon?: boolean;
     }
   | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
+  | {
+      kind: "discord";
+      downloadDir?: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+    }
   | { kind: "attach" }
   | { kind: "invalid"; arg: string };
 
@@ -115,6 +122,17 @@ export function parseCliArgs(argv: string[]): CliCommand {
       daemon: bools.has("daemon"),
     };
   }
+  if (a === "discord") {
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags } = readFlags(r0);
+    return {
+      kind: "discord",
+      downloadDir: flags.to ?? flags.dir,
+      seedTimeMs: seedTimeFrom(flags["seed-time"]),
+      deleteFiles: bools.has("delete-files"),
+      daemon: bools.has("daemon"),
+    };
+  }
   if (/^magnet:\?/i.test(a)) return { kind: "run", initialMagnet: a };
   if (isInfoHash(a)) return { kind: "run", initialMagnet: a };
   if (/\.torrent$/i.test(a)) return { kind: "run", initialTorrent: a };
@@ -130,6 +148,7 @@ usage
   torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk files                headless: serve downloads over HTTP on :9160
+  torlnk discord              headless: notify + take commands over Discord
   torlnk attach               open/reattach the TUI in a persistent tmux session
   torlnk --version            print the version
 
@@ -141,12 +160,12 @@ watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
 info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
 where files land. Handled files move to <dir>/.processed (or /.failed).
 
-seed mode (watch/serve): --seed-time <dur> stops seeding a torrent that long
-after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
+seed mode (watch/serve/discord): --seed-time <dur> stops seeding a torrent that
+long after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
 --delete-files to also remove the downloaded data when the timer expires.
 
---daemon (watch/serve/files): background the process (own session, logs to a
-file), so you can log out and it keeps running. Prints the pid and log path.
+--daemon (watch/serve/files/discord): background the process (own session, logs
+to a file), so you can log out and it keeps running. Prints the pid and log path.
 
 torlnk attach: run the TUI inside a persistent tmux session. Detach with
 tmux's ctrl-b d, log out, then torlnk attach again to reattach where you
@@ -167,4 +186,12 @@ folder, so finished files stream to a browser or media player.
 flags: --port <n> (default 9160), --host <addr> (default 127.0.0.1),
 --token <secret> (required to bind a public --host; or TORLINK_FILES_TOKEN),
 --dir <dir> (folder to serve; defaults to your downloads folder).
+
+discord mode (no TUI): posts download done/failed notices to a channel webhook.
+With a bot token, channel id, and an allowlist it also registers slash commands
+(/search, /add, /status, /cancel, /help) and answers them over the gateway.
+Configure it in the TUI (press g), the config file, or via env:
+TORLINK_DISCORD_WEBHOOK, TORLINK_DISCORD_BOT_TOKEN, TORLINK_DISCORD_CHANNEL,
+TORLINK_DISCORD_ALLOWED_USERS (comma-separated ids). Accepts --to and the seed
+flags like watch/serve.
 `;

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { normalizeConfig, defaultConfig } from "./config";
+
+describe("normalizeConfig", () => {
+  it("falls back to defaults for junk", () => {
+    expect(normalizeConfig(null)).toEqual({ ...defaultConfig, trackers: [] });
+    expect(normalizeConfig("nope")).toEqual({ ...defaultConfig, trackers: [] });
+  });
+  it("keeps a valid downloadDir and filters non-string trackers", () => {
+    const cfg = normalizeConfig({ downloadDir: "/srv/dl", trackers: ["udp://a", 5, "", "udp://b"] });
+    expect(cfg.downloadDir).toBe("/srv/dl");
+    expect(cfg.trackers).toEqual(["udp://a", "udp://b"]);
+  });
+  it("parses a discord block and trims strings", () => {
+    const cfg = normalizeConfig({
+      discord: {
+        webhookUrl: " https://discord.com/api/webhooks/1/x ",
+        botToken: "tok",
+        channelId: "123",
+        allowedUserIds: ["1", "", 2, "3"],
+        pollMs: 5000,
+      },
+    });
+    expect(cfg.discord).toEqual({
+      webhookUrl: "https://discord.com/api/webhooks/1/x",
+      botToken: "tok",
+      channelId: "123",
+      allowedUserIds: ["1", "3"],
+      pollMs: 5000,
+    });
+  });
+  it("drops an empty or malformed discord block", () => {
+    expect(normalizeConfig({ discord: {} }).discord).toBeUndefined();
+    expect(normalizeConfig({ discord: "x" }).discord).toBeUndefined();
+    expect(normalizeConfig({ discord: { pollMs: -1, webhookUrl: 7 } }).discord).toBeUndefined();
+  });
+});

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,15 +2,66 @@ import { promises as fs } from "node:fs";
 import { configFile, defaultDownloadDir } from "./paths";
 import { serializeWrites, writeJsonAtomic } from "../util/atomic";
 
+// Optional Discord bridge. A webhook alone covers notifications (outbound);
+// commands additionally need a bot token to read the channel plus an allowlist
+// of who may drive it. Secrets can also come from the environment (see
+// resolveDiscord) so a server never has to keep them in the config file.
+export interface DiscordConfig {
+  webhookUrl?: string;
+  botToken?: string;
+  channelId?: string;
+  allowedUserIds?: string[];
+  pollMs?: number;
+}
+
 export interface Config {
   downloadDir: string;
   trackers: string[];
+  discord?: DiscordConfig;
 }
 
 export const defaultConfig: Config = {
   downloadDir: defaultDownloadDir,
   trackers: [],
 };
+
+function parseDiscord(raw: unknown): DiscordConfig | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const d = raw as Record<string, unknown>;
+  const str = (v: unknown): string | undefined =>
+    typeof v === "string" && v.trim() ? v.trim() : undefined;
+  const discord: DiscordConfig = {
+    webhookUrl: str(d.webhookUrl),
+    botToken: str(d.botToken),
+    channelId: str(d.channelId),
+    allowedUserIds: Array.isArray(d.allowedUserIds)
+      ? d.allowedUserIds.filter((x): x is string => typeof x === "string" && x.trim().length > 0)
+      : undefined,
+    pollMs: typeof d.pollMs === "number" && d.pollMs > 0 ? d.pollMs : undefined,
+  };
+  // Drop the block entirely when nothing survived, so an empty object doesn't
+  // linger in the file.
+  return Object.values(discord).some((v) => v !== undefined) ? discord : undefined;
+}
+
+function hasSecret(cfg: Config): boolean {
+  return !!(cfg.discord?.botToken || cfg.discord?.webhookUrl);
+}
+
+// Coerce whatever was in the file into a valid Config, dropping anything of the
+// wrong shape. Pure, so the parsing rules are testable without touching disk.
+export function normalizeConfig(parsed: unknown): Config {
+  if (!parsed || typeof parsed !== "object") return { ...defaultConfig, trackers: [] };
+  const p = parsed as Partial<Config>;
+  return {
+    downloadDir:
+      typeof p.downloadDir === "string" && p.downloadDir ? p.downloadDir : defaultDownloadDir,
+    trackers: Array.isArray(p.trackers)
+      ? p.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
+      : [],
+    discord: parseDiscord(p.discord),
+  };
+}
 
 export async function loadConfig(): Promise<Config> {
   let raw: string;
@@ -20,17 +71,7 @@ export async function loadConfig(): Promise<Config> {
     return { ...defaultConfig, trackers: [] };
   }
   try {
-    const parsed = JSON.parse(raw) as Partial<Config>;
-    const cfg: Config = {
-      downloadDir:
-        typeof parsed.downloadDir === "string" && parsed.downloadDir
-          ? parsed.downloadDir
-          : defaultDownloadDir,
-      trackers: Array.isArray(parsed.trackers)
-        ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
-        : [],
-    };
-    return cfg;
+    return normalizeConfig(JSON.parse(raw));
   } catch {
     return { ...defaultConfig, trackers: [] };
   }
@@ -39,5 +80,8 @@ export async function loadConfig(): Promise<Config> {
 const write = serializeWrites();
 
 export function saveConfig(config: Config): Promise<void> {
-  return write(() => writeJsonAtomic(configFile, config));
+  // A stored bot token / webhook is a real credential, so keep the file to the
+  // owner when it carries one.
+  const mode = hasSecret(config) ? 0o600 : undefined;
+  return write(() => writeJsonAtomic(configFile, config, { mode }));
 }

--- a/src/daemon/discord.ts
+++ b/src/daemon/discord.ts
@@ -1,0 +1,161 @@
+// Headless Discord doorway: drive the same download runtime as `serve`, but the
+// interface is a Discord channel. Notifications go out through a webhook; when a
+// bot token + channel + allowlist are configured, it also registers slash
+// commands (/search, /add, /status, /cancel, /help) and answers them in real
+// time over the gateway. One mutating daemon at a time, like serve and watch.
+
+import { startRuntime, type Runtime } from "./runtime";
+import { startSeedReaper } from "./seed-reaper";
+import { loadConfig } from "../config/config";
+import { resolveDiscord, canNotify, canTakeCommands, type ResolvedDiscord } from "../discord/config";
+import { attachNotifications } from "../discord/notify";
+import { executeCommand, addByInfoHash, pageSearch, newUserState, type UserState } from "../discord/execute";
+import { postWebhook } from "../discord/webhook";
+import { SELECT_ADD_ID, PAGE_PREV_ID, PAGE_NEXT_ID, errorEmbed } from "../discord/embeds";
+import { startGateway, type GatewayInteraction } from "../discord/gateway";
+import {
+  resolveIds,
+  registerGuildCommands,
+  interactionToCommand,
+  interactionUserId,
+  deferReply,
+  editReply,
+  respondMessage,
+  updateMessage,
+  replyEphemeral,
+  type DiscordIds,
+} from "../discord/slash";
+import { VERSION } from "../version";
+
+export interface DiscordOptions {
+  downloadDir?: string;
+  seedTimeMs?: number;
+  deleteFiles?: boolean;
+}
+
+const COMPONENT_INTERACTION = 3;
+
+function log(message: string): void {
+  console.log(`[torlnk discord] ${new Date().toISOString()} ${message}`);
+}
+
+function makeInteractionHandler(runtime: Runtime, discord: ResolvedDiscord, ids: DiscordIds) {
+  const states = new Map<string, UserState>();
+  const stateFor = (userId: string): UserState => {
+    let s = states.get(userId);
+    if (!s) {
+      s = newUserState();
+      states.set(userId, s);
+    }
+    return s;
+  };
+
+  return (i: GatewayInteraction): void => {
+    void (async () => {
+      const userId = interactionUserId(i);
+      if (!userId || !discord.allowedUserIds.includes(userId)) {
+        await replyEphemeral(i, "You're not on this bot's allowlist.").catch(() => {});
+        log(`rejected an interaction from ${userId ?? "unknown"} (not allowlisted)`);
+        return;
+      }
+      const state = stateFor(userId);
+
+      // Dropdown pick and pager buttons answer directly (both are quick).
+      if (i.type === COMPONENT_INTERACTION) {
+        const customId = i.data?.custom_id;
+        try {
+          if (customId === PAGE_PREV_ID || customId === PAGE_NEXT_ID) {
+            // No live search (e.g. the daemon restarted since this message).
+            // Still acknowledge, or Discord marks the click "interaction failed".
+            const reply = pageSearch(state, customId === PAGE_NEXT_ID ? 1 : -1);
+            if (reply) await updateMessage(i, reply);
+            else await replyEphemeral(i, "That search expired. Run /search again.");
+          } else if (customId === SELECT_ADD_ID) {
+            await respondMessage(i, await addByInfoHash(i.data?.values?.[0] ?? "", runtime, state));
+            log(`select add from ${userId}`);
+          }
+        } catch (e) {
+          log(`component failed: ${e instanceof Error ? e.message : String(e)}`);
+        }
+        return;
+      }
+
+      const cmd = interactionToCommand(i);
+      if (!cmd) return;
+      // A search can outrun the 3s window, so ack first and fill the reply in.
+      // Edit on failure too, so the reply never sticks on "thinking".
+      await deferReply(i).catch(() => {});
+      try {
+        await editReply(ids.applicationId, i, await executeCommand(cmd, runtime, state));
+        log(`/${i.data?.name} from ${userId}`);
+      } catch (e) {
+        log(`/${i.data?.name} failed: ${e instanceof Error ? e.message : String(e)}`);
+        await editReply(ids.applicationId, i, { embeds: [errorEmbed("Something went wrong running that.")] }).catch(
+          () => {},
+        );
+      }
+    })();
+  };
+}
+
+export async function runDiscord(options: DiscordOptions = {}): Promise<void> {
+  const discord = resolveDiscord(await loadConfig());
+
+  if (!canNotify(discord)) {
+    console.error(
+      "error: Discord isn't set up. Add a webhook URL (and, for commands, a bot token, " +
+        "channel id, and allowed user ids) with the TUI's Discord screen, the config file, " +
+        "or the TORLINK_DISCORD_* environment variables.",
+    );
+    process.exit(1);
+    return;
+  }
+
+  const runtime = await startRuntime(options.downloadDir);
+
+  if (options.seedTimeMs && options.seedTimeMs > 0) {
+    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
+  }
+
+  const detachNotify = attachNotifications(runtime.queue, discord.webhookUrl!, log);
+
+  let stopGateway: (() => void) | null = null;
+  if (canTakeCommands(discord)) {
+    try {
+      const ids = await resolveIds(discord.channelId!, discord.botToken!);
+      await registerGuildCommands(ids, discord.botToken!);
+      log(`registered slash commands in guild ${ids.guildId}`);
+      const handle = startGateway({
+        token: discord.botToken!,
+        onInteraction: makeInteractionHandler(runtime, discord, ids),
+        log,
+      });
+      stopGateway = handle.stop;
+      log("commands enabled: slash commands live over the gateway");
+    } catch (e) {
+      // Notifications still work; a command-setup problem shouldn't take the
+      // whole daemon down, just say why and carry on.
+      log(`commands disabled: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  } else {
+    log("notifications only: add a bot token, channel id, and allowlist to enable commands");
+  }
+
+  log(`online as torlink v${VERSION} (downloads -> ${runtime.downloadDir})`);
+  void postWebhook(
+    discord.webhookUrl!,
+    `torlink v${VERSION} online${stopGateway ? ", try `/help`" : ""}`,
+    { log },
+  );
+
+  await new Promise<void>((resolve) => {
+    const shutdown = (): void => {
+      stopGateway?.();
+      detachNotify();
+      runtime.queue.suspend();
+      resolve();
+    };
+    process.on("SIGINT", shutdown);
+    process.on("SIGTERM", shutdown);
+  });
+}

--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -1,0 +1,10 @@
+import type { SourceGroup } from "../sources/types";
+
+// A command the bridge can run, decoded from a slash interaction (see slash.ts).
+// The kinds line up with what the daemon does against the download runtime.
+export type Command =
+  | { kind: "search"; query: string; group?: SourceGroup }
+  | { kind: "add"; arg: string }
+  | { kind: "status" }
+  | { kind: "cancel"; arg: string }
+  | { kind: "help" };

--- a/src/discord/config.test.ts
+++ b/src/discord/config.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { resolveDiscord, canNotify, canTakeCommands } from "./config";
+import type { Config } from "../config/config";
+
+const base: Config = { downloadDir: "/dl", trackers: [] };
+
+describe("resolveDiscord", () => {
+  it("uses the file config when the env is empty", () => {
+    const cfg: Config = {
+      ...base,
+      discord: { webhookUrl: "hook", botToken: "tok", channelId: "c1", allowedUserIds: ["u1"] },
+    };
+    const r = resolveDiscord(cfg, {});
+    expect(r).toMatchObject({ webhookUrl: "hook", botToken: "tok", channelId: "c1", allowedUserIds: ["u1"] });
+    expect(r.pollMs).toBe(3000);
+  });
+  it("lets env override the file", () => {
+    const cfg: Config = { ...base, discord: { webhookUrl: "file-hook", channelId: "old" } };
+    const r = resolveDiscord(cfg, {
+      TORLINK_DISCORD_WEBHOOK: "env-hook",
+      TORLINK_DISCORD_CHANNEL: "new",
+      TORLINK_DISCORD_ALLOWED_USERS: "a, b ,,c",
+    });
+    expect(r.webhookUrl).toBe("env-hook");
+    expect(r.channelId).toBe("new");
+    expect(r.allowedUserIds).toEqual(["a", "b", "c"]);
+  });
+  it("clamps the poll interval to the floor", () => {
+    const cfg: Config = { ...base, discord: { pollMs: 100 } };
+    expect(resolveDiscord(cfg, {}).pollMs).toBe(1500);
+  });
+});
+
+describe("capabilities", () => {
+  it("notifies with just a webhook", () => {
+    expect(canNotify(resolveDiscord({ ...base, discord: { webhookUrl: "h" } }, {}))).toBe(true);
+    expect(canNotify(resolveDiscord(base, {}))).toBe(false);
+  });
+  it("takes commands only with token + channel + webhook + an allowlisted user", () => {
+    const full: Config = {
+      ...base,
+      discord: { webhookUrl: "h", botToken: "t", channelId: "c", allowedUserIds: ["u"] },
+    };
+    expect(canTakeCommands(resolveDiscord(full, {}))).toBe(true);
+    // missing allowlist
+    const noAllow: Config = { ...base, discord: { webhookUrl: "h", botToken: "t", channelId: "c" } };
+    expect(canTakeCommands(resolveDiscord(noAllow, {}))).toBe(false);
+    // missing bot token
+    const noTok: Config = { ...base, discord: { webhookUrl: "h", channelId: "c", allowedUserIds: ["u"] } };
+    expect(canTakeCommands(resolveDiscord(noTok, {}))).toBe(false);
+  });
+});

--- a/src/discord/config.ts
+++ b/src/discord/config.ts
@@ -1,0 +1,45 @@
+import type { Config } from "../config/config";
+
+export interface ResolvedDiscord {
+  webhookUrl?: string;
+  botToken?: string;
+  channelId?: string;
+  allowedUserIds: string[];
+  pollMs: number;
+}
+
+const DEFAULT_POLL_MS = 3000;
+// Discord's own floor for polling a channel's messages is a few seconds; don't
+// let a config value hammer the API below that.
+const MIN_POLL_MS = 1500;
+
+// Merge environment over the saved config, so a server can keep secrets out of
+// the config file entirely. Env wins because it's the more deliberate,
+// deployment-specific source.
+export function resolveDiscord(cfg: Config, env: NodeJS.ProcessEnv = process.env): ResolvedDiscord {
+  const d = cfg.discord;
+  const pick = (envVal: string | undefined, fileVal: string | undefined): string | undefined =>
+    envVal?.trim() || fileVal;
+  const allowFromEnv = env.TORLINK_DISCORD_ALLOWED_USERS?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return {
+    webhookUrl: pick(env.TORLINK_DISCORD_WEBHOOK, d?.webhookUrl),
+    botToken: pick(env.TORLINK_DISCORD_BOT_TOKEN, d?.botToken),
+    channelId: pick(env.TORLINK_DISCORD_CHANNEL, d?.channelId),
+    allowedUserIds: allowFromEnv ?? d?.allowedUserIds ?? [],
+    pollMs: Math.max(MIN_POLL_MS, d?.pollMs ?? DEFAULT_POLL_MS),
+  };
+}
+
+// A webhook is enough to push notifications out.
+export function canNotify(r: ResolvedDiscord): boolean {
+  return !!r.webhookUrl;
+}
+
+// Commands additionally need a bot token + channel to read from, a webhook to
+// answer through, and at least one allowed user. An empty allowlist means
+// nobody is trusted to drive the daemon, so commands stay off.
+export function canTakeCommands(r: ResolvedDiscord): boolean {
+  return !!(r.botToken && r.channelId && r.webhookUrl) && r.allowedUserIds.length > 0;
+}

--- a/src/discord/embeds.test.ts
+++ b/src/discord/embeds.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  helpEmbed,
+  searchEmbed,
+  searchComponents,
+  statusEmbed,
+  addedEmbed,
+  SELECT_ADD_ID,
+  PAGE_NEXT_ID,
+} from "./embeds";
+import type { TorrentResult } from "../sources/types";
+
+const r = (over: Partial<TorrentResult>): TorrentResult => ({
+  infoHash: "hash1",
+  name: "Big Buck Bunny",
+  sizeBytes: 5_000_000,
+  seeders: 42,
+  leechers: 0,
+  source: "yts",
+  magnet: "magnet:?xt=urn:btih:hash1",
+  ...over,
+});
+
+describe("helpEmbed", () => {
+  it("documents slash commands, not the old ! syntax", () => {
+    const e = helpEmbed();
+    expect(e.description).toContain("/search");
+    expect(e.description).not.toContain("!");
+  });
+});
+
+describe("searchEmbed", () => {
+  it("shows the category and a page footer", () => {
+    const e = searchEmbed("matrix", [r({})], 30, 0, "Movies", 0, 3);
+    expect(e.title).toContain("Movies");
+    expect(e.title).toContain("matrix");
+    expect(e.footer?.text).toContain("Page 1/3");
+    expect(e.footer?.text).toContain("30 results");
+  });
+  it("handles an empty result set", () => {
+    expect(searchEmbed("zzz", [], 0, 0, undefined, 0, 1).description).toContain("No results");
+  });
+});
+
+describe("searchComponents", () => {
+  it("builds a dropdown whose values are info hashes", () => {
+    const rows = searchComponents([r({ infoHash: "abc" })], 0, 0, 1) as { components: { type: number; custom_id?: string; options?: { value: string }[] }[] }[];
+    const select = rows[0]!.components[0]!;
+    expect(select.type).toBe(3);
+    expect(select.custom_id).toBe(SELECT_ADD_ID);
+    expect(select.options?.[0]?.value).toBe("abc");
+  });
+  it("omits the pager on a single page and disables ends on multi-page", () => {
+    expect(searchComponents([r({})], 0, 0, 1)).toHaveLength(1); // dropdown only
+    const rows = searchComponents([r({})], 0, 0, 3) as { components: { custom_id?: string; disabled?: boolean }[] }[];
+    expect(rows).toHaveLength(2);
+    const buttons = rows[1]!.components;
+    expect(buttons.find((b) => b.custom_id === "torlnk:prev")?.disabled).toBe(true); // first page
+    expect(buttons.find((b) => b.custom_id === PAGE_NEXT_ID)?.disabled).toBe(false);
+  });
+});
+
+describe("statusEmbed", () => {
+  it("says so when idle", () => {
+    expect(statusEmbed([], []).description).toContain("Nothing downloading");
+  });
+  it("draws a progress bar for an active download", () => {
+    const e = statusEmbed([{ name: "Movie", status: "downloading", progress: 50 }], []);
+    expect(e.description).toContain("▰");
+    expect(e.description).toContain("50%");
+  });
+});
+
+describe("addedEmbed", () => {
+  it("distinguishes added, duplicate, and invalid", () => {
+    expect(addedEmbed("added", "X").title).toContain("Download started");
+    expect(addedEmbed("duplicate", "X").title).toContain("Already in the queue");
+    expect(addedEmbed("invalid", "X").title).toContain("Couldn't add");
+  });
+});

--- a/src/discord/embeds.ts
+++ b/src/discord/embeds.ts
@@ -1,0 +1,187 @@
+// Discord embeds for the slash-command replies and the notifications. Kept as
+// plain builders (no I/O) so they're easy to test and the daemon just hands the
+// result to Discord. Colours track torlink's palette: violet for neutral, the
+// logo's sprout-green for success, a soft red for failure.
+
+import { cleanText, formatBytes, truncate } from "../util/format";
+import { VERSION } from "../version";
+import type { TorrentResult } from "../sources/types";
+
+const VIOLET = 0x7c5cd6;
+const GREEN = 0x5ae87a;
+const RED = 0xe0555a;
+
+export const SELECT_ADD_ID = "torlnk:add";
+export const PAGE_PREV_ID = "torlnk:prev";
+export const PAGE_NEXT_ID = "torlnk:next";
+export const PAGE_SIZE = 10;
+// Browse the healthiest matches without letting one search balloon in memory.
+export const MAX_RESULTS = 50;
+
+export interface Embed {
+  color?: number;
+  title?: string;
+  description?: string;
+  footer?: { text: string };
+  timestamp?: string;
+}
+
+export interface DownloadRow {
+  name: string;
+  status: string;
+  progress: number;
+}
+export interface SeedRow {
+  name: string;
+  status: string;
+}
+
+export function helpEmbed(): Embed {
+  return {
+    color: VIOLET,
+    title: "🧲 torlink",
+    description: [
+      "Terminal-native torrent search, right here in Discord.",
+      "",
+      "**/search** `query` searches every source at once",
+      "**/add** `number or magnet` downloads a result, or a pasted magnet",
+      "**/status** shows active downloads and seeds",
+      "**/cancel** `number` stops a download from /status",
+    ].join("\n"),
+    footer: { text: `torlink v${VERSION}` },
+  };
+}
+
+// n is the 1-based number the user sees (global across pages), so /add <n> and
+// the dropdown always agree.
+function resultLine(r: TorrentResult, n: number): string {
+  const size = r.sizeBytes ? formatBytes(r.sizeBytes) : "size unknown";
+  return `**${n}.** ${truncate(cleanText(r.name), 88)}\n\`${size}\` · 🌱 **${r.seeders}** · ${r.source}`;
+}
+
+export function searchEmbed(
+  query: string,
+  window: TorrentResult[],
+  total: number,
+  startIndex: number,
+  category: string | undefined,
+  page: number,
+  totalPages: number,
+): Embed {
+  const title = `🔎 ${category ? `${category} · ` : ""}${truncate(query, 80)}`;
+  if (window.length === 0) {
+    return {
+      color: VIOLET,
+      title,
+      description: category
+        ? "No results in this category. Try All sources, or different words."
+        : "No results. Try different words.",
+    };
+  }
+  return {
+    color: VIOLET,
+    title,
+    description: window.map((r, i) => resultLine(r, startIndex + i + 1)).join("\n\n"),
+    footer: { text: `Page ${page + 1}/${totalPages} · ${total} results · pick below, or /add <number>` },
+  };
+}
+
+// The page's dropdown (one click to download) plus prev/next buttons when there's
+// more than one page. Values are info hashes, which are short and page-independent.
+export function searchComponents(
+  window: TorrentResult[],
+  startIndex: number,
+  page: number,
+  totalPages: number,
+): unknown[] | undefined {
+  if (window.length === 0) return undefined;
+  const rows: unknown[] = [
+    {
+      type: 1,
+      components: [
+        {
+          type: 3,
+          custom_id: SELECT_ADD_ID,
+          placeholder: "⬇️  Download a result…",
+          options: window.map((r, i) => ({
+            label: truncate(`${startIndex + i + 1}. ${cleanText(r.name)}`, 95),
+            description: truncate(
+              `${r.sizeBytes ? formatBytes(r.sizeBytes) : "?"} · ${r.seeders} seeders · ${r.source}`,
+              95,
+            ),
+            value: r.infoHash,
+          })),
+        },
+      ],
+    },
+  ];
+  if (totalPages > 1) {
+    rows.push({
+      type: 1,
+      components: [
+        { type: 2, style: 2, custom_id: PAGE_PREV_ID, label: "◀ Prev", disabled: page <= 0 },
+        { type: 2, style: 2, custom_id: "torlnk:pageinfo", label: `Page ${page + 1} / ${totalPages}`, disabled: true },
+        { type: 2, style: 2, custom_id: PAGE_NEXT_ID, label: "Next ▶", disabled: page >= totalPages - 1 },
+      ],
+    });
+  }
+  return rows;
+}
+
+function progressBar(pct: number): string {
+  const slots = 12;
+  const filled = Math.round((Math.max(0, Math.min(100, pct)) / 100) * slots);
+  return "▰".repeat(filled) + "▱".repeat(slots - filled);
+}
+
+export function statusEmbed(downloads: DownloadRow[], seeds: SeedRow[]): Embed {
+  if (downloads.length === 0 && seeds.length === 0) {
+    return { color: VIOLET, title: "📊 Status", description: "Nothing downloading or seeding right now." };
+  }
+  const parts: string[] = [];
+  if (downloads.length) {
+    parts.push("**Downloads**");
+    downloads.forEach((d, i) => {
+      const tail = d.status === "downloading" ? `${progressBar(d.progress)}  ${d.progress}%` : `_${d.status}_`;
+      parts.push(`\`${i + 1}\` ${truncate(cleanText(d.name), 66)}\n${tail}`);
+    });
+  }
+  if (seeds.length) {
+    if (parts.length) parts.push("");
+    parts.push("**Seeding**");
+    seeds.forEach((s) => parts.push(`🌱 ${truncate(cleanText(s.name), 66)} · _${s.status}_`));
+  }
+  return { color: VIOLET, title: "📊 Status", description: parts.join("\n") };
+}
+
+export function addedEmbed(outcome: "added" | "duplicate" | "invalid", name: string): Embed {
+  if (outcome === "added") {
+    return { color: GREEN, title: "⬇️  Download started", description: truncate(cleanText(name), 200) };
+  }
+  if (outcome === "duplicate") {
+    return { color: VIOLET, title: "Already in the queue", description: truncate(cleanText(name), 200) };
+  }
+  return { color: RED, title: "Couldn't add that", description: "Not a valid result number, magnet link, or info hash." };
+}
+
+export function cancelledEmbed(name: string): Embed {
+  return { color: VIOLET, title: "✖️  Cancelled", description: truncate(cleanText(name), 200) };
+}
+
+export function errorEmbed(text: string): Embed {
+  return { color: RED, description: text };
+}
+
+export function finishedEmbed(name: string): Embed {
+  return {
+    color: GREEN,
+    title: "✅ Download complete",
+    description: truncate(cleanText(name), 200),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function failedEmbed(name: string, error?: string): Embed {
+  const desc = truncate(cleanText(name), 180) + (error ? `\n\`${truncate(error, 120)}\`` : "");
+  return { color: RED, title: "⚠️ Download failed", description: desc, timestamp: new Date().toISOString() };
+}

--- a/src/discord/execute.test.ts
+++ b/src/discord/execute.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import os from "node:os";
+import { executeCommand, pageSearch, addByInfoHash, newUserState } from "./execute";
+import type { Runtime } from "../daemon/runtime";
+import type { TorrentResult } from "../sources/types";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+const MAGNET = `magnet:?xt=urn:btih:${HASH}&dn=Big+Buck+Bunny`;
+
+function fakeRuntime(): { runtime: Runtime; items: { id: string; name: string; status: string; progress: number }[] } {
+  const items: { id: string; name: string; status: string; progress: number }[] = [];
+  const queue = {
+    has: (id: string) => items.some((i) => i.id === id),
+    add: (input: { id: string; name: string }) =>
+      items.push({ id: input.id, name: input.name, status: "downloading", progress: 0 }),
+    getItems: () => items,
+    getSeeds: () => [] as unknown[],
+    cancel: (id: string) => {
+      const idx = items.findIndex((i) => i.id === id);
+      if (idx >= 0) items.splice(idx, 1);
+    },
+  };
+  return { runtime: { queue, downloadDir: os.tmpdir() } as unknown as Runtime, items };
+}
+
+const result = (over: Partial<TorrentResult>): TorrentResult => ({
+  infoHash: HASH,
+  name: "Big Buck Bunny",
+  sizeBytes: 5_000_000,
+  seeders: 42,
+  leechers: 1,
+  source: "yts",
+  magnet: MAGNET,
+  ...over,
+});
+
+const searchStub = (list: TorrentResult[]) => async () => list;
+
+describe("executeCommand", () => {
+  it("returns the help embed with slash syntax", async () => {
+    const { runtime } = fakeRuntime();
+    const reply = await executeCommand({ kind: "help" }, runtime, newUserState());
+    expect(reply.embeds[0]!.description).toContain("/search");
+    expect(reply.embeds[0]!.description).not.toContain("!search");
+  });
+
+  it("searches, stores results, and offers a dropdown", async () => {
+    const { runtime } = fakeRuntime();
+    const state = newUserState();
+    const reply = await executeCommand({ kind: "search", query: "bunny" }, runtime, state, {
+      search: searchStub([result({})]),
+    });
+    expect(state.search?.results).toHaveLength(1);
+    expect(reply.components).toBeDefined();
+    expect(reply.embeds[0]!.title).toContain("bunny");
+  });
+
+  it("adds the chosen result by number, then reports duplicates", async () => {
+    const { runtime, items } = fakeRuntime();
+    const state = newUserState();
+    await executeCommand({ kind: "search", query: "bunny" }, runtime, state, { search: searchStub([result({})]) });
+
+    const added = await executeCommand({ kind: "add", arg: "1" }, runtime, state);
+    expect(added.embeds[0]!.title).toContain("Download started");
+    expect(items).toHaveLength(1);
+
+    const again = await executeCommand({ kind: "add", arg: "1" }, runtime, state);
+    expect(again.embeds[0]!.title).toContain("Already in the queue");
+  });
+
+  it("rejects an out-of-range add", async () => {
+    const { runtime } = fakeRuntime();
+    const reply = await executeCommand({ kind: "add", arg: "3" }, runtime, newUserState());
+    expect(reply.embeds[0]!.description).toContain("No result #3");
+  });
+
+  it("adds a raw magnet", async () => {
+    const { runtime, items } = fakeRuntime();
+    const reply = await executeCommand({ kind: "add", arg: MAGNET }, runtime, newUserState());
+    expect(reply.embeds[0]!.title).toContain("Download started");
+    expect(items).toHaveLength(1);
+  });
+
+  it("lists status and cancels by number", async () => {
+    const { runtime, items } = fakeRuntime();
+    const state = newUserState();
+    await executeCommand({ kind: "add", arg: MAGNET }, runtime, state);
+
+    const status = await executeCommand({ kind: "status" }, runtime, state);
+    expect(status.embeds[0]!.description).toContain("Big Buck Bunny");
+
+    const cancel = await executeCommand({ kind: "cancel", arg: "1" }, runtime, state);
+    expect(cancel.embeds[0]!.title).toContain("Cancelled");
+    expect(items).toHaveLength(0);
+  });
+});
+
+describe("pagination", () => {
+  // Real magnets so addInput derives the same id the result advertises.
+  const hex = (i: number) => i.toString(16).padStart(40, "0");
+  const many = Array.from({ length: 23 }, (_, i) =>
+    result({ infoHash: hex(i), name: `Result ${i + 1}`, magnet: `magnet:?xt=urn:btih:${hex(i)}&dn=Result${i + 1}` }),
+  );
+
+  it("pages through results with clamped bounds and global numbering", async () => {
+    const { runtime } = fakeRuntime();
+    const state = newUserState();
+    const p1 = await executeCommand({ kind: "search", query: "x" }, runtime, state, { search: searchStub(many) });
+    expect(p1.embeds[0]!.footer?.text).toContain("Page 1/3");
+    expect(p1.embeds[0]!.description).toContain("**1.**");
+    expect(p1.embeds[0]!.description).toContain("**10.**");
+
+    const p2 = pageSearch(state, 1)!;
+    expect(p2.embeds[0]!.description).toContain("**11.**");
+    expect(p2.embeds[0]!.footer?.text).toContain("Page 2/3");
+
+    pageSearch(state, 1); // to page 3
+    const overshoot = pageSearch(state, 1)!; // clamp at last
+    expect(overshoot.embeds[0]!.footer?.text).toContain("Page 3/3");
+  });
+
+  it("adds a result from a later page by its info hash (dropdown pick)", async () => {
+    const { runtime, items } = fakeRuntime();
+    const state = newUserState();
+    await executeCommand({ kind: "search", query: "x" }, runtime, state, { search: searchStub(many) });
+    const reply = await addByInfoHash(hex(15), runtime, state);
+    expect(reply.embeds[0]!.title).toContain("Download started");
+    expect(items[0]!.id).toBe(hex(15));
+  });
+});

--- a/src/discord/execute.ts
+++ b/src/discord/execute.ts
@@ -1,0 +1,128 @@
+// Runs a resolved command against the download runtime and returns a Discord
+// reply (embed, plus the dropdown + pager for /search). The UI-agnostic half of
+// the bridge; the daemon owns how the command arrived and how the reply is sent.
+
+import { searchAll } from "../sources/search";
+import { addInput, type Runtime } from "../daemon/runtime";
+import { parseInput } from "../sources/magnet";
+import type { Command } from "./commands";
+import type { SourceGroup, TorrentResult } from "../sources/types";
+import {
+  Embed,
+  MAX_RESULTS,
+  PAGE_SIZE,
+  addedEmbed,
+  cancelledEmbed,
+  errorEmbed,
+  helpEmbed,
+  searchComponents,
+  searchEmbed,
+  statusEmbed,
+} from "./embeds";
+
+// Per-user so one person's /add 2 and /cancel 1 refer to what they just saw, and
+// the pager remembers which page they're on.
+export interface SearchState {
+  query: string;
+  group?: SourceGroup;
+  results: TorrentResult[];
+  total: number;
+  page: number;
+}
+export interface UserState {
+  search: SearchState | null;
+  lastStatusIds: string[];
+}
+export function newUserState(): UserState {
+  return { search: null, lastStatusIds: [] };
+}
+
+export interface Reply {
+  embeds: Embed[];
+  components?: unknown[];
+}
+
+// Render the current page of a search, reused by the initial /search and by the
+// prev/next buttons. Clamps the page so it can't run off either end.
+export function renderSearch(s: SearchState): Reply {
+  const totalPages = Math.max(1, Math.ceil(s.results.length / PAGE_SIZE));
+  s.page = Math.min(Math.max(0, s.page), totalPages - 1);
+  const start = s.page * PAGE_SIZE;
+  const window = s.results.slice(start, start + PAGE_SIZE);
+  return {
+    embeds: [searchEmbed(s.query, window, s.total, start, s.group, s.page, totalPages)],
+    components: searchComponents(window, start, s.page, totalPages),
+  };
+}
+
+export function pageSearch(state: UserState, direction: -1 | 1): Reply | null {
+  if (!state.search) return null;
+  state.search.page += direction;
+  return renderSearch(state.search);
+}
+
+export async function executeCommand(
+  cmd: Command,
+  runtime: Runtime,
+  state: UserState,
+  deps: { search?: typeof searchAll } = {},
+): Promise<Reply> {
+  const search = deps.search ?? searchAll;
+  switch (cmd.kind) {
+    case "help":
+      return { embeds: [helpEmbed()] };
+
+    case "search": {
+      const all = await search(cmd.query, cmd.group ? { group: cmd.group } : {});
+      state.search = {
+        query: cmd.query,
+        group: cmd.group,
+        results: all.slice(0, MAX_RESULTS),
+        total: all.length,
+        page: 0,
+      };
+      return renderSearch(state.search);
+    }
+
+    case "add": {
+      if (/^\d+$/.test(cmd.arg)) {
+        const pick = state.search?.results[Number.parseInt(cmd.arg, 10) - 1];
+        if (!pick) return { embeds: [errorEmbed(`No result #${cmd.arg}. Run /search first.`)] };
+        return { embeds: [addedEmbed(await addInput(runtime, pick.magnet), pick.name)] };
+      }
+      const name = parseInput(cmd.arg)?.name ?? cmd.arg;
+      return { embeds: [addedEmbed(await addInput(runtime, cmd.arg), name)] };
+    }
+
+    case "status": {
+      const items = runtime.queue.getItems();
+      state.lastStatusIds = items.map((it) => it.id);
+      const downloads = items.map((it) => ({ name: it.name, status: it.status, progress: it.progress }));
+      const seeds = runtime.queue.getSeeds().map((s) => ({ name: s.name, status: s.status }));
+      return { embeds: [statusEmbed(downloads, seeds)] };
+    }
+
+    case "cancel": {
+      const id = /^\d+$/.test(cmd.arg)
+        ? state.lastStatusIds[Number.parseInt(cmd.arg, 10) - 1]
+        : cmd.arg;
+      if (!id) return { embeds: [errorEmbed(`No download #${cmd.arg}. Run /status first.`)] };
+      const item = runtime.queue.getItems().find((it) => it.id === id || it.id.startsWith(id));
+      if (!item) return { embeds: [errorEmbed("No matching download.")] };
+      runtime.queue.cancel(item.id);
+      return { embeds: [cancelledEmbed(item.name)] };
+    }
+  }
+}
+
+// The /search dropdown resolves to a download here: find the picked info hash in
+// the user's current results and queue its magnet.
+export async function addByInfoHash(
+  infoHash: string,
+  runtime: Runtime,
+  state: UserState,
+): Promise<Reply> {
+  const pick = state.search?.results.find((r) => r.infoHash === infoHash);
+  if (!pick) return { embeds: [errorEmbed("That result expired. Run /search again.")] };
+  return { embeds: [addedEmbed(await addInput(runtime, pick.magnet), pick.name)] };
+}

--- a/src/discord/gateway.ts
+++ b/src/discord/gateway.ts
@@ -1,0 +1,124 @@
+// Minimal Discord gateway client, just enough to receive slash-command
+// interactions in real time. Uses Node's built-in WebSocket (Node 22+), so it
+// adds no dependency, and connects outbound only, so there's no public endpoint
+// from behind a NAT or Tailscale. Interactions aren't gated by intents, so we
+// identify with intents: 0 (no Message Content intent needed).
+
+const GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
+
+export interface GatewayInteraction {
+  id: string;
+  token: string;
+  type: number; // 2 = slash command, 3 = message component (our select menu)
+  data?: {
+    name?: string;
+    options?: { name: string; value: unknown }[];
+    custom_id?: string;
+    values?: string[];
+  };
+  member?: { user?: { id?: string; username?: string } };
+  user?: { id?: string; username?: string };
+  channel_id?: string;
+}
+
+export function startGateway(opts: {
+  token: string;
+  onInteraction: (i: GatewayInteraction) => void;
+  onReady?: (botId: string) => void;
+  log?: (m: string) => void;
+}): { stop: () => void } {
+  const log = opts.log ?? (() => {});
+  let ws: WebSocket | null = null;
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
+  let reconnect: ReturnType<typeof setTimeout> | null = null;
+  let seq: number | null = null;
+  let acked = true;
+  let stopped = false;
+
+  const stopHeartbeat = (): void => {
+    if (heartbeat) clearInterval(heartbeat);
+    heartbeat = null;
+  };
+
+  const beat = (): void => {
+    if (!ws || ws.readyState !== ws.OPEN) return;
+    if (!acked) {
+      // The last heartbeat went unanswered, so the socket is a zombie. Drop it
+      // and let the close handler reconnect.
+      log("gateway: heartbeat unacknowledged, reconnecting");
+      ws.close(4000);
+      return;
+    }
+    acked = false;
+    ws.send(JSON.stringify({ op: 1, d: seq }));
+  };
+
+  const connect = (): void => {
+    if (stopped) return;
+    ws = new WebSocket(GATEWAY_URL);
+
+    ws.addEventListener("message", (ev) => {
+      let payload: { op: number; d: unknown; s: number | null; t: string | null };
+      try {
+        payload = JSON.parse(String(ev.data));
+      } catch {
+        return;
+      }
+      const { op, d, s, t } = payload;
+      if (typeof s === "number") seq = s;
+
+      if (op === 10) {
+        // HELLO: start heartbeating, then identify.
+        const interval = (d as { heartbeat_interval: number }).heartbeat_interval;
+        stopHeartbeat();
+        acked = true;
+        heartbeat = setInterval(beat, interval);
+        ws!.send(
+          JSON.stringify({
+            op: 2,
+            d: {
+              token: opts.token,
+              intents: 0,
+              properties: { os: "linux", browser: "torlink", device: "torlink" },
+            },
+          }),
+        );
+      } else if (op === 1) {
+        beat(); // server asked for a heartbeat now
+      } else if (op === 11) {
+        acked = true; // heartbeat ACK
+      } else if (op === 7 || op === 9) {
+        ws!.close(4000); // reconnect / invalid session -> fresh connect
+      } else if (op === 0) {
+        if (t === "READY") {
+          const botId = (d as { user?: { id?: string } }).user?.id ?? "";
+          log("gateway: ready");
+          opts.onReady?.(botId);
+        } else if (t === "INTERACTION_CREATE") {
+          opts.onInteraction(d as GatewayInteraction);
+        }
+      }
+    });
+
+    ws.addEventListener("close", (ev) => {
+      stopHeartbeat();
+      if (stopped) return;
+      log(`gateway: closed (${ev.code}); reconnecting in 3s`);
+      reconnect = setTimeout(connect, 3000);
+    });
+
+    // 'error' is always followed by 'close', which handles the reconnect.
+    ws.addEventListener("error", () => {});
+  };
+
+  connect();
+
+  return {
+    stop: () => {
+      stopped = true;
+      stopHeartbeat();
+      if (reconnect) clearTimeout(reconnect);
+      ws?.close(1000);
+    },
+  };
+}

--- a/src/discord/notify.ts
+++ b/src/discord/notify.ts
@@ -1,0 +1,24 @@
+import type { DownloadQueue } from "../download/queue";
+import { postWebhookEmbed } from "./webhook";
+import { finishedEmbed, failedEmbed } from "./embeds";
+
+// Push an embed to the channel whenever a download finishes or fails. Returns a
+// detach function so the daemon can unhook cleanly on shutdown.
+export function attachNotifications(
+  queue: DownloadQueue,
+  webhookUrl: string,
+  log: (msg: string) => void = () => {},
+): () => void {
+  const onCompleted = (name: string): void => {
+    void postWebhookEmbed(webhookUrl, finishedEmbed(name), { log });
+  };
+  const onFailed = (name: string, error?: string): void => {
+    void postWebhookEmbed(webhookUrl, failedEmbed(name, error), { log });
+  };
+  queue.on("completed", onCompleted);
+  queue.on("failed", onFailed);
+  return () => {
+    queue.off("completed", onCompleted);
+    queue.off("failed", onFailed);
+  };
+}

--- a/src/discord/slash.test.ts
+++ b/src/discord/slash.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { interactionToCommand, interactionUserId } from "./slash";
+import type { GatewayInteraction } from "./gateway";
+
+const command = (name: string, options: { name: string; value: unknown }[] = []): GatewayInteraction => ({
+  id: "1",
+  token: "t",
+  type: 2,
+  data: { name, options },
+});
+
+describe("interactionToCommand", () => {
+  it("maps a search with an 'all' category to no group", () => {
+    const cmd = interactionToCommand(
+      command("search", [
+        { name: "category", value: "all" },
+        { name: "query", value: "big buck bunny" },
+      ]),
+    );
+    expect(cmd).toEqual({ kind: "search", query: "big buck bunny", group: undefined });
+  });
+
+  it("maps a category choice to its source group", () => {
+    const cmd = interactionToCommand(
+      command("search", [
+        { name: "category", value: "Movies" },
+        { name: "query", value: "matrix" },
+      ]),
+    );
+    expect(cmd).toEqual({ kind: "search", query: "matrix", group: "Movies" });
+  });
+
+  it("maps add / status / cancel / help", () => {
+    expect(interactionToCommand(command("add", [{ name: "item", value: "3" }]))).toEqual({ kind: "add", arg: "3" });
+    expect(interactionToCommand(command("status"))).toEqual({ kind: "status" });
+    expect(interactionToCommand(command("cancel", [{ name: "item", value: "2" }]))).toEqual({ kind: "cancel", arg: "2" });
+    expect(interactionToCommand(command("help"))).toEqual({ kind: "help" });
+  });
+
+  it("ignores non-command interactions and unknown names", () => {
+    expect(interactionToCommand({ id: "1", token: "t", type: 3 })).toBeNull();
+    expect(interactionToCommand(command("frobnicate"))).toBeNull();
+  });
+});
+
+describe("interactionUserId", () => {
+  it("prefers the guild member, falls back to the DM user", () => {
+    expect(interactionUserId({ id: "1", token: "t", type: 2, member: { user: { id: "u1" } } })).toBe("u1");
+    expect(interactionUserId({ id: "1", token: "t", type: 2, user: { id: "u2" } })).toBe("u2");
+    expect(interactionUserId({ id: "1", token: "t", type: 2 })).toBeUndefined();
+  });
+});

--- a/src/discord/slash.ts
+++ b/src/discord/slash.ts
@@ -1,0 +1,192 @@
+import { USER_AGENT, type FetchImpl } from "../util/net";
+import type { SourceGroup } from "../sources/types";
+import type { Command } from "./commands";
+import type { GatewayInteraction } from "./gateway";
+
+const API = "https://discord.com/api/v10";
+
+// Option type 3 = STRING. Slash commands carry their arguments as named options,
+// so there's no text to parse; the options map straight onto our Command.
+// Category is a choices dropdown shown before the query, so a search is: pick
+// what kind of thing, then type what you're after.
+const CATEGORY_CHOICES = [
+  { name: "All sources", value: "all" },
+  { name: "🎮 Games", value: "Games" },
+  { name: "🎬 Movies", value: "Movies" },
+  { name: "📺 TV", value: "TV" },
+  { name: "🍥 Anime", value: "Anime" },
+];
+
+export const SLASH_COMMANDS = [
+  {
+    name: "search",
+    description: "Search for a torrent",
+    options: [
+      { name: "category", description: "What kind of thing", type: 3, required: true, choices: CATEGORY_CHOICES },
+      { name: "query", description: "What to look for", type: 3, required: true },
+    ],
+  },
+  {
+    name: "add",
+    description: "Download a result from your last /search, or a magnet / info hash",
+    options: [{ name: "item", description: "Result number, magnet link, or info hash", type: 3, required: true }],
+  },
+  { name: "status", description: "Show active downloads and seeds" },
+  {
+    name: "cancel",
+    description: "Cancel a download by its /status number",
+    options: [{ name: "item", description: "Download number from /status", type: 3, required: true }],
+  },
+  { name: "help", description: "Show torlink's commands" },
+];
+
+const INTERACTION_APPLICATION_COMMAND = 2;
+const CALLBACK_DEFERRED = 5; // ack now, edit the reply once the work is done
+const CALLBACK_MESSAGE = 4;
+const CALLBACK_UPDATE_MESSAGE = 7; // edit the component's own message in place
+const FLAG_EPHEMERAL = 64;
+
+export interface ReplyPayload {
+  content?: string;
+  embeds?: unknown[];
+  components?: unknown[];
+}
+
+export interface DiscordIds {
+  applicationId: string;
+  guildId: string;
+}
+
+async function botGet(path: string, token: string, fetchImpl: FetchImpl): Promise<Response> {
+  return fetchImpl(`${API}${path}`, {
+    headers: { Authorization: `Bot ${token}`, "User-Agent": USER_AGENT },
+  });
+}
+
+// The application id (== bot user id) and the guild that owns the command
+// channel. Both are needed to register guild commands and to edit deferred replies.
+export async function resolveIds(
+  channelId: string,
+  token: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<DiscordIds> {
+  const meRes = await botGet("/users/@me", token, fetchImpl);
+  if (!meRes.ok) throw new Error(`/users/@me HTTP ${meRes.status}`);
+  const applicationId = ((await meRes.json()) as { id: string }).id;
+
+  const chRes = await botGet(`/channels/${channelId}`, token, fetchImpl);
+  if (!chRes.ok) throw new Error(`/channels HTTP ${chRes.status} (is the bot in that server?)`);
+  const guildId = ((await chRes.json()) as { guild_id?: string }).guild_id ?? "";
+  if (!guildId) throw new Error("that channel isn't in a server");
+  return { applicationId, guildId };
+}
+
+// Register the commands on the guild (guild scope shows up instantly, unlike the
+// up-to-an-hour global cache). Needs the bot to have joined with the
+// applications.commands scope.
+export async function registerGuildCommands(
+  ids: DiscordIds,
+  token: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<void> {
+  const res = await fetchImpl(`${API}/applications/${ids.applicationId}/guilds/${ids.guildId}/commands`, {
+    method: "PUT",
+    headers: { Authorization: `Bot ${token}`, "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify(SLASH_COMMANDS),
+  });
+  if (!res.ok) {
+    const detail = (await res.text().catch(() => "")).slice(0, 200);
+    throw new Error(`register commands HTTP ${res.status}${detail ? `: ${detail}` : ""}`);
+  }
+}
+
+export function interactionUserId(i: GatewayInteraction): string | undefined {
+  return i.member?.user?.id ?? i.user?.id;
+}
+
+export function interactionToCommand(i: GatewayInteraction): Command | null {
+  if (i.type !== INTERACTION_APPLICATION_COMMAND || !i.data?.name) return null;
+  const opt = (name: string): string =>
+    String(i.data?.options?.find((o) => o.name === name)?.value ?? "").trim();
+  switch (i.data.name) {
+    case "search": {
+      const category = opt("category");
+      const group = category && category !== "all" ? (category as SourceGroup) : undefined;
+      return { kind: "search", query: opt("query"), group };
+    }
+    case "add":
+      return { kind: "add", arg: opt("item") };
+    case "status":
+      return { kind: "status" };
+    case "cancel":
+      return { kind: "cancel", arg: opt("item") };
+    case "help":
+      return { kind: "help" };
+    default:
+      return null;
+  }
+}
+
+// Ack within Discord's 3s window; the real reply is edited in once the command
+// finishes (a search can take longer than that).
+export async function deferReply(i: GatewayInteraction, fetchImpl: FetchImpl = fetch): Promise<void> {
+  await fetchImpl(`${API}/interactions/${i.id}/${i.token}/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify({ type: CALLBACK_DEFERRED }),
+  });
+}
+
+// Fill in the deferred reply once the command has run.
+export async function editReply(
+  applicationId: string,
+  i: GatewayInteraction,
+  payload: ReplyPayload,
+  fetchImpl: FetchImpl = fetch,
+): Promise<void> {
+  await fetchImpl(`${API}/webhooks/${applicationId}/${i.token}/messages/@original`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify(payload),
+  });
+}
+
+// Immediate reply, for the fast dropdown "add" (no deferral needed).
+export async function respondMessage(
+  i: GatewayInteraction,
+  payload: ReplyPayload,
+  fetchImpl: FetchImpl = fetch,
+): Promise<void> {
+  await fetchImpl(`${API}/interactions/${i.id}/${i.token}/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify({ type: CALLBACK_MESSAGE, data: payload }),
+  });
+}
+
+// Edit the message a component is attached to in place, so the pager buttons swap
+// the results embed to another page without posting a new message.
+export async function updateMessage(
+  i: GatewayInteraction,
+  payload: ReplyPayload,
+  fetchImpl: FetchImpl = fetch,
+): Promise<void> {
+  await fetchImpl(`${API}/interactions/${i.id}/${i.token}/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify({ type: CALLBACK_UPDATE_MESSAGE, data: payload }),
+  });
+}
+
+// A one-shot ephemeral reply, for the rejection path (no deferral needed).
+export async function replyEphemeral(
+  i: GatewayInteraction,
+  content: string,
+  fetchImpl: FetchImpl = fetch,
+): Promise<void> {
+  await fetchImpl(`${API}/interactions/${i.id}/${i.token}/callback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+    body: JSON.stringify({ type: CALLBACK_MESSAGE, data: { content, flags: FLAG_EPHEMERAL } }),
+  });
+}

--- a/src/discord/webhook.ts
+++ b/src/discord/webhook.ts
@@ -1,0 +1,59 @@
+import { fetchResilient, USER_AGENT, type FetchImpl } from "../util/net";
+import type { Embed } from "./embeds";
+
+// Discord rejects messages over 2000 characters; leave a margin and mark the cut.
+const MAX_CONTENT = 1900;
+const WEBHOOK_NAME = "torlink";
+
+export function trimForDiscord(content: string): string {
+  return content.length <= MAX_CONTENT ? content : `${content.slice(0, MAX_CONTENT - 1)}…`;
+}
+
+interface WebhookBody {
+  content?: string;
+  embeds?: Embed[];
+}
+
+// Post to a channel through its webhook. Outbound only and best-effort: a message
+// that can't be delivered must never take the daemon down, so this reports false
+// rather than throwing.
+async function send(
+  url: string,
+  body: WebhookBody,
+  opts: { log?: (msg: string) => void; fetchImpl?: FetchImpl },
+): Promise<boolean> {
+  const log = opts.log ?? (() => {});
+  try {
+    const res = await fetchResilient(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": USER_AGENT },
+      body: JSON.stringify({ username: WEBHOOK_NAME, ...body }),
+      retries: 2,
+      fetchImpl: opts.fetchImpl,
+    });
+    if (!res.ok) {
+      log(`discord webhook -> HTTP ${res.status}`);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    log(`discord webhook failed: ${e instanceof Error ? e.message : String(e)}`);
+    return false;
+  }
+}
+
+export function postWebhook(
+  url: string,
+  content: string,
+  opts: { log?: (msg: string) => void; fetchImpl?: FetchImpl } = {},
+): Promise<boolean> {
+  return send(url, { content: trimForDiscord(content) }, opts);
+}
+
+export function postWebhookEmbed(
+  url: string,
+  embed: Embed,
+  opts: { log?: (msg: string) => void; fetchImpl?: FetchImpl } = {},
+): Promise<boolean> {
+  return send(url, { embeds: [embed] }, opts);
+}

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -167,6 +167,7 @@ export class DownloadQueue extends EventEmitter {
           it.error = msg;
           it.speed = 0;
           it.peers = 0;
+          this.emit("failed", it.name, msg);
           this.changed();
           void this.persist();
           this.maybeStopPoll();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,6 +63,14 @@ if (cmd.kind === "watch") {
     dir: cmd.dir,
   };
   void import("./daemon/files").then(({ runFiles }) => runFiles(options).catch(failHeadless));
+} else if (cmd.kind === "discord") {
+  if (cmd.daemon) daemonize("discord");
+  const options = {
+    downloadDir: cmd.downloadDir,
+    seedTimeMs: cmd.seedTimeMs,
+    deleteFiles: cmd.deleteFiles,
+  };
+  void import("./daemon/discord").then(({ runDiscord }) => runDiscord(options).catch(failHeadless));
 } else {
 
 // Enter the alt-screen and hide the hardware cursor: the TUI draws its own

--- a/src/sources/search.test.ts
+++ b/src/sources/search.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { dedupe, orderByHealth } from "./search";
+import type { TorrentResult } from "./types";
+
+const r = (over: Partial<TorrentResult>): TorrentResult => ({
+  infoHash: "h",
+  name: "Example",
+  sizeBytes: 1000,
+  seeders: 0,
+  leechers: 0,
+  source: "yts",
+  magnet: "magnet:?xt=urn:btih:h",
+  ...over,
+});
+
+describe("dedupe", () => {
+  it("keeps the highest-seeder copy of each info hash", () => {
+    const out = dedupe([
+      r({ infoHash: "a", seeders: 5 }),
+      r({ infoHash: "a", seeders: 20 }),
+      r({ infoHash: "b", seeders: 3 }),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out.find((x) => x.infoHash === "a")!.seeders).toBe(20);
+  });
+});
+
+describe("orderByHealth", () => {
+  it("sorts by seeders desc, then newer first", () => {
+    const out = orderByHealth([
+      r({ infoHash: "a", seeders: 1, added: 100 }),
+      r({ infoHash: "b", seeders: 9, added: 1 }),
+      r({ infoHash: "c", seeders: 9, added: 50 }),
+    ]);
+    expect(out.map((x) => x.infoHash)).toEqual(["c", "b", "a"]);
+  });
+});

--- a/src/sources/search.ts
+++ b/src/sources/search.ts
@@ -1,0 +1,39 @@
+import { SOURCES } from "./registry";
+import { cachedSearch } from "./cache";
+import type { SearchOptions, SourceGroup, TorrentResult } from "./types";
+
+// Collapse duplicate torrents (same info hash from several sources), keeping the
+// row with the most seeders, the healthiest report of the same swarm.
+export function dedupe(list: TorrentResult[]): TorrentResult[] {
+  const byHash = new Map<string, TorrentResult>();
+  for (const r of list) {
+    const existing = byHash.get(r.infoHash);
+    if (!existing || r.seeders > existing.seeders) byHash.set(r.infoHash, r);
+  }
+  return [...byHash.values()];
+}
+
+// torlink's default ordering: healthiest first, newest as the tiebreak.
+export function orderByHealth(list: TorrentResult[]): TorrentResult[] {
+  return list.sort((a, b) => {
+    if (b.seeders !== a.seeders) return b.seeders - a.seeders;
+    return (b.added ?? 0) - (a.added ?? 0);
+  });
+}
+
+// Search every source at once and return one merged, health-ordered list. The
+// non-React sibling of useConcurrentSearch, for headless callers (the Discord
+// bridge) that need results without a component tree. A source that throws is
+// skipped, matching the TUI's fail-soft behaviour. Pass `group` to search only
+// one category's sources (Games, Movies, TV, Anime), like the TUI's tabs.
+export async function searchAll(
+  query: string,
+  opts: SearchOptions & { group?: SourceGroup } = {},
+): Promise<TorrentResult[]> {
+  const { group, ...searchOpts } = opts;
+  const sources = group ? SOURCES.filter((s) => s.groups?.includes(group)) : SOURCES;
+  const settled = await Promise.all(
+    sources.map((s) => cachedSearch(s, query, searchOpts).catch(() => [] as TorrentResult[])),
+  );
+  return orderByHealth(dedupe(settled.flat()));
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout, useStdin } from "ink";
 import { promises as fs } from "node:fs";
-import { loadConfig, saveConfig, type Config } from "../config/config";
+import { loadConfig, saveConfig, type Config, type DiscordConfig } from "../config/config";
 import { normalizeDownloadDir } from "../config/folder";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
@@ -35,6 +35,7 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { DiscordPrompt } from "./components/DiscordPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -86,6 +87,7 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  const [editingDiscord, setEditingDiscord] = useState(false);
   // A result waiting on the "download to" prompt (D); null when the prompt is
   // closed. lastDownloadToDir pre-fills the next prompt so queueing a batch
   // into the same alternate folder only costs one typed path per session.
@@ -179,6 +181,20 @@ export function App({
   const closeTrackersPrompt = useCallback(() => {
     setEditingTrackers(false);
   }, []);
+
+  const closeDiscordPrompt = useCallback(() => {
+    setEditingDiscord(false);
+  }, []);
+
+  const setDiscord = useCallback(
+    (discord: DiscordConfig | undefined) => {
+      closeDiscordPrompt();
+      if (!config) return;
+      setConfig({ ...config, discord });
+      setNotice(discord ? "Saved Discord settings." : "Cleared Discord settings.");
+    },
+    [config, setConfig, closeDiscordPrompt],
+  );
 
   const setTrackers = useCallback(
     (list: string[]) => {
@@ -392,7 +408,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || editingDiscord || pendingDownload ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -425,6 +441,7 @@ export function App({
     showHelp,
     editingFolder,
     editingTrackers,
+    editingDiscord,
     pendingDownload,
     captureMode,
     downloadFocus,
@@ -450,7 +467,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || editingDiscord || pendingDownload) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -468,6 +485,11 @@ export function App({
       if (input === "t") {
         setShowHelp(false);
         setEditingTrackers(true);
+        return;
+      }
+      if (input === "g") {
+        setShowHelp(false);
+        setEditingDiscord(true);
         return;
       }
       if (input === "m") {
@@ -568,6 +590,17 @@ export function App({
           </Box>
         ) : null}
 
+        {editingDiscord ? (
+          <Box marginTop={1}>
+            <DiscordPrompt
+              width={Math.max(24, Math.min(cols - 4, 78))}
+              value={store.config.discord}
+              onSubmit={setDiscord}
+              onCancel={closeDiscordPrompt}
+            />
+          </Box>
+        ) : null}
+
         {pendingDownload ? (
           <Box marginTop={1}>
             <FolderPrompt
@@ -589,7 +622,7 @@ export function App({
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || editingDiscord || pendingDownload ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -605,7 +638,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || editingDiscord || pendingDownload ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/DiscordPrompt.tsx
+++ b/src/ui/components/DiscordPrompt.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { COLOR, ICON } from "../theme";
+import type { DiscordConfig } from "../../config/config";
+
+interface DiscordPromptProps {
+  width: number;
+  value?: DiscordConfig;
+  onSubmit: (discord: DiscordConfig | undefined) => void;
+  onCancel: () => void;
+}
+
+const FIELDS = [
+  { key: "webhookUrl", label: "Webhook URL", placeholder: "https://discord.com/api/webhooks/…", secret: true },
+  { key: "botToken", label: "Bot token", placeholder: "optional · enables commands", secret: true },
+  { key: "channelId", label: "Channel ID", placeholder: "optional · channel to read", secret: false },
+  { key: "allowedUsers", label: "Allowed users", placeholder: "optional · comma-separated ids", secret: false },
+] as const;
+
+type FieldKey = (typeof FIELDS)[number]["key"];
+
+const LABEL_W = 17;
+
+export function DiscordPrompt({ width, value, onSubmit, onCancel }: DiscordPromptProps) {
+  const [values, setValues] = useState<Record<FieldKey, string>>({
+    webhookUrl: value?.webhookUrl ?? "",
+    botToken: value?.botToken ?? "",
+    channelId: value?.channelId ?? "",
+    allowedUsers: (value?.allowedUserIds ?? []).join(", "),
+  });
+  const [focus, setFocus] = useState(0);
+
+  // Arrow keys move between rows; the active field owns everything else. Both
+  // this handler and the focused TextField see the key, but the field ignores
+  // the vertical arrows, so only the move lands.
+  useInput((_input, key) => {
+    if (key.escape) return onCancel();
+    if (key.upArrow) setFocus((f) => Math.max(0, f - 1));
+    else if (key.downArrow) setFocus((f) => Math.min(FIELDS.length - 1, f + 1));
+  });
+
+  const save = (): void => {
+    const trimmed = (k: FieldKey): string => values[k].trim();
+    const webhookUrl = trimmed("webhookUrl") || undefined;
+    const botToken = trimmed("botToken") || undefined;
+    const channelId = trimmed("channelId") || undefined;
+    const allowedUserIds = trimmed("allowedUsers")
+      ? trimmed("allowedUsers").split(",").map((s) => s.trim()).filter(Boolean)
+      : undefined;
+    if (!webhookUrl && !botToken && !channelId && !allowedUserIds) return onSubmit(undefined);
+    onSubmit({ webhookUrl, botToken, channelId, allowedUserIds });
+  };
+
+  // A webhook alone is notifications only; commands need all four.
+  const notifyOn = values.webhookUrl.trim() !== "";
+  const commandsOn = (["webhookUrl", "botToken", "channelId", "allowedUsers"] as const).every(
+    (k) => values[k].trim() !== "",
+  );
+
+  const fieldW = Math.max(1, width - LABEL_W - 6);
+
+  return (
+    <Box flexDirection="column" width={width}>
+      {/* rows: one status line + one per field, plus the panel's bottom border */}
+      <Panel title="discord" width={width} focused height={FIELDS.length + 2}>
+        <Box>
+          <Text dimColor>notifications </Text>
+          <Text color={notifyOn ? COLOR.good : COLOR.alt}>{notifyOn ? "on" : "off"}</Text>
+          <Text dimColor>{`  ${ICON.dot}  commands `}</Text>
+          <Text color={commandsOn ? COLOR.good : COLOR.alt}>{commandsOn ? "on" : "off"}</Text>
+        </Box>
+        {FIELDS.map((f, i) => {
+          const active = i === focus;
+          return (
+            <Box key={f.key}>
+              <Box width={LABEL_W}>
+                <Text color={active ? COLOR.accent : undefined} dimColor={!active} wrap="truncate-end">
+                  {active ? `${ICON.pointer} ` : "  "}
+                  {f.label}
+                </Text>
+              </Box>
+              <Box flexGrow={1} minWidth={0}>
+                {active ? (
+                  <TextField
+                    defaultValue={values[f.key]}
+                    placeholder={f.placeholder}
+                    width={fieldW}
+                    onChange={(v) => setValues((prev) => ({ ...prev, [f.key]: v }))}
+                    onSubmit={save}
+                  />
+                ) : (
+                  <Text dimColor wrap="truncate-end">
+                    {values[f.key] ? (f.secret ? "•••••••• (set)" : values[f.key]) : f.placeholder}
+                  </Text>
+                )}
+              </Box>
+            </Box>
+          );
+        })}
+      </Panel>
+      <Box marginTop={1}>
+        <Box marginRight={2}>
+          <Text color={COLOR.alt}>↑↓</Text>
+          <Text dimColor> fields</Text>
+        </Box>
+        <PromptHints submitLabel="save" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([122, 101, 65, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 12, 16, 30]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([9, 12, 17, 31]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { SOURCES } from "../../sources/registry";
 import { cachedSearch } from "../../sources/cache";
+import { dedupe, orderByHealth } from "../../sources/search";
 import { HttpError } from "../../util/net";
 import type { SourceId, TorrentResult } from "../../sources/types";
 
@@ -28,24 +29,6 @@ function blankPerSource(loading: boolean): Record<SourceId, SourceState> {
   const out = {} as Record<SourceId, SourceState>;
   for (const s of SOURCES) out[s.id] = { loading, error: null, code: null, count: 0 };
   return out;
-}
-
-function dedupe(list: TorrentResult[]): TorrentResult[] {
-  const byHash = new Map<string, TorrentResult>();
-  for (const r of list) {
-    const existing = byHash.get(r.infoHash);
-    if (!existing || r.seeders > existing.seeders) byHash.set(r.infoHash, r);
-  }
-  return [...byHash.values()];
-}
-
-// torlink's default ordering: healthiest first. The results view can re-sort
-// on demand (the `s` key), and its "none"/default state preserves this order.
-function defaultOrder(list: TorrentResult[]): TorrentResult[] {
-  return list.sort((a, b) => {
-    if (b.seeders !== a.seeders) return b.seeders - a.seeders;
-    return (b.added ?? 0) - (a.added ?? 0);
-  });
 }
 
 function idleState(): ConcurrentSearchState {
@@ -78,7 +61,7 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
 
     const flush = (): void => {
       setState({
-        results: defaultOrder(dedupe(collected.slice())),
+        results: orderByHealth(dedupe(collected.slice())),
         perSource: { ...per },
         loading: done < SOURCES.length,
         done,

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -20,6 +20,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "esc", label: "Back" },
       { keys: "o", label: "Default download folder" },
       { keys: "t", label: "Extra trackers" },
+      { keys: "g", label: "Discord setup" },
       { keys: "q", label: "Quit" },
     ],
   },

--- a/src/util/atomic.ts
+++ b/src/util/atomic.ts
@@ -9,9 +9,16 @@ export function serializeWrites(): (task: () => Promise<void>) => Promise<void> 
   };
 }
 
-export async function writeJsonAtomic(file: string, data: unknown): Promise<void> {
+export async function writeJsonAtomic(
+  file: string,
+  data: unknown,
+  opts: { mode?: number } = {},
+): Promise<void> {
   await fs.mkdir(path.dirname(file), { recursive: true });
   const tmp = `${file}.tmp`;
   await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf8");
+  // Set the mode before the rename so the file is never briefly world-readable
+  // (chmod is a no-op on Windows, hence the swallow).
+  if (opts.mode !== undefined) await fs.chmod(tmp, opts.mode).catch(() => {});
   await fs.rename(tmp, file);
 }


### PR DESCRIPTION
## What this does

An optional Discord bridge for headless runs. A channel webhook carries notifications when a download finishes or fails. With a bot token, channel id, and an allowlist, the daemon also registers slash commands and answers them in real time:

- `/search` with a category picker, a pick-to-download dropdown, and prev/next paging
- `/add`, `/status` (with a progress bar), `/cancel`, `/help`

It runs as a new headless mode, `torlnk discord`, over the same runtime as serve and watch. Set it up in the TUI (press `g`), the config file, or the `TORLINK_DISCORD_*` env vars.

## Why

A seedbox is headless, but you still want to know when a download lands or fails, and sometimes to start one without opening a terminal.

## Design notes

Slash commands arrive over a small gateway client built on Node's built-in WebSocket, so there is no new dependency and no public endpoint to expose from behind a NAT. Notifications are outbound webhook posts. Secrets live in the config file (written `0600`) or the env vars, and commands run only for an allowlisted user id; an empty allowlist keeps notifications on and commands off, never an open remote. `searchAll` is lifted out of `useConcurrentSearch` so the bridge and the TUI share one search path.

## Testing

`npm run typecheck` and `npm test` are clean, with tests for the command executor, the slash mapping, the embeds, and pagination. Verified live against a real Discord server: slash commands, category search, paging, the dropdown add, and notifications all work.
