### PR TITLE
feat: add in-memory multi-token filter for search results

### DIFF
--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { useStore, CATEGORIES } from "../store";
 import { Spinner } from "./Spinner";
 import { SearchBar } from "./SearchBar";
+import { TextField } from "./TextField";
 import { Panel } from "./Panel";
 import { Rule } from "./Rule";
 import { useConcurrentSearch } from "../hooks/useConcurrentSearch";
@@ -14,7 +15,7 @@ import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Source, TorrentResult } from "../../sources/types";
 
-type Mode = "list" | "search" | "detail";
+type Mode = "list" | "search" | "detail" | "filter";
 
 const PLACEHOLDER = "Search or paste a magnet link…";
 
@@ -128,13 +129,14 @@ export function Results() {
 
   const [sort, setSort] = useState<Sort>("none");
   const [hideDead, setHideDead] = useState(false);
+  const [textFilter, setTextFilter] = useState("");
   const results = useMemo(() => {
     const cat = CATEGORIES.find((c) => c.key === section);
     const base = cat?.group
       ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
       : search.results;
-    return sortResults(filterResults(base, hideDead), sort);
-  }, [search.results, section, sort, hideDead]);
+    return sortResults(filterResults(base, hideDead, textFilter), sort);
+  }, [search.results, section, sort, hideDead, textFilter]);
 
   const focused = region === "content";
   const [mode, setMode] = useState<Mode>("list");
@@ -151,11 +153,12 @@ export function Results() {
   useEffect(() => {
     selRef.current = null;
     setCursor(0);
+    setTextFilter("");
   }, [query, section]);
 
   useEffect(() => {
     if (!focused) return;
-    setCaptureMode(mode === "search" ? "text" : mode === "detail" ? "esc" : "none");
+    setCaptureMode(mode === "search" || mode === "filter" ? "text" : mode === "detail" ? "esc" : "none");
     return () => setCaptureMode("none");
   }, [mode, focused, setCaptureMode]);
 
@@ -166,7 +169,8 @@ export function Results() {
   const clamped = Math.min(cursor, Math.max(0, results.length - 1));
 
   const searchH = 3;
-  const panelOuter = resultsPanelOuter(listRows, searchH);
+  const filterH = mode === "filter" || textFilter ? 1 : 0;
+  const panelOuter = resultsPanelOuter(listRows, searchH + filterH);
   const listHeight = Math.max(3, panelOuter - 4);
   const pageJump = Math.max(1, listHeight - 1);
 
@@ -230,6 +234,8 @@ export function Results() {
         setSort((cur) => nextSort(cur));
       } else if (input === "z") {
         setHideDead((on) => !on);
+      } else if (input === "f") {
+        setMode("filter");
       }
     },
     { isActive: focused && mode === "list" },
@@ -251,7 +257,7 @@ export function Results() {
     (_input, key) => {
       if (key.escape) setMode("list");
     },
-    { isActive: focused && mode === "search" },
+    { isActive: focused && (mode === "search" || mode === "filter") },
   );
 
   const onSubmit = (value: string): void => {
@@ -467,6 +473,25 @@ export function Results() {
             </>
           )}
         </Panel>
+        {(mode === "filter" || textFilter) && (
+          <Box marginLeft={1}>
+            <Text color={COLOR.accent}>{`Filter ${ICON.pointer} `}</Text>
+            <Box flexGrow={1} minWidth={0}>
+              {mode === "filter" ? (
+                <TextField
+                  defaultValue={textFilter}
+                  width={Math.max(1, contentWidth - 10)}
+                  onChange={setTextFilter}
+                  onSubmit={() => setMode("list")}
+                  onExitDown={() => setMode("list")}
+                  onExitLeft={() => setMode("list")}
+                />
+              ) : (
+                <Text wrap="truncate-end">{textFilter}</Text>
+              )}
+            </Box>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -169,7 +169,7 @@ export function Results() {
   const clamped = Math.min(cursor, Math.max(0, results.length - 1));
 
   const searchH = 3;
-  const filterH = mode === "filter" || textFilter ? 1 : 0;
+  const filterH = mode === "filter" || textFilter.trim() ? 1 : 0;
   const panelOuter = resultsPanelOuter(listRows, searchH + filterH);
   const listHeight = Math.max(3, panelOuter - 4);
   const pageJump = Math.max(1, listHeight - 1);
@@ -211,11 +211,21 @@ export function Results() {
         else setMode("search");
         return;
       }
-      if (results.length === 0) return;
-      if (key.downArrow || input === "j") moveTo(wrapStep(clamped, 1, results.length));
-      else if (key.pageUp) moveTo(Math.max(0, clamped - pageJump));
-      else if (key.pageDown) moveTo(Math.min(results.length - 1, clamped + pageJump));
-      else if (key.return) {
+      if (input === "s") {
+        setSort((cur) => nextSort(cur));
+      } else if (input === "z") {
+        setHideDead((on) => !on);
+      } else if (input === "f") {
+        setMode("filter");
+      } else if (results.length === 0) {
+        return;
+      } else if (key.downArrow || input === "j") {
+        moveTo(wrapStep(clamped, 1, results.length));
+      } else if (key.pageUp) {
+        moveTo(Math.max(0, clamped - pageJump));
+      } else if (key.pageDown) {
+        moveTo(Math.min(results.length - 1, clamped + pageJump));
+      } else if (key.return) {
         const r = results[clamped];
         if (r) {
           setDetail(r);
@@ -230,12 +240,6 @@ export function Results() {
       } else if (input === "y") {
         const r = results[clamped];
         if (r) copyResultMagnet(r);
-      } else if (input === "s") {
-        setSort((cur) => nextSort(cur));
-      } else if (input === "z") {
-        setHideDead((on) => !on);
-      } else if (input === "f") {
-        setMode("filter");
       }
     },
     { isActive: focused && mode === "list" },
@@ -473,7 +477,7 @@ export function Results() {
             </>
           )}
         </Panel>
-        {(mode === "filter" || textFilter) && (
+        {(mode === "filter" || textFilter.trim()) && (
           <Box marginLeft={1}>
             <Text color={COLOR.accent}>{`Filter ${ICON.pointer} `}</Text>
             <Box flexGrow={1} minWidth={0}>
@@ -482,9 +486,9 @@ export function Results() {
                   defaultValue={textFilter}
                   width={Math.max(1, contentWidth - 10)}
                   onChange={setTextFilter}
-                  onSubmit={() => setMode("list")}
-                  onExitDown={() => setMode("list")}
-                  onExitLeft={() => setMode("list")}
+                  onSubmit={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
+                  onExitDown={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
+                  onExitLeft={() => { setTextFilter(textFilter.trim()); setMode("list"); }}
                 />
               ) : (
                 <Text wrap="truncate-end">{textFilter}</Text>

--- a/src/ui/filter.test.ts
+++ b/src/ui/filter.test.ts
@@ -45,4 +45,19 @@ describe("filterResults", () => {
     filterResults(list, true);
     expect(list.map((x) => x.infoHash)).toEqual(before);
   });
+
+  it("filters by text matching all tokens and ranks exact matches higher", () => {
+    const list = [
+      r({ infoHash: "a", name: "ubuntu 24 desktop" }),
+      r({ infoHash: "b", name: "ubuntu desktop 24.04" }),
+      r({ infoHash: "c", name: "debian 12" }),
+      r({ infoHash: "d", name: "24 ubuntu desktop" }),
+    ];
+    // "ubuntu 24" -> 
+    // a: exact substring "ubuntu 24" (score 60)
+    // b: "ubuntu" before "24" (score 30)
+    // d: "24" before "ubuntu" (out of order, score 10)
+    // c: no match
+    expect(filterResults(list, false, "ubuntu 24").map(x => x.infoHash)).toEqual(["a", "b", "d"]);
+  });
 });

--- a/src/ui/filter.ts
+++ b/src/ui/filter.ts
@@ -4,9 +4,54 @@ import type { TorrentResult } from "../sources/types";
 export function filterResults(
   list: TorrentResult[],
   hideDead: boolean,
+  textFilter: string = "",
 ): TorrentResult[] {
-  if (!hideDead) return list;
-  // Sources without swarm data report seeders: 0 for everything (unknown, not
-  // dead), so the filter only judges rows whose source actually reports health.
-  return list.filter((r) => r.seeders > 0 || !getSource(r.source).reportsHealth);
+  let filtered = list;
+
+  if (hideDead) {
+    // Sources without swarm data report seeders: 0 for everything (unknown, not
+    // dead), so the filter only judges rows whose source actually reports health.
+    filtered = filtered.filter((r) => r.seeders > 0 || !getSource(r.source).reportsHealth);
+  }
+
+  const text = textFilter.trim().toLowerCase();
+  if (text) {
+    const tokens = text.split(/\s+/);
+    const scored = filtered.map((r) => {
+      const name = r.name.toLowerCase();
+      let score = 0;
+
+      // Every token must be present
+      const matchesAll = tokens.every((token) => name.includes(token));
+      if (!matchesAll) return { r, score: 0 };
+
+      score += 10; // Base score for matching all tokens
+
+      if (name.includes(text)) {
+        score += 50; // Exact substring gets highest boost
+      } else {
+        // Boost if tokens appear in the same order
+        let lastIndex = -1;
+        let inOrder = true;
+        for (const token of tokens) {
+          const idx = name.indexOf(token, lastIndex + 1);
+          if (idx === -1 || idx < lastIndex) {
+            inOrder = false;
+            break;
+          }
+          lastIndex = idx;
+        }
+        if (inOrder) score += 20;
+      }
+
+      return { r, score };
+    });
+
+    filtered = scored
+      .filter((x) => x.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .map((x) => x.r);
+  }
+
+  return filtered;
 }

--- a/src/ui/filter.ts
+++ b/src/ui/filter.ts
@@ -27,7 +27,8 @@ export function filterResults(
 
       score += 10; // Base score for matching all tokens
 
-      if (name.includes(text)) {
+      const normalizedText = tokens.join(" ");
+      if (name.includes(normalizedText)) {
         score += 50; // Exact substring gets highest boost
       } else {
         // Boost if tokens appear in the same order

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([122, 101, 65, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 12, 16, 30]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 31]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -27,6 +27,7 @@ export const HELP_GROUPS: HelpGroup[] = [
     title: "Search",
     hints: [
       { keys: "/", label: "Edit search" },
+      { keys: "f", label: "Filter list" },
       { keys: "d", label: "Download (shift+d picks folder)" },
       { keys: "s", label: "Sort results" },
       { keys: "z", label: "Hide dead torrents" },
@@ -117,6 +118,7 @@ export function footerHints(
     { keys: "y", label: "Copy" },
     { keys: "s", label: "Sort" },
     { keys: "/", label: "Search" },
+    { keys: "f", label: "Filter" },
     SWITCH,
     ALWAYS,
   ];


### PR DESCRIPTION
- Adds a filter bar to the Results panel, triggered by `f`
- Implements multi-token (AND) matching against torrent names
- Ranks exact matches and in-order tokens higher than scattered matches
- Updates HELP_GROUPS and footerHints to advertise the shortcut
- Adjusts layout tests to account for the new key hint height

## What and why

<!-- What does this change do, and why? The diff shows the what; tell us the why. -->

## Checklist

- [ ] `npm run typecheck` is clean
- [ ] `npm test` passes
- [ ] New logic has a test (vitest; mock node built-ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [ ] OS-touching code works on Windows, macOS, and Linux
- [ ] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)

New here? [CONTRIBUTING.md](../CONTRIBUTING.md) explains each of these with examples from real merged PRs.
