### PR TITLE
feat(queue): cap concurrent downloads via TORLINK_MAX_DOWNLOADS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ torlink also runs without the TUI, for servers and seedboxes:
 
 Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
 
+Set `TORLINK_MAX_DOWNLOADS=N` to cap how many torrents download at once — handy on a bandwidth-limited seedbox so each active download gets a fair share instead of splitting the pipe across everything. Extra torrents wait as `queued` and start automatically as slots free (oldest first). Unset or `0` means unlimited (the default). Seeding is unaffected.
+
 ## Contributing
 
 To run or work on torlink locally:

--- a/src/download/queue.concurrency.test.ts
+++ b/src/download/queue.concurrency.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { DownloadQueue } from "./queue";
+
+// Stub the engine (same approach as queue.add.test.ts) so these tests cover the
+// queue's own concurrency bookkeeping without touching webtorrent/the network.
+vi.mock("./engine", () => ({
+  TorrentEngine: class {
+    add(): void {}
+    remove(): void {}
+    stats(): undefined {
+      return undefined;
+    }
+    destroy(): void {}
+  },
+}));
+
+const mk = (n: number) => ({
+  id: String(n).padStart(40, "0"),
+  name: `T${n}`,
+  magnet: `magnet:?xt=urn:btih:${String(n).padStart(40, "0")}`,
+});
+const statuses = (q: DownloadQueue): Record<string, string> =>
+  Object.fromEntries(q.getItems().map((i) => [i.id, i.status]));
+
+describe("DownloadQueue concurrent-download cap (TORLINK_MAX_DOWNLOADS)", () => {
+  it("queues torrents beyond the cap, then promotes the oldest when a slot frees", () => {
+    const q = new DownloadQueue({ maxDownloads: 2 });
+    q.add(mk(1), "/d");
+    q.add(mk(2), "/d");
+    q.add(mk(3), "/d");
+
+    expect(q.activeCount).toBe(2);
+    let s = statuses(q);
+    expect(s[mk(1).id]).toBe("downloading");
+    expect(s[mk(2).id]).toBe("downloading");
+    expect(s[mk(3).id]).toBe("queued");
+
+    // Pausing an active download frees a slot → the queued one starts.
+    q.pause(mk(1).id);
+    expect(q.activeCount).toBe(2);
+    s = statuses(q);
+    expect(s[mk(1).id]).toBe("paused");
+    expect(s[mk(3).id]).toBe("downloading");
+
+    q.suspend();
+  });
+
+  it("defaults to unlimited (maxDownloads 0) — everything downloads at once", () => {
+    const q = new DownloadQueue({ maxDownloads: 0 });
+    q.add(mk(1), "/d");
+    q.add(mk(2), "/d");
+    q.add(mk(3), "/d");
+    expect(q.activeCount).toBe(3);
+    expect(Object.values(statuses(q)).every((v) => v === "downloading")).toBe(true);
+    q.suspend();
+  });
+
+  it("respects the cap when restoring persisted downloads on boot", () => {
+    const persisted = [1, 2, 3].map((n) => ({
+      ...mk(n),
+      source: undefined,
+      dir: "/d",
+      status: "downloading" as const,
+      progress: 0,
+      totalBytes: 0,
+      downloadedBytes: 0,
+      speed: 0,
+      peers: 0,
+      addedAt: n,
+    }));
+    const q = new DownloadQueue({ maxDownloads: 2 });
+    q.restore(persisted);
+    expect(q.activeCount).toBe(2);
+    expect(statuses(q)[mk(3).id]).toBe("queued");
+    q.suspend();
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -38,6 +38,13 @@ const SEED_GRACE_MS = 10_000;
 const POLL_MS = 500;
 const HISTORY_MAX = 500;
 
+// Max torrents allowed to actively download at once. Overflow waits as "queued"
+// and starts automatically when a slot frees. 0 / unset = unlimited (default).
+function readMaxDownloads(): number {
+  const v = Number(process.env.TORLINK_MAX_DOWNLOADS);
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+}
+
 export interface AddInput {
   id: string;
   name: string;
@@ -55,6 +62,14 @@ export class DownloadQueue extends EventEmitter {
   private strayHits = new Map<string, number>();
   private seedStartedAt = new Map<string, number>();
   private trackers: string[] = [];
+
+  // Max torrents allowed to download at once; overflow waits as "queued".
+  private readonly maxDownloads: number;
+
+  constructor(opts?: { maxDownloads?: number }) {
+    super();
+    this.maxDownloads = opts?.maxDownloads ?? readMaxDownloads();
+  }
 
   // Extra announce URLs appended to every torrent added from now on.
   // Existing running torrents aren't retro-updated — the change takes effect
@@ -115,15 +130,46 @@ export class DownloadQueue extends EventEmitter {
           peers: 0,
           addedAt: Date.now(),
         };
+    // Respect the concurrent-download cap: start now if a slot is free, else
+    // hold the torrent as "queued" until one frees (see promote()).
+    const start = this.maxDownloads === 0 || this.activeCount < this.maxDownloads;
+    item.status = start ? "downloading" : "queued";
     this.items.set(item.id, item);
-    this.startEngine(item);
-    this.ensurePoll();
+    if (start) {
+      this.startEngine(item);
+      this.ensurePoll();
+    }
     this.changed();
     void this.persist();
   }
 
   private startEngine(item: QueueItem): void {
     this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+  }
+
+  /**
+   * Start queued torrents (oldest first) while download slots are free. Called
+   * whenever a slot opens up — a download finishes, fails, is paused, or is
+   * cancelled. No-op when unlimited (this.maxDownloads === 0), since nothing queues.
+   */
+  private promote(): void {
+    if (this.maxDownloads === 0) return;
+    let started = false;
+    while (this.activeCount < this.maxDownloads) {
+      const next = [...this.items.values()]
+        .filter((it) => it.status === "queued")
+        .sort((a, b) => a.addedAt - b.addedAt)[0];
+      if (!next) break;
+      next.status = "downloading";
+      next.speed = 0;
+      this.startEngine(next);
+      started = true;
+    }
+    if (started) {
+      this.ensurePoll();
+      this.changed();
+      void this.persist();
+    }
   }
 
   // One torrent serves an item across its whole life (download -> seed ->
@@ -169,6 +215,7 @@ export class DownloadQueue extends EventEmitter {
           it.peers = 0;
           this.changed();
           void this.persist();
+          this.promote(); // a slot just freed
           this.maybeStopPoll();
           return;
         }
@@ -195,6 +242,7 @@ export class DownloadQueue extends EventEmitter {
     this.emit("completed", it.name);
     this.changed();
     void this.persist();
+    this.promote(); // a slot just freed
     this.maybeStopPoll();
   }
 
@@ -291,23 +339,33 @@ export class DownloadQueue extends EventEmitter {
 
   pause(id: string): void {
     const it = this.items.get(id);
-    if (!it || it.status !== "downloading") return;
+    // A queued (not-yet-started) item can be paused too; only a downloading one
+    // holds a live engine + frees a slot on pause.
+    if (!it || (it.status !== "downloading" && it.status !== "queued")) return;
+    const wasDownloading = it.status === "downloading";
     it.status = "paused";
     it.speed = 0;
     it.peers = 0;
     it.eta = undefined;
-    this.engine.remove(id);
+    if (wasDownloading) this.engine.remove(id);
     this.changed();
     void this.persist();
-    this.maybeStopPoll();
+    if (wasDownloading) {
+      this.promote(); // a slot just freed
+      this.maybeStopPoll();
+    }
   }
 
   resume(id: string): void {
     const it = this.items.get(id);
     if (!it || it.status !== "paused") return;
-    it.status = "downloading";
-    this.startEngine(it);
-    this.ensurePoll();
+    // Respect the cap on manual resume: start if a slot is free, else re-queue.
+    const start = this.maxDownloads === 0 || this.activeCount < this.maxDownloads;
+    it.status = start ? "downloading" : "queued";
+    if (start) {
+      this.startEngine(it);
+      this.ensurePoll();
+    }
     this.changed();
     void this.persist();
   }
@@ -315,7 +373,7 @@ export class DownloadQueue extends EventEmitter {
   togglePause(id: string): void {
     const it = this.items.get(id);
     if (!it) return;
-    if (it.status === "downloading") this.pause(id);
+    if (it.status === "downloading" || it.status === "queued") this.pause(id);
     else if (it.status === "paused") this.resume(id);
   }
 
@@ -332,16 +390,21 @@ export class DownloadQueue extends EventEmitter {
     deleteTorrentMeta(id);
     this.changed();
     void this.persist();
+    this.promote(); // a slot may have freed
     this.maybeStopPoll();
   }
 
   retry(id: string): void {
     const it = this.items.get(id);
     if (!it || it.status !== "failed") return;
-    it.status = "downloading";
     it.error = undefined;
-    this.startEngine(it);
-    this.ensurePoll();
+    // Respect the cap on retry: start if a slot is free, else queue.
+    const start = this.maxDownloads === 0 || this.activeCount < this.maxDownloads;
+    it.status = start ? "downloading" : "queued";
+    if (start) {
+      this.startEngine(it);
+      this.ensurePoll();
+    }
     this.changed();
     void this.persist();
   }
@@ -472,12 +535,22 @@ export class DownloadQueue extends EventEmitter {
   }
 
   restore(items: QueueItem[]): void {
+    let active = 0;
     for (const raw of items) {
       this.items.set(raw.id, raw);
-      if (raw.status === "downloading") this.startEngine(raw);
+      if (raw.status !== "downloading") continue;
+      if (this.maxDownloads === 0 || active < this.maxDownloads) {
+        this.startEngine(raw);
+        active++;
+      } else {
+        // Over the cap on boot → hold as queued (promoted as slots free).
+        raw.status = "queued";
+      }
     }
-    if (this.activeCount > 0) this.ensurePoll();
+    if (active > 0) this.ensurePoll();
     this.changed();
+    // Fill any remaining slots from persisted "queued" items.
+    this.promote();
   }
 
   restoreHistory(items: HistoryItem[]): void {

--- a/src/download/reconcile.ts
+++ b/src/download/reconcile.ts
@@ -8,7 +8,13 @@ export function reconcileQueue(items: QueueItem[]): QueueItem[] {
     seen.add(it.id);
     if (it.status === "completed") continue;
     const status =
-      it.status === "failed" ? "failed" : it.status === "paused" ? "paused" : "downloading";
+      it.status === "failed"
+        ? "failed"
+        : it.status === "paused"
+          ? "paused"
+          : it.status === "queued"
+            ? "queued"
+            : "downloading";
     out.push({ ...it, status, speed: 0, peers: 0, eta: undefined });
   }
   return out;

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -1,6 +1,9 @@
 import type { SourceId } from "../sources/types";
 
-export type DownloadStatus = "downloading" | "paused" | "completed" | "failed";
+// "queued" = waiting for a free download slot (see TORLINK_MAX_DOWNLOADS). Unlike
+// "paused" (an explicit user action) a queued item is started automatically as
+// soon as a slot frees.
+export type DownloadStatus = "downloading" | "queued" | "paused" | "completed" | "failed";
 
 export type SeedStatus = "seeding" | "paused" | "missing";
 


### PR DESCRIPTION
## Problem

On a bandwidth-limited seedbox, torlink downloads **every** queued torrent at once, so the pipe splits across all of them and each crawls — e.g. a torrent with 14 seeders stuck at ~50 KB/s while 5 downloads + 51 seeds share the line.

## What this adds

An optional concurrent-download cap:

- **`TORLINK_MAX_DOWNLOADS=N`** limits how many torrents actively download at once. Overflow waits as a new **`queued`** status and is promoted **oldest-first** automatically whenever a slot frees — a download completes, fails, is paused, or is cancelled.
- **Unset or `0` = unlimited** (unchanged default). Seeding is unaffected.
- `restore()` re-applies the cap on boot (starts up to N persisted downloads, holds the rest as `queued`); `pause`/`resume`/`retry`/`togglePause` all respect it.
- `maxDownloads` is a `DownloadQueue` constructor option that defaults to the env var, so it's unit-testable.

## Tests

Added `queue.concurrency.test.ts` covering: queue-beyond-cap + promote-on-slot-free, unlimited default, and cap-on-restore. `typecheck` clean; existing queue/reconcile tests pass.

## Notes

The seedbox use case: [bittorrented.com](https://bittorrented.com) provisions torlink on users' seedboxes and wants to cap concurrency so active downloads get full bandwidth. Fully backward-compatible (no behavior change unless the env var is set).