### PR TITLE
feat: stream in-progress torrents to a media player

### DIFF
--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -101,6 +101,7 @@ function makeStore(
     copyMagnet: noop,
     openDownloadFolder: noop,
     exportTorrent: noop,
+    playTorrent: noop,
     notice: null,
     setNotice: noop,
     quitAll: noop,

--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -1,5 +1,11 @@
 import { EventEmitter } from "node:events";
 import { describe, it, expect, vi, afterEach } from "vitest";
+import type { TorrentFile } from "webtorrent";
+
+// Build a minimal TorrentFile — pickBestFile only reads name and length.
+function file(name: string, length: number): TorrentFile {
+  return { name, path: name, length };
+}
 
 const constructorCalls: Record<string, unknown>[] = [];
 
@@ -83,5 +89,61 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     }
     expect(constructorCalls).toHaveLength(1);
     expect(constructorCalls[0]).not.toHaveProperty("natPmp", false);
+  });
+});
+
+describe("pickBestFile (stream target selection)", () => {
+  it("returns null for an empty file list", async () => {
+    const { pickBestFile } = await import("./engine");
+    expect(pickBestFile([])).toBeNull();
+  });
+
+  it("prefers the largest media file over a larger non-media file", async () => {
+    const { pickBestFile } = await import("./engine");
+    const picked = pickBestFile([
+      file("readme.txt", 500),
+      file("movie.mkv", 100),
+      file("bigger.iso", 9000), // largest overall, but not playable
+      file("feature.mp4", 200), // largest among media files
+    ]);
+    expect(picked?.name).toBe("feature.mp4");
+  });
+
+  it("falls back to the largest file when none are media", async () => {
+    const { pickBestFile } = await import("./engine");
+    const picked = pickBestFile([
+      file("small.bin", 10),
+      file("big.bin", 999),
+    ]);
+    expect(picked?.name).toBe("big.bin");
+  });
+
+  it("matches media extensions case-insensitively", async () => {
+    const { pickBestFile } = await import("./engine");
+    const picked = pickBestFile([file("notes.txt", 800), file("EPISODE.MKV", 100)]);
+    expect(picked?.name).toBe("EPISODE.MKV");
+  });
+});
+
+describe("TorrentEngine.getStreamUrl", () => {
+  it("returns null when the torrent has no metadata yet (no file list)", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    // Mocked add() yields a torrent with no `files` — a magnet pre-metadata.
+    engine.add(
+      "test-id",
+      "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+      "/downloads",
+      {},
+    );
+    await expect(engine.getStreamUrl("test-id")).resolves.toBeNull();
+    engine.destroy();
+  });
+
+  it("returns null for an unknown torrent id", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    await expect(engine.getStreamUrl("missing")).resolves.toBeNull();
+    engine.destroy();
   });
 });

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -1,4 +1,22 @@
-import WebTorrent, { type Torrent } from "webtorrent";
+import { extname } from "node:path";
+import WebTorrent, { type Torrent, type TorrentFile, type TorrentServer } from "webtorrent";
+
+const MEDIA_EXT = new Set([
+  ".mp4", ".mkv", ".avi", ".mov", ".webm", ".m4v", ".mpg", ".mpeg", ".flv",
+  ".wmv", ".m2ts", ".ts", ".mp3", ".flac", ".m4a", ".aac", ".ogg", ".opus", ".wav",
+]);
+
+// The largest media file in a multi-file torrent, else the largest file of any
+// kind. Exported for testing.
+export function pickBestFile(files: TorrentFile[]): TorrentFile | null {
+  const media = files.filter((f) => MEDIA_EXT.has(extname(f.name).toLowerCase()));
+  const pool = media.length > 0 ? media : files;
+  let best: TorrentFile | null = null;
+  for (const f of pool) {
+    if (!best || f.length > best.length) best = f;
+  }
+  return best;
+}
 
 export interface TorrentProgress {
   progress: number;
@@ -35,6 +53,10 @@ function message(e: unknown): string {
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
+  private streamServer: TorrentServer | null = null;
+  // Started lazily on first stream so an ordinary session never opens the port;
+  // resolves to the bound port and is reused thereafter.
+  private streamServerReady: Promise<number> | null = null;
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
@@ -110,6 +132,43 @@ export class TorrentEngine {
     return this.client?.torrentPort ?? null;
   }
 
+  // Loopback-only, so a partially-downloaded file is never exposed on the network.
+  private ensureStreamServer(): Promise<number> {
+    if (this.streamServerReady) return this.streamServerReady;
+    const client = this.ensureClient();
+    const instance = client.createServer();
+    this.streamServer = instance;
+    this.streamServerReady = new Promise<number>((resolve, reject) => {
+      const wanted = Number(process.env.TORLINK_STREAM_PORT) || 0;
+      instance.server.once("error", reject);
+      instance.server.listen(wanted, "127.0.0.1", () => {
+        const addr = instance.server.address();
+        if (addr && typeof addr === "object") resolve(addr.port);
+        else reject(new Error("stream server did not bind a port"));
+      });
+    });
+    return this.streamServerReady;
+  }
+
+  // Playable URL for a file in a (possibly still-downloading) torrent, or null
+  // before metadata arrives. Defaults to the largest media file.
+  async getStreamUrl(id: string, fileIndex?: number): Promise<string | null> {
+    const t = this.torrents.get(id);
+    const files = t?.files;
+    if (!files || files.length === 0) return null;
+    const file = fileIndex != null ? files[fileIndex] : pickBestFile(files);
+    if (!file) return null;
+    try {
+      const port = await this.ensureStreamServer();
+      // webtorrent's own `file.streamURL` is only a path, so build the absolute
+      // URL. The server matches on decodeURI(path.replace(/\\/g, "/")).
+      const path = encodeURI(file.path.replace(/\\/g, "/"));
+      return `http://127.0.0.1:${port}/webtorrent/${t.infoHash}/${path}`;
+    } catch {
+      return null;
+    }
+  }
+
   stats(id: string): TorrentProgress | null {
     const t = this.torrents.get(id);
     if (!t) return null;
@@ -151,6 +210,14 @@ export class TorrentEngine {
 
   destroy(): void {
     this.torrents.clear();
+    const server = this.streamServer;
+    this.streamServer = null;
+    this.streamServerReady = null;
+    if (server) {
+      try {
+        server.close();
+      } catch {}
+    }
     // Never block shutdown on webtorrent's async teardown: hand off the client
     // destroy to a later tick and let the OS reclaim sockets if we exit first.
     const client = this.client;

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -385,6 +385,10 @@ export class DownloadQueue extends EventEmitter {
     return exportTorrentMeta(it.id, it.name, it.dir);
   }
 
+  getStreamUrl(id: string, fileIndex?: number): Promise<string | null> {
+    return this.engine.getStreamUrl(id, fileIndex);
+  }
+
   cancel(id: string): void {
     if (!this.items.has(id)) return;
     this.engine.remove(id);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -11,6 +11,7 @@ import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
 import { readClipboard, writeClipboard } from "../util/clipboard";
 import { openFolder } from "../util/openFolder";
+import { playMedia } from "../util/playMedia";
 import { cleanText, formatBytes, truncate } from "../util/format";
 import {
   StoreContext,
@@ -339,6 +340,26 @@ export function App({
     [queue],
   );
 
+  const playTorrent = useCallback(
+    (input: { id: string; name: string }) => {
+      if (!queue) return;
+      void (async () => {
+        const url = await queue.getStreamUrl(input.id);
+        if (!url) {
+          setNotice(`Nothing to stream yet for ${truncate(cleanText(input.name), 32)}.`);
+          return;
+        }
+        const ok = await playMedia(url);
+        setNotice(
+          ok
+            ? `${ICON.play} Streaming ${truncate(cleanText(input.name), 40)}`
+            : `Couldn't launch a media player. Set TORLINK_MEDIA_PLAYER?`,
+        );
+      })();
+    },
+    [queue],
+  );
+
   const submitQuery = useCallback(
     (raw: string) => {
       const q = raw.trim();
@@ -422,6 +443,7 @@ export function App({
       copyMagnet,
       openDownloadFolder,
       exportTorrent,
+      playTorrent,
       notice,
       setNotice,
       quitAll,
@@ -451,6 +473,7 @@ export function App({
     copyMagnet,
     openDownloadFolder,
     exportTorrent,
+    playTorrent,
     notice,
     listRows,
     compact,

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -55,6 +55,7 @@ export function Downloads() {
     openDownloadFolder,
     setDownloadFocus,
     exportTorrent,
+    playTorrent,
   } = useStore();
   const active = useQueueItems(queue);
   const recent = useQueueHistory(queue);
@@ -77,6 +78,9 @@ export function Downloads() {
       } else if (input === "s") {
         const item = inActive ? active[clamped] : recent[recentCursor];
         if (item) exportTorrent({ id: item.id, name: item.name });
+      } else if (input === "v") {
+        const item = inActive ? active[clamped] : recent[recentCursor];
+        if (item) playTorrent({ id: item.id, name: item.name });
       } else if (inActive) {
         const it = active[clamped];
         if (!it) return;

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([134, 113, 77, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 30]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 31]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -44,6 +44,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "d", label: "Download again" },
       { keys: "e", label: "Open folder" },
       { keys: "s", label: "Export torrent file" },
+      { keys: "v", label: "Stream to a media player" },
     ],
   },
   {
@@ -69,6 +70,8 @@ const FOLDER: Hint = { keys: "e", label: "Folder" };
 
 const TORRENT: Hint = { keys: "s", label: "Export" };
 
+const PLAY: Hint = { keys: "v", label: "Play" };
+
 export function footerHints(
   region: Region,
   section: Section,
@@ -91,7 +94,7 @@ export function footerHints(
   }
   if (section === "downloads") {
     if (downloadFocus === "paused") {
-      return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+      return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, PLAY, FOLDER, TORRENT, SWITCH, ALWAYS];
     }
     if (downloadFocus === "failed") {
       return [{ keys: "f", label: "Retry" }, { keys: "c", label: "Remove" }, FOLDER, TORRENT, SWITCH, ALWAYS];
@@ -108,7 +111,7 @@ export function footerHints(
         ALWAYS,
       ];
     }
-    return [{ keys: "p", label: "Pause" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+    return [{ keys: "p", label: "Pause" }, { keys: "c", label: "Cancel" }, PLAY, FOLDER, TORRENT, SWITCH, ALWAYS];
   }
   return [
     NAVIGATE,

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -70,6 +70,8 @@ export interface Store {
   // Copies the cached .torrent metadata into the item's download folder and
   // reports the outcome through the notice line.
   exportTorrent: (input: { id: string; name: string }) => void;
+  // Streams the torrent's main file to a media player, even while downloading.
+  playTorrent: (input: { id: string; name: string }) => void;
 
   notice: string | null;
   setNotice: (s: string | null) => void;

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -162,6 +162,7 @@ export function makeTestStore(overrides: Partial<Store> = {}): Store {
     copyMagnet: noop,
     openDownloadFolder: noop,
     exportTorrent: noop,
+    playTorrent: noop,
     notice: null,
     setNotice: noop,
     quitAll: noop,

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -22,6 +22,7 @@ export const ICON = {
   up: "↑",
   peer: "•",
   pause: "⏸",
+  play: "▶",
 } as const;
 
 export const RULE = "#6b6577";

--- a/src/util/playMedia.ts
+++ b/src/util/playMedia.ts
@@ -1,0 +1,64 @@
+import { spawn } from "node:child_process";
+
+// A media player outlives its launch, so — unlike openFolder — spawn detached
+// and never kill it on a timer. Success means it didn't fail to spawn (ENOENT)
+// or exit non-zero within the grace window.
+function launch(cmd: string, args: string[]): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawn(cmd, args, { stdio: "ignore", detached: true });
+      let settled = false;
+      const done = (ok: boolean): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(ok);
+      };
+      // Still alive after the grace window: unref so playback survives quit.
+      const timer = setTimeout(() => {
+        proc.unref();
+        done(true);
+      }, 400);
+      timer.unref?.();
+      proc.on("error", () => done(false));
+      proc.on("exit", (code) => done(code === 0));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+// e.g. TORLINK_MEDIA_PLAYER="mpv --fullscreen"; the URL is appended last.
+function customPlayer(): string[] | null {
+  const raw = process.env.TORLINK_MEDIA_PLAYER?.trim();
+  if (!raw) return null;
+  const parts = raw.split(/\s+/);
+  return parts.length > 0 && parts[0] ? parts : null;
+}
+
+// Tried in order; mpv/vlc first, the OS URL handler last. Windows `start` needs
+// an empty title argument before the URL.
+function candidates(): [string, string[]][] {
+  if (process.platform === "darwin") {
+    return [["mpv", []], ["open", ["-a", "VLC"]], ["open", []]];
+  }
+  if (process.platform === "win32") {
+    return [["mpv", []], ["vlc", []], ["cmd", ["/c", "start", ""]]];
+  }
+  return [["mpv", []], ["vlc", []], ["xdg-open", []]];
+}
+
+// Open `url` in a media player. Never throws; false means nothing could be
+// launched and the caller should tell the user.
+export async function playMedia(url: string): Promise<boolean> {
+  if (!url) return false;
+  const custom = customPlayer();
+  if (custom) {
+    const [cmd, ...rest] = custom;
+    return launch(cmd as string, [...rest, url]);
+  }
+  for (const [cmd, args] of candidates()) {
+    if (await launch(cmd, [...args, url])) return true;
+  }
+  return false;
+}

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -1,10 +1,17 @@
 declare module "webtorrent" {
   import type { EventEmitter } from "node:events";
+  import type { Server } from "node:http";
 
   interface TorrentFile {
     name: string;
     path: string;
     length: number;
+  }
+
+  // What `client.createServer()` hands back.
+  interface TorrentServer {
+    server: Server;
+    close(cb?: () => void): void;
   }
 
   interface Torrent extends EventEmitter {
@@ -64,9 +71,10 @@ declare module "webtorrent" {
     ): Torrent;
     get(torrentId: string): Torrent | null;
     remove(torrentId: string, cb?: (err?: Error) => void): void;
+    createServer(opts?: { hostname?: string; pathname?: string }): TorrentServer;
     destroy(cb?: (err?: Error) => void): void;
   }
 
   export default WebTorrent;
-  export type { Torrent, TorrentFile };
+  export type { Torrent, TorrentFile, TorrentServer };
 }


### PR DESCRIPTION
Adds the ability to play a torrent's media in a player while it is still downloading, instead of only after it finishes.

## Usage
Press `v` on a download to open its main file in a media player. It streams from the start and buffers pieces on demand as you watch. Seeking far ahead into not-yet-downloaded data will stall until those pieces arrive.

Player is chosen in this order: $TORLINK_MEDIA_PLAYER (e.g. "mpv --fullscreen"), then mpv/vlc on PATH, then the OS URL handler.

## How it works
- TorrentEngine.getStreamUrl serves files through webtorrent's own on-demand streaming server (client.createServer), which prioritizes the pieces each range request needs. The server is bound to 127.0.0.1 only, so partial files are never exposed on the network. TORLINK_STREAM_PORT overrides the port; the default is OS-assigned.
- Multi-file torrents auto-pick the largest media file, so there is no new file-picker UI to maintain.
- The player is spawned detached so playback outlives the TUI.

## Testing
- Unit tests for file selection and getStreamUrl gating (returns null before metadata / for unknown ids).
- Verified end to end by seeding a local file, serving it, and confirming a 200 full-body fetch and a 206 range response.
- Typecheck clean, full suite passes (258 tests).