### PR TITLE
fix(ui): let Tab/Down-arrow enter browse from the splash search box

### DIFF
--- a/src/ui/components/TextField.tsx
+++ b/src/ui/components/TextField.tsx
@@ -92,11 +92,11 @@ export function TextField({
 
   useInput(
     (input, key) => {
-      if (key.downArrow) {
+      if (key.downArrow || key.tab) {
         onExitDown?.();
         return;
       }
-      if (key.upArrow || key.tab || (key.ctrl && input === "c")) return;
+      if (key.upArrow || (key.ctrl && input === "c")) return;
 
       if (key.return) {
         onSubmit?.(value);

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -54,6 +54,7 @@ export function Splash({ updateVersion }: { updateVersion?: string | null } = {}
           editing
           placeholder="Search or paste a magnet link…"
           onSubmit={submitQuery}
+          onExitDown={() => submitQuery("")}
         />
       </Box>
       <Box marginTop={1}>
@@ -61,8 +62,7 @@ export function Splash({ updateVersion }: { updateVersion?: string | null } = {}
           <Text color={COLOR.alt}>↵</Text>
           <Text dimColor> search</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
-          <Text dimColor>empty </Text>
-          <Text color={COLOR.alt}>↵</Text>
+          <Text color={COLOR.alt}>⇥</Text>
           <Text dimColor> browse</Text>
           <Text dimColor>{`  ${ICON.dot}  `}</Text>
           <Text color={COLOR.alt}>^c</Text>


### PR DESCRIPTION
## Problem

On the splash screen, the search box only reacts to Enter (query ↵ searches, empty ↵ browses). Tab and the arrow keys are silently swallowed by the focused text field, so there's no visible way to "move down" out of the search box — which is exactly what the layout invites, and Tab is the conventional key for it. Easy to read as "keyboard navigation is broken" (this is how it was reported to me by a user).

## Change (4 lines)

- **TextField**: treat Tab like Down-arrow — fire `onExitDown` instead of swallowing it. This also makes Tab move from the in-app search bar down into the results list, consistent with Tab's "switch pane" role elsewhere.
- **Splash**: pass `onExitDown={() => submitQuery("")}` to the search bar, so Tab or ↓ enters browse mode even with text typed in the box. Empty-Enter still works exactly as before.
- Splash hint row now advertises it: `↵ search · ⇥ browse · ^c quit`.

## Testing

- `pnpm typecheck` clean, `pnpm test` 252/252 passing.
- Manually drove the TUI in tmux: Tab and ↓ from the splash (with and without text typed) open browse; ↑/↓/j/k selection, `d`, and pane-switch Tab all behave as before once inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JDwVT9EmvBXvDRRSPJafyS
