### PR TITLE
feat(serve): POST /control to manage torrents (pause/resume, seeding, remove/delete)

### DIFF
--- a/src/daemon/seed-reaper.ts
+++ b/src/daemon/seed-reaper.ts
@@ -7,9 +7,11 @@
 // The clock is the download's completion time (history.completedAt), not when
 // this process started, so a restart doesn't reset every torrent's timer.
 
-import { rm } from "node:fs/promises";
-import path from "node:path";
 import type { DownloadQueue } from "../download/queue";
+import { deleteSeedData } from "../download/delete-data";
+
+// Re-exported for backwards compatibility (the reaper's original home for it).
+export { deleteSeedData } from "../download/delete-data";
 
 const DEFAULT_CHECK_MS = 30_000;
 
@@ -36,17 +38,6 @@ export function dueSeeds(queue: ReapableQueue, seedTimeMs: number, now: number):
     if (now - since >= seedTimeMs) out.push({ id: s.id, name: s.name, dir: s.dir });
   }
   return out;
-}
-
-// Best-effort delete of a torrent's on-disk data: only the torrent's own entry
-// directly under its download dir (a file, or the folder named after it). Never
-// walks outside that dir, never throws.
-export async function deleteSeedData(dir: string, name: string): Promise<string | null> {
-  const base = path.basename(name.trim());
-  if (!base || base === "." || base === "..") return null;
-  const target = path.join(dir, base);
-  await rm(target, { recursive: true, force: true }).catch(() => {});
-  return target;
 }
 
 export interface SeedReaperOptions {

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { handleApi, isAuthorized, extractMagnet } from "./serve";
+import { handleApi, isAuthorized, extractMagnet, parseControl, applyControl } from "./serve";
 import type { Runtime } from "./runtime";
 
 const HASH = "abcdef0123456789abcdef0123456789abcdef01";
@@ -101,5 +101,93 @@ describe("handleApi", () => {
   it("404s an unknown route", async () => {
     const res = await handleApi(runtime, null, "GET", "/nope", undefined, "");
     expect(res.status).toBe(404);
+  });
+
+  it("400s POST /control with a malformed body", async () => {
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"x"}`);
+    expect(res.status).toBe(400);
+  });
+
+  it("400s POST /control with an unknown action", async () => {
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"boom"}`);
+    expect(res.status).toBe(400);
+    expect(String(res.body.error)).toContain("unknown action");
+  });
+
+  it("404s POST /control for an unknown torrent", async () => {
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"pause"}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("pauses a known download on POST /control", async () => {
+    const pause = vi.fn();
+    runtime.queue = { has: (id: string) => id === HASH, pause } as unknown as Runtime["queue"];
+    const res = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"pause"}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, action: "pause" });
+    expect(pause).toHaveBeenCalledWith(HASH);
+  });
+});
+
+describe("parseControl", () => {
+  it("reads id + action from JSON", () => {
+    expect(parseControl(`{"id":"abc","action":"pause"}`)).toEqual({ id: "abc", action: "pause", deleteFiles: false });
+  });
+  it("reads the deleteFiles flag", () => {
+    expect(parseControl(`{"id":"abc","action":"delete","deleteFiles":true}`)).toEqual({
+      id: "abc",
+      action: "delete",
+      deleteFiles: true,
+    });
+  });
+  it("returns null when id or action is missing/blank or the body isn't JSON", () => {
+    expect(parseControl(`{"id":"abc"}`)).toBeNull();
+    expect(parseControl(`{"action":"pause"}`)).toBeNull();
+    expect(parseControl(`{"id":"  ","action":"pause"}`)).toBeNull();
+    expect(parseControl(`pause abc`)).toBeNull();
+    expect(parseControl("")).toBeNull();
+  });
+});
+
+describe("applyControl", () => {
+  const mkRuntime = (queue: Partial<Record<string, unknown>>): Runtime =>
+    ({ queue: queue as unknown as Runtime["queue"], downloadDir: "/tmp" });
+
+  it("resumes a paused download", async () => {
+    const resume = vi.fn();
+    const rt = mkRuntime({ has: (id: string) => id === "x", resume });
+    expect(await applyControl(rt, { id: "x", action: "resume", deleteFiles: false })).toBe("ok");
+    expect(resume).toHaveBeenCalledWith("x");
+  });
+
+  it("stops seeding but keeps files", async () => {
+    const stopSeeding = vi.fn();
+    const rt = mkRuntime({ getSeed: (id: string) => (id === "s" ? { id } : undefined), stopSeeding });
+    expect(await applyControl(rt, { id: "s", action: "stop-seed", deleteFiles: false })).toBe("ok");
+    expect(stopSeeding).toHaveBeenCalledWith("s");
+  });
+
+  it("starts seeding from a history entry", async () => {
+    const startSeeding = vi.fn();
+    const hist = { id: "h", name: "H", magnet: "m", dir: "/d", sizeBytes: 1, completedAt: 0 };
+    const rt = mkRuntime({ getHistory: () => [hist], startSeeding });
+    expect(await applyControl(rt, { id: "h", action: "start-seed", deleteFiles: false })).toBe("ok");
+    expect(startSeeding).toHaveBeenCalledWith(hist);
+  });
+
+  it("delete forces deleteFiles:true; remove keeps files", async () => {
+    const remove = vi.fn().mockResolvedValue(true);
+    const rt = mkRuntime({ remove });
+    expect(await applyControl(rt, { id: "z", action: "delete", deleteFiles: false })).toBe("ok");
+    expect(remove).toHaveBeenCalledWith("z", { deleteFiles: true });
+    remove.mockClear();
+    await applyControl(rt, { id: "z", action: "remove", deleteFiles: false });
+    expect(remove).toHaveBeenCalledWith("z", { deleteFiles: false });
+  });
+
+  it("reports not-found when remove finds nothing and unknown-action otherwise", async () => {
+    const rt = mkRuntime({ remove: vi.fn().mockResolvedValue(false) });
+    expect(await applyControl(rt, { id: "z", action: "remove", deleteFiles: false })).toBe("not-found");
+    expect(await applyControl(mkRuntime({}), { id: "z", action: "nope", deleteFiles: false })).toBe("unknown-action");
   });
 });

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -53,6 +53,81 @@ export function extractMagnet(bodyText: string): string | null {
   return raw;
 }
 
+// Control actions the headless API accepts (POST /control). A seedbox web app
+// drives per-torrent buttons through these instead of the interactive keymap.
+export const CONTROL_ACTIONS = [
+  "pause", // pause an active/queued download
+  "resume", // resume a paused download
+  "start-seed", // (re)start seeding a finished torrent
+  "stop-seed", // stop seeding but keep the files
+  "remove", // forget the torrent, keep files on disk
+  "delete", // forget the torrent AND delete its files
+] as const;
+export type ControlAction = (typeof CONTROL_ACTIONS)[number];
+
+export interface ControlRequest {
+  id: string;
+  action: string;
+  deleteFiles: boolean;
+}
+
+// Parse a control request body: JSON { id, action, deleteFiles? }. Returns null
+// for anything missing the two required string fields; the action string itself
+// is validated later so an unknown action gets a precise error.
+export function parseControl(bodyText: string): ControlRequest | null {
+  const raw = bodyText.trim();
+  if (!raw.startsWith("{")) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const id = typeof obj.id === "string" ? obj.id.trim() : "";
+  const action = typeof obj.action === "string" ? obj.action.trim() : "";
+  if (!id || !action) return null;
+  return { id, action, deleteFiles: obj.deleteFiles === true };
+}
+
+export type ControlOutcome = "ok" | "not-found" | "unknown-action";
+
+// Apply a parsed control request to the queue. Pure over the runtime so it's
+// unit-testable with a fake queue.
+export async function applyControl(
+  runtime: Runtime,
+  req: ControlRequest,
+): Promise<ControlOutcome> {
+  const q = runtime.queue;
+  const { id, action, deleteFiles } = req;
+  switch (action as ControlAction) {
+    case "pause":
+      if (!q.has(id)) return "not-found";
+      q.pause(id);
+      return "ok";
+    case "resume":
+      if (!q.has(id)) return "not-found";
+      q.resume(id);
+      return "ok";
+    case "stop-seed":
+      if (!q.getSeed(id)) return "not-found";
+      q.stopSeeding(id);
+      return "ok";
+    case "start-seed": {
+      const h = q.getHistory().find((x) => x.id === id);
+      if (!h) return "not-found";
+      q.startSeeding(h);
+      return "ok";
+    }
+    case "remove":
+    case "delete": {
+      const found = await q.remove(id, { deleteFiles: action === "delete" || deleteFiles });
+      return found ? "ok" : "not-found";
+    }
+    default:
+      return "unknown-action";
+  }
+}
+
 function statusPayload(runtime: Runtime): Record<string, unknown> {
   const downloads = runtime.queue.getItems().map((it) => ({
     id: it.id,
@@ -96,6 +171,16 @@ export async function handleApi(
     const outcome = await addInput(runtime, magnet);
     if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
     return { status: 200, body: { ok: true, outcome } };
+  }
+  if (method === "POST" && urlPath === "/control") {
+    const req = parseControl(bodyText);
+    if (!req) return { status: 400, body: { error: "missing or invalid { id, action }" } };
+    const outcome = await applyControl(runtime, req);
+    if (outcome === "unknown-action") {
+      return { status: 400, body: { error: `unknown action: ${req.action}` } };
+    }
+    if (outcome === "not-found") return { status: 404, body: { error: "no such torrent" } };
+    return { status: 200, body: { ok: true, id: req.id, action: req.action } };
   }
   return { status: 404, body: { error: "not found" } };
 }

--- a/src/download/delete-data.ts
+++ b/src/download/delete-data.ts
@@ -1,0 +1,15 @@
+// Best-effort delete of a torrent's on-disk data: only the torrent's own entry
+// directly under its download dir (a file, or the folder named after it). Never
+// walks outside that dir, never throws. Shared by the seed reaper (auto-purge
+// after the seed timer) and the headless control API (manual delete).
+
+import { rm } from "node:fs/promises";
+import path from "node:path";
+
+export async function deleteSeedData(dir: string, name: string): Promise<string | null> {
+  const base = path.basename(name.trim());
+  if (!base || base === "." || base === "..") return null;
+  const target = path.join(dir, base);
+  await rm(target, { recursive: true, force: true }).catch(() => {});
+  return target;
+}

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -13,6 +13,7 @@ import {
   type SeedRecord,
 } from "./persist";
 import { saveHistory, saveHistorySync, type HistoryItem } from "./history";
+import { deleteSeedData } from "./delete-data";
 import type { QueueItem, SeedItem } from "./types";
 import type { SourceId } from "../sources/types";
 
@@ -394,6 +395,43 @@ export class DownloadQueue extends EventEmitter {
     void this.persist();
     this.promote(); // a slot may have freed
     this.maybeStopPoll();
+  }
+
+  // Remove a torrent from the daemon entirely, wherever it lives (active
+  // download, seed, or just history), and optionally delete its on-disk data.
+  // Unlike cancel() (downloads only) or stopSeeding() (which leaves a paused
+  // seed record behind), this forgets the torrent completely. Returns false if
+  // the id is unknown.
+  async remove(id: string, opts: { deleteFiles?: boolean } = {}): Promise<boolean> {
+    const it = this.items.get(id);
+    const seed = this.seeds.get(id);
+    const hist = this.history.find((h) => h.id === id);
+    if (!it && !seed && !hist) return false;
+
+    const dir = it?.dir ?? seed?.dir ?? hist?.dir;
+    const name = it?.name ?? seed?.name ?? hist?.name;
+
+    // Tear down any live engine handle + in-memory record.
+    if (it || seed) this.engine.remove(id);
+    if (it) this.items.delete(id);
+    if (seed) {
+      this.seeds.delete(id);
+      this.strayHits.delete(id);
+      this.seedStartedAt.delete(id);
+    }
+    deleteTorrentMeta(id);
+    this.removeHistory(id); // persists history
+
+    if (opts.deleteFiles && dir && name) {
+      await deleteSeedData(dir, name);
+    }
+
+    this.changed();
+    void this.persist();
+    void this.persistSeeds();
+    if (it) this.promote(); // a download slot may have freed
+    this.maybeStopPoll();
+    return true;
   }
 
   retry(id: string): void {


### PR DESCRIPTION
## Why

The headless HTTP API (`torlnk serve`) can **add** torrents and **report** status, but there's no way to **manage** them over HTTP — a seedbox web UI has no equivalent of the interactive keymap (pause, resume, stop/start seeding, remove). This adds that missing doorway.

## What

New authenticated endpoint:

```
POST /control   { "id": "<infohash>", "action": "<action>", "deleteFiles?": true }
```

| action | effect |
|---|---|
| `pause` | pause an active/queued download |
| `resume` | resume a paused download |
| `start-seed` | (re)start seeding a finished torrent (from history) |
| `stop-seed` | stop seeding but **keep** the files |
| `remove` | forget the torrent, keep files on disk |
| `delete` | forget the torrent **and** delete its files |

Responses mirror `/add`: `401` unauthorized, `400` malformed / unknown action, `404` no such torrent, `200 { ok, id, action }`.

## Implementation

- **`serve.ts`** — `parseControl()` + `applyControl()` are pure (no `node:http`), wired to existing queue methods, unit-tested like `extractMagnet`/`handleApi`.
- **`queue.ts`** — new `remove(id, { deleteFiles })` that forgets a torrent wherever it lives (active download, seed, or history) and optionally deletes its on-disk data. Existing `cancel()` (downloads only) and `stopSeeding()` (leaves a paused seed) didn't cover full removal.
- **`delete-data.ts`** — extracted `deleteSeedData` (previously in `seed-reaper.ts`) so the seed reaper and the new delete path share it; re-exported from `seed-reaper.ts` for compatibility. No import cycle.

## Tests

Added `parseControl`, `applyControl` (all actions, not-found / unknown-action), and `POST /control` routing tests. Full serve + queue suites pass locally.