### PR TITLE
Fixes #109 (and resolves duplicate reports like #22 where the app remains stuck indefinitely on the `"Starting torlink"` spinner after an unexpected crash, interrupted download, or disk error).

### DIFF
--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -84,4 +84,28 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     expect(constructorCalls).toHaveLength(1);
     expect(constructorCalls[0]).not.toHaveProperty("natPmp", false);
   });
+
+  it("stats(id) ignores getter errors and returns safe defaults", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    const fakeTorrent = new EventEmitter();
+    Object.defineProperty(fakeTorrent, "progress", {
+      get() {
+        throw new Error("Metadata not ready");
+      },
+    });
+    Object.defineProperty(fakeTorrent, "length", {
+      get() {
+        throw new Error("Metadata not ready");
+      },
+    });
+    // Inject fakeTorrent directly into private torrents map
+    (engine as unknown as { torrents: Map<string, unknown> }).torrents.set("bad-id", fakeTorrent);
+
+    const result = engine.stats("bad-id");
+    expect(result).not.toBeNull();
+    expect(result?.progress).toBe(0);
+    expect(result?.total).toBe(0);
+    engine.destroy();
+  });
 });

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -28,7 +28,7 @@ export interface AddHandlers {
   onError?: (message: string) => void;
 }
 
-function message(e: unknown): string {
+export function message(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
@@ -116,26 +116,38 @@ export class TorrentEngine {
 
     let progress = 0;
     let downloaded = 0;
+    let total = 0;
+    let speed = 0;
+    let uploadSpeed = 0;
+    let uploaded = 0;
+    let peers = 0;
     let timeRemaining = Infinity;
+    let name = "";
 
     try {
-      progress = t.progress;
-      downloaded = t.downloaded;
+      progress = t.progress || 0;
+      downloaded = t.downloaded || 0;
+      total = t.length || 0;
+      speed = t.downloadSpeed || 0;
+      uploadSpeed = t.uploadSpeed || 0;
+      uploaded = t.uploaded || 0;
+      peers = t.numPeers || 0;
       timeRemaining = t.timeRemaining;
+      name = t.name || "";
     } catch (err) {
-      // Ignore webtorrent getter errors that occur before metadata is fully parsed
+      // Ignore webtorrent getter errors that occur before metadata is fully parsed or on error
     }
 
     return {
       progress,
       downloaded,
-      total: t.length || 0,
-      speed: t.downloadSpeed || 0,
-      uploadSpeed: t.uploadSpeed || 0,
-      uploaded: t.uploaded || 0,
-      peers: t.numPeers || 0,
+      total,
+      speed,
+      uploadSpeed,
+      uploaded,
+      peers,
       timeRemaining,
-      name: t.name || '',
+      name,
     };
   }
 

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -99,10 +99,11 @@ describe("DownloadQueue error resilience on boot", () => {
         {
           id: "err1",
           name: "Broken Download",
-          source: "magnet",
+          source: undefined,
           magnet: "magnet:?xt=urn:btih:1111111111111111111111111111111111111111",
           dir: "/downloads",
           status: "downloading",
+          progress: 0,
           totalBytes: 100,
           downloadedBytes: 0,
           speed: 0,
@@ -112,8 +113,9 @@ describe("DownloadQueue error resilience on boot", () => {
       ])
     ).not.toThrow();
 
-    expect(q.items.get("err1")?.status).toBe("failed");
-    expect(q.items.get("err1")?.error).toContain("Disk error during add");
+    const errItem = q.getItems().find((i) => i.id === "err1");
+    expect(errItem?.status).toBe("failed");
+    expect(errItem?.error).toContain("Disk error during add");
     q.suspend();
   });
 

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -84,3 +84,52 @@ describe("strayDownload (missing-file safety-net)", () => {
     expect(strayDownload({ total: 0, progress: 0, speed: 0 })).toBe(false);
   });
 });
+
+describe("DownloadQueue error resilience on boot", () => {
+  it("restore() marks item failed if engine.add throws synchronously", () => {
+    const q = new DownloadQueue();
+    // Spy on internal engine to force synchronous throw when add is called
+    const fakeEngine = (q as unknown as { engine: { add: () => void } }).engine;
+    fakeEngine.add = () => {
+      throw new Error("Disk error during add");
+    };
+
+    expect(() =>
+      q.restore([
+        {
+          id: "err1",
+          name: "Broken Download",
+          source: "magnet",
+          magnet: "magnet:?xt=urn:btih:1111111111111111111111111111111111111111",
+          dir: "/downloads",
+          status: "downloading",
+          totalBytes: 100,
+          downloadedBytes: 0,
+          speed: 0,
+          peers: 0,
+          addedAt: Date.now(),
+        },
+      ])
+    ).not.toThrow();
+
+    expect(q.items.get("err1")?.status).toBe("failed");
+    expect(q.items.get("err1")?.error).toContain("Disk error during add");
+    q.suspend();
+  });
+
+  it("restoreSeeds() marks seed paused if engine.add throws synchronously", () => {
+    const q = new DownloadQueue();
+    q.restoreHistory([h({ id: "h-broken" })]);
+    const fakeEngine = (q as unknown as { engine: { add: () => void } }).engine;
+    fakeEngine.add = () => {
+      throw new Error("Chunk store init failed");
+    };
+
+    expect(() =>
+      q.restoreSeeds([{ id: "h-broken", status: "seeding" }])
+    ).not.toThrow();
+
+    expect(q.getSeed("h-broken")?.status).toBe("paused");
+    q.suspend();
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { TorrentEngine, type AddHandlers } from "./engine";
+import { TorrentEngine, message, type AddHandlers } from "./engine";
 import {
   saveQueue,
   saveQueueSync,
@@ -145,7 +145,14 @@ export class DownloadQueue extends EventEmitter {
   }
 
   private startEngine(item: QueueItem): void {
-    this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+    try {
+      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+    } catch (e) {
+      item.status = "failed";
+      item.error = message(e);
+      item.speed = 0;
+      item.peers = 0;
+    }
   }
 
   /**
@@ -502,7 +509,14 @@ export class DownloadQueue extends EventEmitter {
     // Seed from the stored .torrent metadata when we have it (verifies the local
     // file immediately, no swarm needed); fall back to the magnet otherwise.
     const source = torrentMetaExists(h.id) ? torrentMetaPath(h.id) : h.magnet;
-    this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers);
+    try {
+      this.engine.add(h.id, source, h.dir, this.engineHandlers(h.id), this.trackers);
+    } catch (e) {
+      this.seeds.set(h.id, { ...base, status: "paused" });
+      this.changed();
+      void this.persistSeeds();
+      return;
+    }
     this.ensurePoll();
     this.changed();
     void this.persistSeeds();
@@ -531,12 +545,16 @@ export class DownloadQueue extends EventEmitter {
 
   restoreSeeds(records: SeedRecord[]): void {
     for (const r of records) {
-      const h = this.history.find((x) => x.id === r.id);
-      if (!h) continue;
-      // Respect the persisted choice: resume seeders, but leave a paused seed
-      // paused (and visibly so) instead of auto-starting it.
-      if (r.status === "seeding") this.startSeeding(h);
-      else this.restorePaused(h);
+      try {
+        const h = this.history.find((x) => x.id === r.id);
+        if (!h) continue;
+        // Respect the persisted choice: resume seeders, but leave a paused seed
+        // paused (and visibly so) instead of auto-starting it.
+        if (r.status === "seeding") this.startSeeding(h);
+        else this.restorePaused(h);
+      } catch (e) {
+        // If restoring a specific seed fails, ignore and proceed to the next record
+      }
     }
   }
 
@@ -577,20 +595,26 @@ export class DownloadQueue extends EventEmitter {
   restore(items: QueueItem[]): void {
     let active = 0;
     for (const raw of items) {
-      this.items.set(raw.id, raw);
-      if (raw.status !== "downloading") continue;
-      if (this.maxDownloads === 0 || active < this.maxDownloads) {
-        this.startEngine(raw);
-        active++;
-      } else {
-        // Over the cap on boot → hold as queued (promoted as slots free).
-        raw.status = "queued";
+      try {
+        this.items.set(raw.id, raw);
+        if (raw.status !== "downloading") continue;
+        if (this.maxDownloads === 0 || active < this.maxDownloads) {
+          this.startEngine(raw);
+          active++;
+        } else {
+          // Over the cap on boot → hold as queued (promoted as slots free).
+          raw.status = "queued";
+        }
+      } catch (e) {
+        // Ignore corrupted items during restore
       }
     }
     if (active > 0) this.ensurePoll();
     this.changed();
     // Fill any remaining slots from persisted "queued" items.
-    this.promote();
+    try {
+      this.promote();
+    } catch {}
   }
 
   restoreHistory(items: HistoryItem[]): void {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Text, useApp, useInput, useStdout, useStdin } from "ink";
 import { promises as fs } from "node:fs";
-import { loadConfig, saveConfig, type Config } from "../config/config";
+import { loadConfig, saveConfig, defaultConfig, type Config } from "../config/config";
 import { normalizeDownloadDir } from "../config/folder";
 import { DownloadQueue } from "../download/queue";
 import { loadQueue, loadSeeds } from "../download/persist";
@@ -108,33 +108,46 @@ export function App({
     booting.current = true;
     let alive = true;
     void (async () => {
-      const cfg = await loadConfig();
+      let cfg: Config;
+      try {
+        cfg = await loadConfig();
+      } catch {
+        cfg = { ...defaultConfig, trackers: [] };
+      }
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
-      q.restore(reconcileQueue(await loadQueue()));
-      q.restoreHistory(await loadHistory());
-      q.restoreSeeds(await loadSeeds());
+      try {
+        q.restore(reconcileQueue(await loadQueue()));
+      } catch {}
+      try {
+        q.restoreHistory(await loadHistory());
+      } catch {}
+      try {
+        q.restoreSeeds(await loadSeeds());
+      } catch {}
       if (!alive) {
         q.suspend();
         return;
       }
       setConfigState(cfg);
       setQueue(q);
-      const launch = initialMagnet
-        ? parseInput(initialMagnet)
-        : initialTorrent
-          ? await magnetFromTorrentFile(initialTorrent)
-          : null;
-      if (launch) {
-        await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
-        q.add(
-          { id: launch.infoHash, name: launch.name, magnet: launch.magnet },
-          cfg.downloadDir,
-        );
-        setView("browser");
-        setSection("downloads");
-        setRegion("content");
-      }
+      try {
+        const launch = initialMagnet
+          ? parseInput(initialMagnet)
+          : initialTorrent
+            ? await magnetFromTorrentFile(initialTorrent)
+            : null;
+        if (launch) {
+          await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
+          q.add(
+            { id: launch.infoHash, name: launch.name, magnet: launch.magnet },
+            cfg.downloadDir,
+          );
+          setView("browser");
+          setSection("downloads");
+          setRegion("content");
+        }
+      } catch {}
     })();
     return () => {
       alive = false;


### PR DESCRIPTION
## What and why

<!-- What does this change do, and why? The diff shows the what; tell us the why. -->
Fixes #109 (and resolves duplicate reports like #22 where the app remains stuck indefinitely on the `"Starting torlink"` spinner after an unexpected crash, interrupted download, or disk error).

### Why
When `torlink` boots, `src/ui/App.tsx` initializes the `Store` inside an async `useEffect` sequence:
`loadConfig()` -> `restore(queue)` -> `restoreHistory(history)` -> `restoreSeeds(seeds)` -> `setConfigState(cfg)` -> `setQueue(q)`.
If any state file is corrupt, or if an item in `restore()` / `restoreSeeds()` triggers a synchronous exception when calling `webtorrent` / `client.add(...)` (due to locked files, chunk store errors, or synchronous EADDRINUSE/PMP failures), the function throws and aborts prematurely. Because there was no error boundary or fallback around those steps, `setConfigState` and `setQueue` were never reached, leaving `store` permanently `null` and locking the UI on `<Spinner label="Starting torlink" />`.

Furthermore, calling `engine.stats(id)` before metadata completes or when storage has errored could throw getter exceptions on `webtorrent` properties (`t.length`, `t.downloadSpeed`, `t.progress`), disrupting queue ticks.

### What
1. **App Boot Resilience (`src/ui/App.tsx`)**: Wrapped `loadConfig()`, `q.restore()`, `q.restoreHistory()`, and `q.restoreSeeds()` in individual defensive `try/catch` blocks with fallback to default config and clean queues so `setConfigState` and `setQueue` are guaranteed to run.
2. **DownloadQueue Error Handling (`src/download/queue.ts`)**: Wrapped `engine.add(...)` inside `startEngine(...)` and `startSeeding(...)` with `try/catch` blocks. If an engine error occurs during queue or seed restoration, downloads cleanly transition to `status: "failed"` (displaying their error message) and seeds transition to `status: "paused"`, keeping the rest of the application stable.
3. **Safe Engine Stats Getters (`src/download/engine.ts`)**: Protected all property/getter accesses (`progress`, `length`, `downloadSpeed`, `uploadSpeed`, `numPeers`, etc.) inside `try/catch` in `stats(id)` to return safe default values whenever getters throw.
4. **Automated Verification (`src/download/queue.test.ts` & `src/download/engine.test.ts`)**: Added unit tests specifically verifying that `restore()`, `restoreSeeds()`, and `stats()` gracefully catch synchronous engine exceptions without throwing.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
