### PR TITLE
feat(sources): add E-Books and Audiobooks categories

### DIFF
--- a/src/sources/ebooks.test.ts
+++ b/src/sources/ebooks.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { sourcesByGroup, SOURCES } from "./registry";
+import { CATEGORIES } from "../ui/store";
+import { sourceStyle } from "../ui/theme";
+
+describe("E-Books & Audiobooks Categories Integration", () => {
+  it("enforces category ordering: E-Books before Audiobooks in sourcesByGroup", () => {
+    const groups = sourcesByGroup().map((g) => g.group);
+    expect(groups).toEqual(["Games", "Movies", "TV", "Anime", "E-Books", "Audiobooks"]);
+  });
+
+  it("enforces sidebar CATEGORIES sequence: E-Books before Audiobooks", () => {
+    const keys = CATEGORIES.map((c) => c.key);
+    expect(keys).toEqual(["all", "games", "movies", "tv", "anime", "ebooks", "audiobooks"]);
+
+    const ebookIdx = keys.indexOf("ebooks");
+    const audioIdx = keys.indexOf("audiobooks");
+    expect(ebookIdx).toBeGreaterThan(-1);
+    expect(audioIdx).toBeGreaterThan(-1);
+    expect(ebookIdx).toBeLessThan(audioIdx);
+  });
+
+  it("maps filtered Nyaa Literature, TPB, and 1337x sources to E-Books and Audiobooks groups", () => {
+    const groups = sourcesByGroup();
+    const ebookGroup = groups.find((g) => g.group === "E-Books");
+    const audioGroup = groups.find((g) => g.group === "Audiobooks");
+
+    const ebookSourceIds = ebookGroup?.sources.map((s) => s.id) ?? [];
+    const audioSourceIds = audioGroup?.sources.map((s) => s.id) ?? [];
+
+    expect(ebookSourceIds).toContain("tpb-ebooks");
+    expect(ebookSourceIds).toContain("x1337-ebooks");
+    expect(ebookSourceIds).toContain("nyaa-ebooks");
+
+    expect(audioSourceIds).toContain("tpb-audiobooks");
+    expect(audioSourceIds).toContain("x1337-audiobooks");
+  });
+
+  it("provides valid badge styles for all original indexer source IDs", () => {
+    expect(sourceStyle("tpb-ebooks").tag).toBe("TPB");
+    expect(sourceStyle("x1337-ebooks").tag).toBe("1337");
+    expect(sourceStyle("nyaa-ebooks").tag).toBe("NYAA");
+    expect(sourceStyle("tpb-audiobooks").tag).toBe("TPB");
+    expect(sourceStyle("x1337-audiobooks").tag).toBe("1337");
+    expect(sourceStyle("bittorrented").tag).toBe("BT");
+  });
+});

--- a/src/sources/nyaa.ts
+++ b/src/sources/nyaa.ts
@@ -2,16 +2,22 @@ import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
 import { buildMagnet } from "./magnet";
 import { unescapeEntities } from "./rss";
 import { parseSize } from "../util/format";
-import type { SearchOptions, Source, TorrentResult } from "./types";
+import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 const BASE = "https://nyaa.si/";
+const AUDIO_FILTER = /\b(mp3|flac|aac|lossless|ost|soundtrack|drama cd|audiobook|audiobooks)\b/i;
 
 function tag(item: string, name: string): string {
   return item.match(new RegExp(`<${name}>(?:<!\\[CDATA\\[)?(.*?)(?:\\]\\]>)?</${name}>`, "s"))?.[1]?.trim() ?? "";
 }
 
-async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
-  const params = new URLSearchParams({ page: "rss", q: query.trim(), c: "0_0", f: "0" });
+async function search(
+  query: string,
+  cat = "0_0",
+  sourceId: SourceId = "nyaa",
+  opts: SearchOptions = {},
+): Promise<TorrentResult[]> {
+  const params = new URLSearchParams({ page: "rss", q: query.trim(), c: cat, f: "0" });
   const res = await fetchResilient(`${BASE}?${params.toString()}`, {
     headers: { "User-Agent": USER_AGENT },
     signal: opts.signal,
@@ -24,6 +30,10 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
     const infoHash = tag(item, "nyaa:infoHash").toLowerCase();
     const name = unescapeEntities(tag(item, "title"));
     if (!infoHash || !name) continue;
+
+    // Filter out audio/drama CD releases when querying E-Books
+    if (sourceId === "nyaa-ebooks" && AUDIO_FILTER.test(name)) continue;
+
     const seeders = Number(tag(item, "nyaa:seeders"));
     const leechers = Number(tag(item, "nyaa:leechers"));
     const dateStr = tag(item, "pubDate");
@@ -33,7 +43,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
       sizeBytes: parseSize(tag(item, "nyaa:size")),
       seeders: Number.isFinite(seeders) ? seeders : 0,
       leechers: Number.isFinite(leechers) ? leechers : 0,
-      source: "nyaa",
+      source: sourceId,
       magnet: buildMagnet(infoHash, name),
       added: dateStr ? new Date(dateStr).getTime() / 1000 : undefined,
     });
@@ -47,5 +57,14 @@ export const nyaa: Source = {
   groups: ["Anime"],
   homepage: "https://nyaa.si",
   reportsHealth: true,
-  search,
+  search: (query, opts = {}) => search(query, "1_0", "nyaa", opts),
+};
+
+export const nyaaEbooks: Source = {
+  id: "nyaa-ebooks",
+  label: "Nyaa",
+  groups: ["E-Books"],
+  homepage: "https://nyaa.si",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, "3_0", "nyaa-ebooks", opts),
 };

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -6,9 +6,13 @@ const API = "https://apibay.org";
 
 const MOVIE_CATS = new Set([201, 202, 207, 209]);
 const TV_CATS = new Set([205, 208]);
+const AUDIOBOOK_CATS = new Set([102]);
+const EBOOK_CATS = new Set([601]);
 
 const TOP_MOVIES = `${API}/precompiled/data_top100_207.json`;
 const TOP_TV = `${API}/precompiled/data_top100_208.json`;
+const TOP_AUDIOBOOKS = `${API}/precompiled/data_top100_102.json`;
+const TOP_EBOOKS = `${API}/precompiled/data_top100_601.json`;
 
 interface ApibayItem {
   id?: string;
@@ -90,4 +94,22 @@ export const tpbTv: Source = {
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, TV_CATS, TOP_TV, "tpb-tv", opts),
+};
+
+export const tpbAudiobooks: Source = {
+  id: "tpb-audiobooks",
+  label: "TPB",
+  groups: ["Audiobooks"],
+  homepage: "https://thepiratebay.org",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, AUDIOBOOK_CATS, TOP_AUDIOBOOKS, "tpb-audiobooks", opts),
+};
+
+export const tpbEbooks: Source = {
+  id: "tpb-ebooks",
+  label: "TPB",
+  groups: ["E-Books"],
+  homepage: "https://thepiratebay.org",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, EBOOK_CATS, TOP_EBOOKS, "tpb-ebooks", opts),
 };

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,10 +1,10 @@
 import { bittorrented } from "./bittorrented";
 import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
-import { nyaa } from "./nyaa";
+import { nyaa, nyaaEbooks } from "./nyaa";
 import { subsplease } from "./subsplease";
-import { tpbMovies, tpbTv } from "./piratebay";
-import { x1337Movies, x1337Tv } from "./x1337";
+import { tpbAudiobooks, tpbEbooks, tpbMovies, tpbTv } from "./piratebay";
+import { x1337Audiobooks, x1337Ebooks, x1337Movies, x1337Tv } from "./x1337";
 import { yts } from "./yts";
 import type { Source, SourceGroup, SourceId } from "./types";
 
@@ -19,6 +19,11 @@ export const SOURCES: readonly Source[] = [
   nyaa,
   subsplease,
   bittorrented,
+  tpbEbooks,
+  x1337Ebooks,
+  nyaaEbooks,
+  tpbAudiobooks,
+  x1337Audiobooks,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;
@@ -27,7 +32,14 @@ export function getSource(id: SourceId): Source {
   return SOURCES.find((s) => s.id === id) ?? DEFAULT_SOURCE;
 }
 
-const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime"];
+const GROUP_ORDER: readonly SourceGroup[] = [
+  "Games",
+  "Movies",
+  "TV",
+  "Anime",
+  "E-Books",
+  "Audiobooks",
+];
 
 export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
   return GROUP_ORDER.map((group) => ({

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -3,14 +3,19 @@ export type SourceId =
   | "yts"
   | "eztv"
   | "nyaa"
+  | "nyaa-ebooks"
   | "subsplease"
   | "tpb-movies"
   | "tpb-tv"
+  | "tpb-audiobooks"
+  | "tpb-ebooks"
   | "x1337-movies"
   | "x1337-tv"
+  | "x1337-ebooks"
+  | "x1337-audiobooks"
   | "bittorrented";
 
-export type SourceGroup = "Games" | "Movies" | "TV" | "Anime";
+export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "E-Books" | "Audiobooks";
 
 export interface TorrentResult {
   infoHash: string;

--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -9,6 +9,7 @@ let workingHostIndex = 0;
 const MAX_DETAILS = 4;
 
 const STOP = new Set(["the", "a", "an", "of", "and", "or", "to"]);
+const AUDIO_KW = /\b(audiobook|audiobooks|audio book|audio books|mp3|m4b|flac|narrated|read by|audible)\b/i;
 
 interface Row {
   name: string;
@@ -48,8 +49,18 @@ async function fetchText(url: string, opts: SearchOptions, retries: number): Pro
 }
 
 const MONTHS: Record<string, number> = {
-  jan: 0, feb: 1, mar: 2, apr: 3, may: 4, jun: 5,
-  jul: 6, aug: 7, sep: 8, oct: 9, nov: 10, dec: 11,
+  jan: 0,
+  feb: 1,
+  mar: 2,
+  apr: 3,
+  may: 4,
+  jun: 5,
+  jul: 6,
+  aug: 7,
+  sep: 8,
+  oct: 9,
+  nov: 10,
+  dec: 11,
 };
 
 // 1337x detail pages render "Date uploaded" as e.g. "Jun. 26th  '26".
@@ -81,14 +92,15 @@ async function detailInfo(
 
 async function search(
   query: string,
-  cat: "Movies" | "TV",
+  cat: "Movies" | "TV" | "Other",
   source: SourceId,
   opts: SearchOptions = {},
 ): Promise<TorrentResult[]> {
   const q = query.trim();
+  const catSlug = cat === "Movies" ? "movies" : cat === "TV" ? "tv" : "other";
   const path = q
     ? `/category-search/${encodeURIComponent(q).replace(/%20/g, "+")}/${cat}/1/`
-    : `/popular-${cat === "Movies" ? "movies" : "tv"}`;
+    : `/popular-${catSlug}`;
 
   let base = "";
   let html = "";
@@ -109,7 +121,15 @@ async function search(
   }
   if (!base) throw lastError instanceof Error ? lastError : new HttpError(0, "1337x unreachable");
 
-  const all = parseRows(html);
+  let all = parseRows(html);
+
+  // Category media purity filtering for 1337x's shared 'Other' category
+  if (source === "x1337-ebooks") {
+    all = all.filter((r) => !AUDIO_KW.test(r.name));
+  } else if (source === "x1337-audiobooks") {
+    all = all.filter((r) => AUDIO_KW.test(r.name));
+  }
+
   const tokens = q.toLowerCase().split(/\s+/).filter(Boolean);
   const meaningful = tokens.filter((t) => !STOP.has(t));
   const need = meaningful.length ? meaningful : tokens;
@@ -157,4 +177,22 @@ export const x1337Tv: Source = {
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "TV", "x1337-tv", opts),
+};
+
+export const x1337Ebooks: Source = {
+  id: "x1337-ebooks",
+  label: "1337x",
+  groups: ["E-Books"],
+  homepage: "https://1337x.to",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, "Other", "x1337-ebooks", opts),
+};
+
+export const x1337Audiobooks: Source = {
+  id: "x1337-audiobooks",
+  label: "1337x",
+  groups: ["Audiobooks"],
+  homepage: "https://1337x.to",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, "Other", "x1337-audiobooks", opts),
 };

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -7,7 +7,7 @@ import type { SourceGroup, SourceId } from "../sources/types";
 
 export type View = "splash" | "browser";
 
-export type Category = "all" | "games" | "movies" | "tv" | "anime";
+export type Category = "all" | "games" | "movies" | "tv" | "anime" | "ebooks" | "audiobooks";
 
 export type Section = Category | "downloads" | "seeding";
 
@@ -17,6 +17,8 @@ export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[]
   { key: "movies", label: "Movies", group: "Movies" },
   { key: "tv", label: "TV", group: "TV" },
   { key: "anime", label: "Anime", group: "Anime" },
+  { key: "ebooks", label: "E-Books", group: "E-Books" },
+  { key: "audiobooks", label: "Audiobooks", group: "Audiobooks" },
 ];
 
 export type Region = "sidebar" | "content" | "help";

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -33,11 +33,16 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   yts: { tag: "YTS", color: COLOR.good },
   eztv: { tag: "EZTV", color: COLOR.warn },
   nyaa: { tag: "NYAA", color: COLOR.bright },
+  "nyaa-ebooks": { tag: "NYAA", color: COLOR.bright },
   subsplease: { tag: "SUB", color: "#b9a7e6" },
   "tpb-movies": { tag: "TPB", color: "#5fd0c5" },
   "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
+  "tpb-audiobooks": { tag: "TPB", color: "#5fd0c5" },
+  "tpb-ebooks": { tag: "TPB", color: "#5fd0c5" },
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
+  "x1337-ebooks": { tag: "1337", color: "#f6a55c" },
+  "x1337-audiobooks": { tag: "1337", color: "#f6a55c" },
   bittorrented: { tag: "BT", color: "#7db8f0" },
 };
 


### PR DESCRIPTION
Adds E-Books and Audiobooks categories to torlink using original indexers.

## Category Sequence

```text
Games -> Movies -> TV -> Anime -> E-Books -> Audiobooks
```

## Indexer Breakdown

| Category | Source Name | Endpoint / Filter |
| :--- | :--- | :--- |
| **E-Books** | The Pirate Bay | API Category 601 (E-Books) |
| **E-Books** | 1337x | Other category (Filtered for EPUB/PDF text) |
| **E-Books** | Nyaa | Category 3_0 (Literature and Manga) |
| **Audiobooks** | The Pirate Bay | API Category 102 (Audiobooks) |
| **Audiobooks** | 1337x | Other category (Filtered for audiobooks) |