### PR TITLE
fix(macOS): disable WebRTC to prevent 100% CPU usage Closes-#119

### DIFF
--- a/scripts/cli-entry.cjs
+++ b/scripts/cli-entry.cjs
@@ -12,15 +12,21 @@ if (major < 22) {
   process.exit(1);
 }
 
-// The WebRTC stack (webtorrent -> simple-peer -> webrtc-polyfill) eagerly
-// requires node-datachannel's native binary, which only install scripts
-// download; npm 12 skips those scripts by default, so the binary is often
-// absent and the eager import would kill startup. When it cannot load,
-// resolve webrtc-polyfill to an inert stub instead: simple-peer then reports
-// WEBRTC_SUPPORT = false and downloads run on TCP/uTP and DHT peers alone.
-try {
-  require('node-datachannel');
-} catch (err) {
+// WebRTC on macOS causes high/100% CPU usage even when idle due to issues in node-datachannel / libdatachannel.
+// Since TCP/UDP/DHT peers are sufficient, we completely disable WebRTC on macOS by forcing the stub resolver.
+var isDarwin = process.platform === 'darwin';
+var hasDatachannel = false;
+
+if (!isDarwin) {
+  try {
+    require('node-datachannel');
+    hasDatachannel = true;
+  } catch (err) {
+    // Keep hasDatachannel false
+  }
+}
+
+if (!hasDatachannel) {
   var Module = require('node:module');
   if (typeof Module.registerHooks === 'function') {
     var stubUrl = require('node:url')
@@ -34,24 +40,39 @@ try {
         return nextResolve(specifier, context);
       },
     });
-    process.stderr.write(
-      'torlnk: WebRTC peers unavailable (native module not installed); ' +
-        'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
-    );
+    if (isDarwin) {
+      process.stderr.write(
+        'torlnk: WebRTC peers disabled on macOS to prevent high CPU usage/crashes; ' +
+          'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
+      );
+    } else {
+      process.stderr.write(
+        'torlnk: WebRTC peers unavailable (native module not installed); ' +
+          'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
+      );
+    }
   } else {
     // Node 22.0 to 22.14 has no module.registerHooks, so the eager import
     // cannot be redirected; a clear explanation beats the raw module error.
-    process.stderr.write(
-      '\ntorlnk needs the WebRTC native module (node-datachannel), and it is\n' +
-        'not installed. Either upgrade to Node 22.15+ (torlnk then runs\n' +
-        'without WebRTC peers), or install the build tools and reinstall:\n' +
-        '  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static\n' +
-        '  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev\n' +
-        '  macOS:   xcode-select --install\n' +
-        '  Windows: install CMake and Visual Studio Build Tools\n' +
-        'On npm 12, also allow install scripts: npm approve-scripts\n\n' +
-        'https://github.com/baairon/torlink/issues/60\n\n'
-    );
+    if (isDarwin) {
+      process.stderr.write(
+        '\ntorlnk requires disabling WebRTC on macOS to prevent high CPU usage, which\n' +
+          'requires Node 22.15+ (to allow module redirection stubs).\n' +
+          'Please upgrade Node.js to Node 22.15+ or later.\n\n'
+      );
+    } else {
+      process.stderr.write(
+        '\ntorlnk needs the WebRTC native module (node-datachannel), and it is\n' +
+          'not installed. Either upgrade to Node 22.15+ (torlnk then runs\n' +
+          'without WebRTC peers), or install the build tools and reinstall:\n' +
+          '  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static\n' +
+          '  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev\n' +
+          '  macOS:   xcode-select --install\n' +
+          '  Windows: install CMake and Visual Studio Build Tools\n' +
+          'On npm 12, also allow install scripts: npm approve-scripts\n\n' +
+          'https://github.com/baairon/torlink/issues/60\n\n'
+      );
+    }
     process.exit(1);
   }
 }

--- a/scripts/cli-entry.cjs
+++ b/scripts/cli-entry.cjs
@@ -43,7 +43,7 @@ if (!hasDatachannel) {
     if (isDarwin) {
       process.stderr.write(
         'torlnk: WebRTC peers disabled on macOS to prevent high CPU usage/crashes; ' +
-          'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
+          'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/119\n'
       );
     } else {
       process.stderr.write(


### PR DESCRIPTION
## What and why

Closes #119

This PR resolves the 100% CPU usage issue reported by macOS users when starting the app or using the package. 

WebTorrent uses `node-datachannel` for WebRTC communication. However, on macOS, the native WebRTC event loop/thread management in `libdatachannel` has a severe performance bottleneck that results in 100% CPU utilization, even when completely idle.

Since `torlnk` is a Node-based CLI client, it communicates natively with the entire global BitTorrent swarm using standard TCP and UDP (uTP/DHT). WebRTC is only needed for web-browser-based peers, which represent a tiny fraction of the swarm.

By detecting macOS (`process.platform === 'darwin'`), we can safely bypass the native `node-datachannel` load and force the `webrtc-stub` resolver for `webrtc-polyfill`. This disables WebRTC entirely on macOS, gracefully falling back to standard TCP/UDP swarms and completely resolving the CPU drain.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [ ] New logic has a test (vitest; mock node built ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat`/`fix`/`docs`/`chore`)
