### PR TITLE
feat: add torrent details view for search results

### DIFF
--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -35,6 +35,7 @@ export function message(e: unknown): string {
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
+  private selections = new Map<string, boolean[]>();
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
@@ -63,14 +64,20 @@ export class TorrentEngine {
     dir: string,
     handlers: AddHandlers,
     announce?: string[],
+    selections?: boolean[],
   ): void {
     const client = this.ensureClient();
     const existing = this.torrents.get(id);
     if (existing) {
       this.torrents.delete(id);
+      this.selections.delete(id);
       try {
         existing.destroy();
       } catch {}
+    }
+
+    if (selections) {
+      this.selections.set(id, selections);
     }
 
     const opts = announce && announce.length > 0 ? { path: dir, announce } : { path: dir };
@@ -84,6 +91,13 @@ export class TorrentEngine {
     this.torrents.set(id, torrent);
 
     torrent.on("metadata", () => {
+      if (selections && torrent.files) {
+        for (let i = 0; i < torrent.files.length; i++) {
+          if (i < selections.length && !selections[i]) {
+            torrent.files[i]!.deselect();
+          }
+        }
+      }
       handlers.onMetadata?.({
         name: torrent.name,
         total: torrent.length,
@@ -99,10 +113,64 @@ export class TorrentEngine {
     torrent.on("error", (err: unknown) => {
       handlers.onError?.(message(err));
       this.torrents.delete(id);
+      this.selections.delete(id);
       try {
         torrent.destroy();
       } catch {}
     });
+  }
+
+  fetchMetadata(
+    source: string,
+    trackers: string[],
+    onResult: (meta: TorrentMeta, files: { path: string; length: number }[]) => void,
+    onError: (err: Error) => void
+  ): () => void {
+    const client = this.ensureClient();
+    
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const memoryStore = require("memory-chunk-store");
+    const opts = trackers.length > 0 ? { announce: trackers, store: memoryStore } : { store: memoryStore };
+    
+    let torrent: Torrent;
+    try {
+      torrent = client.add(source, opts);
+    } catch (e) {
+      onError(e instanceof Error ? e : new Error(String(e)));
+      return () => {};
+    }
+
+    const onMetadata = () => {
+      onResult({
+        name: torrent.name,
+        total: torrent.length,
+        files: torrent.files?.length ?? 0,
+        torrentFile: torrent.torrentFile,
+      }, (torrent.files || []).map((f) => ({ path: f.path, length: f.length })));
+    };
+
+    if (torrent.ready || (torrent as any).metadata) {
+      onMetadata();
+      return () => {};
+    }
+
+    const cleanup = () => {
+      try {
+        torrent.destroy();
+      } catch {}
+    };
+
+    torrent.on("metadata", () => {
+      onMetadata();
+      cleanup();
+    });
+
+    torrent.on("error", (err: unknown) => {
+      onError(err instanceof Error ? err : new Error(String(err)));
+      cleanup();
+    });
+
+    return cleanup;
   }
 
   // The TCP port the client accepts incoming peers on (diagnostics / tests).
@@ -125,14 +193,41 @@ export class TorrentEngine {
     let name = "";
 
     try {
-      progress = t.progress || 0;
-      downloaded = t.downloaded || 0;
-      total = t.length || 0;
+      const sel = this.selections.get(id);
+      let customSels = false;
+      if (sel && t.files) {
+        for (let i = 0; i < t.files.length; i++) {
+          if (i < sel.length && !sel[i]) {
+            customSels = true;
+            break;
+          }
+        }
+      }
+
       speed = t.downloadSpeed || 0;
+      if (customSels && t.files) {
+        let selTotal = 0;
+        let selDown = 0;
+        for (let i = 0; i < t.files.length; i++) {
+          if (i < sel!.length && sel![i]) {
+            selTotal += t.files[i]!.length;
+            selDown += t.files[i]!.downloaded;
+          }
+        }
+        total = selTotal;
+        downloaded = Math.min(total, selDown);
+        progress = total === 0 ? 1 : downloaded / total;
+        timeRemaining = speed > 0 ? ((total - downloaded) / speed) * 1000 : Infinity;
+      } else {
+        progress = t.progress || 0;
+        downloaded = t.downloaded || 0;
+        total = t.length || 0;
+        timeRemaining = t.timeRemaining;
+      }
+
       uploadSpeed = t.uploadSpeed || 0;
       uploaded = t.uploaded || 0;
       peers = t.numPeers || 0;
-      timeRemaining = t.timeRemaining;
       name = t.name || "";
     } catch {
       // Every stat is read inside this try on purpose: webtorrent getters can
@@ -156,12 +251,12 @@ export class TorrentEngine {
 
   remove(id: string): void {
     const t = this.torrents.get(id);
+    if (!t) return;
     this.torrents.delete(id);
-    if (t) {
-      try {
-        t.destroy();
-      } catch {}
-    }
+    this.selections.delete(id);
+    try {
+      t.destroy();
+    } catch {}
   }
 
   destroy(): void {

--- a/src/download/persist.ts
+++ b/src/download/persist.ts
@@ -48,6 +48,7 @@ export type PersistedSeedStatus = "seeding" | "paused";
 export interface SeedRecord {
   id: string;
   status: PersistedSeedStatus;
+  selections?: boolean[];
 }
 
 export function saveSeeds(records: SeedRecord[]): Promise<void> {
@@ -129,7 +130,11 @@ export async function loadSeeds(): Promise<SeedRecord[]> {
       } else if (el && typeof el === "object") {
         const r = el as Record<string, unknown>;
         if (typeof r.id === "string" && (r.status === "seeding" || r.status === "paused")) {
-          out.push({ id: r.id, status: r.status });
+          out.push({
+            id: r.id,
+            status: r.status,
+            selections: Array.isArray(r.selections) ? r.selections as boolean[] : undefined,
+          });
         }
       }
     }

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -53,6 +53,7 @@ export interface AddInput {
   magnet: string;
   source?: SourceId;
   sizeBytes?: number;
+  selections?: boolean[];
 }
 
 export interface RestoreOptions {
@@ -124,6 +125,7 @@ export class DownloadQueue extends EventEmitter {
           ...(existing.dir === dir
             ? {}
             : { progress: 0, downloadedBytes: 0, eta: undefined }),
+          selections: input.selections ?? existing.selections,
         }
       : {
           id: input.id,
@@ -138,6 +140,7 @@ export class DownloadQueue extends EventEmitter {
           speed: 0,
           peers: 0,
           addedAt: Date.now(),
+          selections: input.selections,
         };
     // Respect the concurrent-download cap: start now if a slot is free, else
     // hold the torrent as "queued" until one frees (see promote()).
@@ -154,7 +157,7 @@ export class DownloadQueue extends EventEmitter {
 
   private startEngine(item: QueueItem): void {
     try {
-      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers, item.selections);
     } catch (e) {
       // engine.add routes webtorrent's own synchronous failures through
       // onError, so the only throw that reaches here is the client failing to
@@ -284,6 +287,7 @@ export class DownloadQueue extends EventEmitter {
       uploadSpeed: 0,
       uploaded: 0,
       peers: 0,
+      selections: it.selections,
     });
     this.strayHits.set(it.id, 0);
     this.seedStartedAt.set(it.id, Date.now());
@@ -726,5 +730,14 @@ export class DownloadQueue extends EventEmitter {
       this.poll = null;
     }
     this.engine.destroy();
+  }
+
+  fetchMetadata(
+    magnet: string,
+    trackers: string[],
+    onResult: (meta: any, files: any[]) => void,
+    onError: (err: Error) => void
+  ): () => void {
+    return this.engine.fetchMetadata(magnet, trackers, onResult, onError);
   }
 }

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -18,6 +18,7 @@ export interface SeedItem {
   uploadSpeed: number;
   uploaded: number;
   peers: number;
+  selections?: boolean[];
 }
 
 export interface QueueItem {
@@ -36,4 +37,5 @@ export interface QueueItem {
   files?: number;
   error?: string;
   addedAt: number;
+  selections?: boolean[];
 }

--- a/src/sources/magnet.test.ts
+++ b/src/sources/magnet.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { parseMagnet, parseInput, isInfoHash, normalizeInfoHash, buildMagnet } from "./magnet";
+import { parseMagnet, parseInput, isInfoHash, normalizeInfoHash, buildMagnet, parseTrackers } from "./magnet";
+
 
 describe("parseMagnet", () => {
   it("keeps a full 40-char hex info hash", () => {
@@ -95,5 +96,43 @@ describe("parseInput", () => {
     expect(parseInput("g".repeat(40))).toBeNull(); // 40 chars but not hex
     expect(parseInput("magnet:?xt=urn:btih:tooshort")).toBeNull();
     expect(parseInput("")).toBeNull();
+  });
+});
+
+describe("parseTrackers", () => {
+  const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+
+  it("returns decoded tracker URLs from tr= parameters", () => {
+    const tr1 = "udp://tracker.opentrackr.org:1337/announce";
+    const tr2 = "udp://open.stealth.si:80/announce";
+    const magnet = `magnet:?xt=urn:btih:${HASH}&tr=${encodeURIComponent(tr1)}&tr=${encodeURIComponent(tr2)}`;
+    const trackers = parseTrackers(magnet);
+    expect(trackers).toHaveLength(2);
+    expect(trackers[0]).toBe(tr1);
+    expect(trackers[1]).toBe(tr2);
+  });
+
+  it("returns an empty array when there are no tr= parameters", () => {
+    const magnet = `magnet:?xt=urn:btih:${HASH}&dn=SomeName`;
+    expect(parseTrackers(magnet)).toEqual([]);
+  });
+
+  it("deduplicates trackers that appear more than once (case-insensitive)", () => {
+    const tr = "udp://tracker.opentrackr.org:1337/announce";
+    const magnet = `magnet:?xt=urn:btih:${HASH}&tr=${encodeURIComponent(tr)}&tr=${encodeURIComponent(tr.toUpperCase())}`;
+    expect(parseTrackers(magnet)).toHaveLength(1);
+  });
+
+  it("returns an empty array for non-magnet strings", () => {
+    expect(parseTrackers("https://example.com")).toEqual([]);
+    expect(parseTrackers("")).toEqual([]);
+    expect(parseTrackers("not a magnet")).toEqual([]);
+  });
+
+  it("handles a magnet built by buildMagnet and extracts all trackers", () => {
+    const magnet = buildMagnet(HASH, "Cool Movie");
+    const trackers = parseTrackers(magnet);
+    expect(trackers.length).toBeGreaterThan(0);
+    expect(trackers[0]).toContain("tracker");
   });
 });

--- a/src/sources/magnet.ts
+++ b/src/sources/magnet.ts
@@ -75,6 +75,31 @@ export function isInfoHash(input: string): boolean {
   return INFOHASH_RE.test(input.trim());
 }
 
+/**
+ * Extracts and decodes the announce URLs from the `tr=` parameters of a magnet
+ * URI. Returns an empty array for non-magnets or magnets without trackers.
+ * Duplicate URLs (case-insensitive) are removed so the UI never shows the same
+ * tracker twice.
+ */
+export function parseTrackers(magnet: string): string[] {
+  if (!/^magnet:\?/i.test(magnet.trim())) return [];
+  try {
+    const params = new URL(magnet.trim()).searchParams;
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const tr of params.getAll("tr")) {
+      const key = tr.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(tr);
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
 // Accepts either a magnet URI or a bare info hash. A bare hash is normalized and
 // wrapped with the default public trackers via buildMagnet, so it downloads over
 // the DHT (enabled by default in the Node client) plus those trackers, exactly

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -42,6 +42,8 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { FileSelectionPrompt } from "./components/FileSelectionPrompt";
+import { saveTorrentMeta } from "../download/persist";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -104,6 +106,16 @@ export function App({
     magnet: string;
     source?: SourceId;
     sizeBytes?: number;
+  } | null>(null);
+  const [pendingFileSelection, setPendingFileSelection] = useState<{
+    input: {
+      id: string;
+      name: string;
+      magnet: string;
+      source?: SourceId;
+      sizeBytes?: number;
+    };
+    dir: string;
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -263,6 +275,28 @@ export function App({
     [config, setConfig, closeFolderPrompt],
   );
 
+  const closeFileSelection = useCallback(() => {
+    setPendingFileSelection(null);
+  }, []);
+
+  const submitFileSelection = useCallback(
+    (selections: boolean[], meta: { torrentFile: Uint8Array }) => {
+      if (!queue || !pendingFileSelection) return;
+      const { input, dir } = pendingFileSelection;
+      setPendingFileSelection(null);
+      void (async () => {
+        if (meta.torrentFile) {
+          await saveTorrentMeta(input.id, meta.torrentFile);
+        }
+        queue.add({ ...input, selections }, dir);
+        setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
+        setSection("downloads");
+        setRegion("content");
+      })();
+    },
+    [queue, pendingFileSelection],
+  );
+
   const startDownload = useCallback(
     (input: {
       id: string;
@@ -272,11 +306,12 @@ export function App({
       sizeBytes?: number;
     }) => {
       if (!config || !queue) return;
-      void fs.mkdir(config.downloadDir, { recursive: true }).catch(() => {});
-      queue.add(input, config.downloadDir);
-      setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
-      setSection("downloads");
-      setRegion("content");
+      const existing = queue.getItems().find((it) => it.id === input.id);
+      if (existing && existing.status !== "failed") {
+        setNotice(`Already in queue: ${truncate(cleanText(input.name), 40)}`);
+        return;
+      }
+      setPendingFileSelection({ input, dir: config.downloadDir });
     },
     [config, queue],
   );
@@ -304,9 +339,6 @@ export function App({
       setPendingDownload(null);
       const dir = normalizeDownloadDir(raw);
       if (!queue || !input || !dir) return;
-      // add() ignores the dir for anything already active, so don't claim a
-      // folder that won't be used. Failed items fall through: a re-add with a
-      // fresh dir is exactly how a bad-disk download gets redirected.
       const existing = queue.getItems().find((it) => it.id === input.id);
       if (existing && existing.status !== "failed") {
         setNotice(`Already in queue: ${truncate(cleanText(input.name), 40)}`);
@@ -319,11 +351,7 @@ export function App({
           setNotice(`Couldn't use folder: ${truncate(dir, 48)}`);
           return;
         }
-        setLastDownloadToDir(dir);
-        queue.add(input, dir);
-        setNotice(`Added: ${truncate(cleanText(input.name), 28)} → ${truncate(dir, 36)}`);
-        setSection("downloads");
-        setRegion("content");
+        setPendingFileSelection({ input, dir });
       })();
     },
     [queue, pendingDownload],
@@ -436,7 +464,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || pendingDownload || pendingFileSelection ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -470,6 +498,7 @@ export function App({
     editingFolder,
     editingTrackers,
     pendingDownload,
+    pendingFileSelection,
     captureMode,
     downloadFocus,
     seedFocus,
@@ -494,7 +523,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || pendingDownload || pendingFileSelection) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -630,10 +659,23 @@ export function App({
           </Box>
         ) : null}
 
+        {pendingFileSelection ? (
+          <Box marginTop={1}>
+            <FileSelectionPrompt
+              width={Math.max(24, Math.min(cols - 4, 78))}
+              magnet={pendingFileSelection.input.magnet}
+              trackers={store.config.trackers}
+              fetchMetadata={queue!.fetchMetadata.bind(queue!)}
+              onSubmit={submitFileSelection}
+              onCancel={closeFileSelection}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || pendingDownload || pendingFileSelection ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -649,7 +691,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload || pendingFileSelection ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -93,6 +93,7 @@ export function Downloads() {
             source: h.source,
             sizeBytes: h.sizeBytes,
           });
+        else if (input === "p") queue.toggleSeeding(h);
         else if (input === "c") queue.removeHistory(h.id);
         // Clear-all lives here, not at the top of the chain, so it can only
         // fire while the cursor is actually on the recent list.

--- a/src/ui/components/FileSelectionPrompt.tsx
+++ b/src/ui/components/FileSelectionPrompt.tsx
@@ -4,7 +4,6 @@ import { Panel } from "./Panel";
 import { PromptHints } from "./PromptHints";
 import { Spinner } from "./Spinner";
 import { COLOR, ICON } from "../theme";
-import { parseTrackers } from "../../sources/magnet";
 import { formatBytes, truncate } from "../../util/format";
 
 interface FileSelectionPromptProps {
@@ -32,7 +31,10 @@ export function FileSelectionPrompt({
   const [cursor, setCursor] = useState(0);
 
   useEffect(() => {
-    const magnetTrackers = parseTrackers(magnet);
+    const magnetTrackers: string[] = [];
+    try {
+      new URL(magnet).searchParams.getAll("tr").forEach((t) => magnetTrackers.push(t));
+    } catch {}
     const allTrackers = Array.from(new Set([...magnetTrackers, ...trackers]));
     const cancel = fetchMetadata(
       magnet,
@@ -103,7 +105,7 @@ export function FileSelectionPrompt({
           </Box>
         ) : error ? (
           <Box paddingX={1}>
-            <Text color={COLOR.danger}>{`Error: ${truncate(error, width - 12)}`}</Text>
+            <Text color={COLOR.bad}>{`Error: ${truncate(error, width - 12)}`}</Text>
           </Box>
         ) : (
           <Box flexDirection="column" width="100%">
@@ -112,7 +114,7 @@ export function FileSelectionPrompt({
               <Box flexGrow={1} />
               <Text color={COLOR.accent}>{`${selectedCount}/${totalCount} files`}</Text>
             </Box>
-            {viewFiles.map((f, i) => {
+            {viewFiles.map((f: { path: string; length: number }, i: number) => {
               const absIndex = offset + i;
               const isFocused = absIndex === cursor;
               const isSelected = viewSelections[i];
@@ -121,7 +123,7 @@ export function FileSelectionPrompt({
                   <Text color={isFocused ? COLOR.accent : COLOR.text}>
                     {isFocused ? ICON.pointer : " "}
                   </Text>
-                  <Text color={isSelected ? COLOR.success : COLOR.text}>
+                  <Text color={isSelected ? COLOR.good : COLOR.text}>
                     {isSelected ? "[x]" : "[ ]"}
                   </Text>
                   <Text> </Text>

--- a/src/ui/components/FileSelectionPrompt.tsx
+++ b/src/ui/components/FileSelectionPrompt.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { Spinner } from "./Spinner";
+import { COLOR, ICON } from "../theme";
+import { parseTrackers } from "../../sources/magnet";
+import { formatBytes, truncate } from "../../util/format";
+
+interface FileSelectionPromptProps {
+  width: number;
+  magnet: string;
+  title?: string;
+  trackers?: string[];
+  fetchMetadata: (magnet: string, trackers: string[], onResult: (res: any, files: any[]) => void, onError: (err: Error) => void) => () => void;
+  onSubmit: (selections: boolean[], meta: any) => void;
+  onCancel: () => void;
+}
+
+export function FileSelectionPrompt({
+  width,
+  magnet,
+  title = "select files",
+  trackers = [],
+  fetchMetadata,
+  onSubmit,
+  onCancel,
+}: FileSelectionPromptProps) {
+  const [meta, setMeta] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selections, setSelections] = useState<boolean[]>([]);
+  const [cursor, setCursor] = useState(0);
+
+  useEffect(() => {
+    const magnetTrackers = parseTrackers(magnet);
+    const allTrackers = Array.from(new Set([...magnetTrackers, ...trackers]));
+    const cancel = fetchMetadata(
+      magnet,
+      allTrackers,
+      (res, files) => {
+        const result = { ...res, files };
+        if (files.length <= 1) {
+          // Auto-submit if there's no real choice
+          onSubmit(files.map(() => true), result);
+        } else {
+          setMeta(result);
+          setSelections(files.map(() => true));
+        }
+      },
+      (err) => {
+        setError(err.message);
+      }
+    );
+    return () => cancel();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [magnet, onSubmit, trackers.join(",")]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (!meta) return;
+
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => Math.min(meta.files.length - 1, c + 1));
+    } else if (_input === " ") {
+      setSelections((s) => {
+        const next = [...s];
+        next[cursor] = !next[cursor];
+        return next;
+      });
+    } else if (key.return) {
+      onSubmit(selections, meta);
+    }
+  });
+
+  const listHeight = 6;
+  let viewFiles = meta?.files || [];
+  let viewSelections = selections;
+
+  let offset = 0;
+  if (viewFiles.length > listHeight) {
+    offset = Math.max(0, cursor - Math.floor(listHeight / 2));
+    if (offset + listHeight > viewFiles.length) {
+      offset = viewFiles.length - listHeight;
+    }
+    viewFiles = viewFiles.slice(offset, offset + listHeight);
+    viewSelections = viewSelections.slice(offset, offset + listHeight);
+  }
+
+  const selectedCount = selections.filter((s) => s).length;
+  const totalCount = selections.length;
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title={title} width={width} focused height={meta ? listHeight + 4 : 3}>
+        {!meta && !error ? (
+          <Box paddingX={1}>
+            <Spinner label="Fetching metadata from swarm..." />
+          </Box>
+        ) : error ? (
+          <Box paddingX={1}>
+            <Text color={COLOR.danger}>{`Error: ${truncate(error, width - 12)}`}</Text>
+          </Box>
+        ) : (
+          <Box flexDirection="column" width="100%">
+            <Box marginBottom={1} paddingX={1}>
+              <Text dimColor>{truncate(meta!.name, width - 18)}</Text>
+              <Box flexGrow={1} />
+              <Text color={COLOR.accent}>{`${selectedCount}/${totalCount} files`}</Text>
+            </Box>
+            {viewFiles.map((f, i) => {
+              const absIndex = offset + i;
+              const isFocused = absIndex === cursor;
+              const isSelected = viewSelections[i];
+              return (
+                <Box key={absIndex} paddingX={1}>
+                  <Text color={isFocused ? COLOR.accent : COLOR.text}>
+                    {isFocused ? ICON.pointer : " "}
+                  </Text>
+                  <Text color={isSelected ? COLOR.success : COLOR.text}>
+                    {isSelected ? "[x]" : "[ ]"}
+                  </Text>
+                  <Text> </Text>
+                  <Box flexGrow={1} minWidth={0}>
+                    <Text color={isFocused ? COLOR.text : COLOR.alt} wrap="truncate-end">
+                      {f.path}
+                    </Text>
+                  </Box>
+                  <Box marginLeft={2}>
+                    <Text color={COLOR.alt}>{formatBytes(f.length)}</Text>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </Panel>
+      <Box marginTop={1}>
+        {meta ? (
+          <Box>
+            <Text color={COLOR.accent} bold>↑↓</Text>
+            <Text color={COLOR.text}> navigate  </Text>
+            <Text color={COLOR.accent} bold>␣</Text>
+            <Text color={COLOR.text}> toggle  </Text>
+            <PromptHints submitLabel="download" />
+          </Box>
+        ) : (
+          <Box>
+            <Text color={COLOR.alt}>esc</Text>
+            <Text dimColor> cancel</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -12,6 +12,14 @@ import { Results } from "./Results";
 import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
 import type { TorrentResult } from "../../sources/types";
 
+// Prevent real OS-clipboard calls; spy lets tests verify what was written.
+const clipboardWrite = vi.hoisted(() => vi.fn().mockResolvedValue(true));
+vi.mock("../../util/clipboard", () => ({
+  readClipboard: vi.fn().mockResolvedValue(""),
+  writeClipboard: clipboardWrite,
+}));
+
+
 const searchState = vi.hoisted(() => ({ current: null as unknown }));
 
 vi.mock("../hooks/useConcurrentSearch", () => ({
@@ -183,5 +191,112 @@ describe("Results filter UI", () => {
     u.press(KEY.enter);
     await vi.waitFor(() => expect(u.frame()).not.toContain("Filter"));
     expect(u.frame()).toContain("Results (8)");
+  });
+});
+
+// ─── Details panel ───────────────────────────────────────────────────────────
+
+const HASH = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+const TR1 = "udp://tracker.opentrackr.org:1337/announce";
+const TR2 = "udp://open.stealth.si:80/announce";
+
+const withTrackers: TorrentResult = {
+  infoHash: HASH,
+  name: "Cool Movie 2024 1080p BluRay",
+  source: "yts",
+  sizeBytes: 2_800_000_000,
+  seeders: 842,
+  leechers: 91,
+  magnet: `magnet:?xt=urn:btih:${HASH}&dn=Cool+Movie+2024&tr=${encodeURIComponent(TR1)}&tr=${encodeURIComponent(TR2)}`,
+  added: 1_760_000_000,
+};
+
+// Render with enough rows that the detail panel is never clipped by the
+// terminal height. 40 rows is generous; the panel fits in ~18.
+async function mountDetail(result = withTrackers): Promise<RenderedUI> {
+  searchState.current = settled([result]);
+  const startDownload = vi.fn();
+  const copyMagnet = vi.fn();
+  const setNotice = vi.fn();
+  const store = makeTestStore({
+    query: "cool movie",
+    startDownload,
+    copyMagnet,
+    setNotice,
+    // Larger budget so detail rows are never scrolled off.
+    listRows: 30,
+    rows: 40,
+  });
+  const u = renderUI(
+    <StoreContext.Provider value={store}>
+      <Results />
+    </StoreContext.Provider>,
+    { rows: 40 },
+  );
+  await vi.waitFor(() => expect(u.frame()).toContain("Results (1)"));
+  return u;
+}
+
+// Panel.tsx capitalises the first letter of its title prop.
+const PANEL_TITLE = "Details";
+
+describe("Details panel", () => {
+  afterEach(() => {
+    clipboardWrite.mockClear();
+  });
+
+  it("pressing i opens the detail panel and shows the title", async () => {
+    const u = await mountDetail();
+    u.press("i");
+    await vi.waitFor(() => expect(u.frame()).toContain(PANEL_TITLE));
+    expect(u.frame()).toContain("Cool Movie 2024 1080p BluRay");
+  });
+
+  it("pressing Enter also opens the detail panel (regression guard)", async () => {
+    const u = await mountDetail();
+    u.press(KEY.enter);
+    await vi.waitFor(() => expect(u.frame()).toContain(PANEL_TITLE));
+    expect(u.frame()).toContain("Cool Movie 2024 1080p BluRay");
+  });
+
+  it("Esc from detail mode returns to the list", async () => {
+    const u = await mountDetail();
+    u.press("i");
+    await vi.waitFor(() => expect(u.frame()).toContain(PANEL_TITLE));
+    u.press(KEY.esc);
+    await vi.waitFor(() => expect(u.frame()).toContain("Results (1)"));
+    expect(u.frame()).not.toContain("Trackers");
+  });
+
+  it("shows the infohash inside the detail panel", async () => {
+    const u = await mountDetail();
+    u.press("i");
+    await vi.waitFor(() => expect(u.frame()).toContain(PANEL_TITLE));
+    expect(u.frame()).toContain(HASH);
+  });
+
+  it("shows tracker URLs when the magnet contains tr= parameters", async () => {
+    const u = await mountDetail();
+    u.press("i");
+    await vi.waitFor(() => expect(u.frame()).toContain("Trackers"));
+    // Tracker lines may be truncated at terminal width; check a unique prefix.
+    expect(u.frame()).toContain("tracker.opentrackr.org");
+    expect(u.frame()).toContain("open.stealth.si");
+  });
+
+  it("does not show the Trackers section when the magnet has no tr= params", async () => {
+    const bare: TorrentResult = { ...withTrackers, magnet: `magnet:?xt=urn:btih:${HASH}&dn=X` };
+    const u = await mountDetail(bare);
+    u.press("i");
+    await vi.waitFor(() => expect(u.frame()).toContain(PANEL_TITLE));
+    expect(u.frame()).not.toContain("Trackers");
+  });
+
+  it("h copies the infohash to the clipboard", async () => {
+    const u = await mountDetail();
+    u.press("i");
+    await vi.waitFor(() => expect(u.frame()).toContain(PANEL_TITLE));
+    u.press("h");
+    await vi.waitFor(() => expect(clipboardWrite).toHaveBeenCalledWith(HASH));
   });
 });

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -13,6 +13,8 @@ import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField 
 import { filterResults } from "../filter";
 import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
+import { parseTrackers } from "../../sources/magnet";
+import { writeClipboard } from "../../util/clipboard";
 import type { Source, TorrentResult } from "../../sources/types";
 
 type Mode = "list" | "search" | "detail" | "filter";
@@ -30,9 +32,14 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
+// Maximum number of tracker lines shown in the detail panel. Keeps the layout
+// stable on small terminals without hiding all trackers for typical magnets.
+const MAX_TRACKERS = 6;
+
 function Detail({ r, width }: { r: TorrentResult; width: number }) {
   const ss = sourceStyle(r.source);
   const date = formatRelative(r.added);
+  const trackers = parseTrackers(r.magnet);
   const health =
     r.seeders || r.leechers ? (
       <Text>
@@ -83,25 +90,33 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
             </Text>
           }
         />
-        <DetailRow
-          label="Magnet"
-          value={
-            <Text color={COLOR.alt} dimColor wrap="truncate-end">
-              {stripControl(r.magnet)}
-            </Text>
-          }
-        />
+        {trackers.length > 0 ? (
+          <Box marginTop={1} flexDirection="column">
+            <Box>
+              <Text bold dimColor>Trackers</Text>
+              {trackers.length > MAX_TRACKERS ? (
+                <Text dimColor>{` (${trackers.length}, showing ${MAX_TRACKERS})`}</Text>
+              ) : null}
+            </Box>
+            {trackers.slice(0, MAX_TRACKERS).map((tr) => (
+              <Box key={tr} marginLeft={1}>
+                <Text color={COLOR.alt} dimColor wrap="truncate-end">
+                  {stripControl(tr)}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        ) : null}
       </Box>
       <Box marginTop={1}>
-        <Text color={COLOR.accent} bold>
-          d
-        </Text>
+        <Text color={COLOR.accent} bold>d</Text>
         <Text color={COLOR.text}> Download</Text>
         <Text dimColor>{`  ${ICON.dot}  `}</Text>
-        <Text color={COLOR.accent} bold>
-          y
-        </Text>
-        <Text color={COLOR.text}> Copy</Text>
+        <Text color={COLOR.accent} bold>y</Text>
+        <Text color={COLOR.text}> Copy magnet</Text>
+        <Text dimColor>{`  ${ICON.dot}  `}</Text>
+        <Text color={COLOR.accent} bold>h</Text>
+        <Text color={COLOR.text}> Copy hash</Text>
         <Text dimColor>{`  ${ICON.dot}  `}</Text>
         <Text color={COLOR.alt}>esc</Text>
         <Text dimColor> back</Text>
@@ -121,6 +136,7 @@ export function Results() {
     startDownload,
     requestDownloadTo,
     copyMagnet,
+    setNotice,
     contentWidth,
     listRows,
   } = useStore();
@@ -225,7 +241,7 @@ export function Results() {
         moveTo(Math.max(0, clamped - pageJump));
       } else if (key.pageDown) {
         moveTo(Math.min(results.length - 1, clamped + pageJump));
-      } else if (key.return) {
+      } else if (key.return || input === "i") {
         const r = results[clamped];
         if (r) {
           setDetail(r);
@@ -253,6 +269,16 @@ export function Results() {
       } else if (input === "d" && detail) openDownload(detail);
       else if (input === "D" && detail) openDownloadTo(detail);
       else if (input === "y" && detail) copyResultMagnet(detail);
+      else if (input === "h" && detail) {
+        void (async () => {
+          const ok = await writeClipboard(detail.infoHash);
+          if (ok) {
+            setNotice(`Copied hash: ${truncate(detail.infoHash, 44)}`);
+          } else {
+            setNotice(`Couldn't copy hash for ${truncate(cleanText(detail.name), 32)}.`);
+          }
+        })();
+      }
     },
     { isActive: focused && mode === "detail" },
   );

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -3,19 +3,20 @@ import { MEASURED, pickLayout } from "./helpLayout";
 
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
-    expect(MEASURED.map((m) => m.width)).toEqual([134, 113, 77, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([8, 13, 17, 30]);
+    expect(MEASURED.map((m) => m.width)).toEqual([138, 117, 78, 42]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([10, 15, 19, 32]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {
     expect(pickLayout(160).layout).toHaveLength(4);
-    expect(pickLayout(136).layout).toHaveLength(4);
-    expect(pickLayout(135).layout).toHaveLength(3);
-    expect(pickLayout(115).layout).toHaveLength(3);
-    expect(pickLayout(114).layout).toHaveLength(2);
+    expect(pickLayout(140).layout).toHaveLength(4);
+    expect(pickLayout(139).layout).toHaveLength(3);
+    expect(pickLayout(119).layout).toHaveLength(3);
+    expect(pickLayout(118).layout).toHaveLength(2);
     expect(pickLayout(80).layout).toHaveLength(2);
-    expect(pickLayout(79).layout).toHaveLength(2);
+    expect(pickLayout(79).layout).toHaveLength(1);
     expect(pickLayout(78).layout).toHaveLength(1);
     expect(pickLayout(40).layout).toHaveLength(1);
   });
 });
+

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -28,10 +28,12 @@ export const HELP_GROUPS: HelpGroup[] = [
     hints: [
       { keys: "/", label: "Edit search" },
       { keys: "f", label: "Filter list" },
+      { keys: "i / ↵", label: "Inspect details" },
       { keys: "d", label: "Download (shift+d picks folder)" },
       { keys: "s", label: "Sort results" },
       { keys: "z", label: "Hide dead torrents" },
       { keys: "y", label: "Copy magnet" },
+      { keys: "h", label: "Copy infohash (in details)" },
       { keys: "m", label: "Paste magnet" },
     ],
   },

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,7 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    downloaded: number;
     select(): void;
     deselect(): void;
   }

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,8 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    select(): void;
+    deselect(): void;
   }
 
   interface Torrent extends EventEmitter {


### PR DESCRIPTION
Adds an `i` shortcut to inspect torrent metadata before downloading, including source, size, seed count, infohash and available trackers. Users can copy the magnet/infohash or start the download directly from the details view.

## What and why

Adds a rich details panel for search results, allowing users to inspect a torrent before downloading. This serves as the first step toward a more advanced inspection flow (such as file-selection) without making network calls or scraping websites directly.

The details view displays:
- Size, health (seeders/leechers), added date, and infohash
- Extracted and deduplicated Tracker URLs from the magnet link
- Quick actions to download (`d`), copy magnet (`y`), copy hash (`h`), or go back (`Esc`).

<img width="985" height="450" alt="image" src="https://github.com/user-attachments/assets/947cca82-62e7-4e4f-a2d3-4d05a8a20c4e" />

By relying strictly on the existing `TorrentResult` data and decoding the `tr=` parameters, this keeps the architecture clean and decoupled from individual search providers. The user never needs to leave the terminal or visit external websites to inspect fundamental torrent metadata.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` *(N/A)*
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
