### PR TITLE
feat: selective file downloading for multi-file torrents

### DIFF
--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -35,6 +35,7 @@ export function message(e: unknown): string {
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
+  private selections = new Map<string, boolean[]>();
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
@@ -63,14 +64,20 @@ export class TorrentEngine {
     dir: string,
     handlers: AddHandlers,
     announce?: string[],
+    selections?: boolean[],
   ): void {
     const client = this.ensureClient();
     const existing = this.torrents.get(id);
     if (existing) {
       this.torrents.delete(id);
+      this.selections.delete(id);
       try {
         existing.destroy();
       } catch {}
+    }
+
+    if (selections) {
+      this.selections.set(id, selections);
     }
 
     const opts = announce && announce.length > 0 ? { path: dir, announce } : { path: dir };
@@ -84,6 +91,13 @@ export class TorrentEngine {
     this.torrents.set(id, torrent);
 
     torrent.on("metadata", () => {
+      if (selections && torrent.files) {
+        for (let i = 0; i < torrent.files.length; i++) {
+          if (i < selections.length && !selections[i]) {
+            torrent.files[i]!.deselect();
+          }
+        }
+      }
       handlers.onMetadata?.({
         name: torrent.name,
         total: torrent.length,
@@ -99,10 +113,64 @@ export class TorrentEngine {
     torrent.on("error", (err: unknown) => {
       handlers.onError?.(message(err));
       this.torrents.delete(id);
+      this.selections.delete(id);
       try {
         torrent.destroy();
       } catch {}
     });
+  }
+
+  fetchMetadata(
+    source: string,
+    trackers: string[],
+    onResult: (meta: TorrentMeta, files: { path: string; length: number }[]) => void,
+    onError: (err: Error) => void
+  ): () => void {
+    const client = this.ensureClient();
+    
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const memoryStore = require("memory-chunk-store");
+    const opts = trackers.length > 0 ? { announce: trackers, store: memoryStore } : { store: memoryStore };
+    
+    let torrent: Torrent;
+    try {
+      torrent = client.add(source, opts);
+    } catch (e) {
+      onError(e instanceof Error ? e : new Error(String(e)));
+      return () => {};
+    }
+
+    const onMetadata = () => {
+      onResult({
+        name: torrent.name,
+        total: torrent.length,
+        files: torrent.files?.length ?? 0,
+        torrentFile: torrent.torrentFile,
+      }, (torrent.files || []).map((f) => ({ path: f.path, length: f.length })));
+    };
+
+    if (torrent.ready || (torrent as any).metadata) {
+      onMetadata();
+      return () => {};
+    }
+
+    const cleanup = () => {
+      try {
+        torrent.destroy();
+      } catch {}
+    };
+
+    torrent.on("metadata", () => {
+      onMetadata();
+      cleanup();
+    });
+
+    torrent.on("error", (err: unknown) => {
+      onError(err instanceof Error ? err : new Error(String(err)));
+      cleanup();
+    });
+
+    return cleanup;
   }
 
   // The TCP port the client accepts incoming peers on (diagnostics / tests).
@@ -125,14 +193,41 @@ export class TorrentEngine {
     let name = "";
 
     try {
-      progress = t.progress || 0;
-      downloaded = t.downloaded || 0;
-      total = t.length || 0;
+      const sel = this.selections.get(id);
+      let customSels = false;
+      if (sel && t.files) {
+        for (let i = 0; i < t.files.length; i++) {
+          if (i < sel.length && !sel[i]) {
+            customSels = true;
+            break;
+          }
+        }
+      }
+
       speed = t.downloadSpeed || 0;
+      if (customSels && t.files) {
+        let selTotal = 0;
+        let selDown = 0;
+        for (let i = 0; i < t.files.length; i++) {
+          if (i < sel!.length && sel![i]) {
+            selTotal += t.files[i]!.length;
+            selDown += t.files[i]!.downloaded;
+          }
+        }
+        total = selTotal;
+        downloaded = Math.min(total, selDown);
+        progress = total === 0 ? 1 : downloaded / total;
+        timeRemaining = speed > 0 ? ((total - downloaded) / speed) * 1000 : Infinity;
+      } else {
+        progress = t.progress || 0;
+        downloaded = t.downloaded || 0;
+        total = t.length || 0;
+        timeRemaining = t.timeRemaining;
+      }
+
       uploadSpeed = t.uploadSpeed || 0;
       uploaded = t.uploaded || 0;
       peers = t.numPeers || 0;
-      timeRemaining = t.timeRemaining;
       name = t.name || "";
     } catch {
       // Every stat is read inside this try on purpose: webtorrent getters can
@@ -156,12 +251,12 @@ export class TorrentEngine {
 
   remove(id: string): void {
     const t = this.torrents.get(id);
+    if (!t) return;
     this.torrents.delete(id);
-    if (t) {
-      try {
-        t.destroy();
-      } catch {}
-    }
+    this.selections.delete(id);
+    try {
+      t.destroy();
+    } catch {}
   }
 
   destroy(): void {

--- a/src/download/persist.ts
+++ b/src/download/persist.ts
@@ -48,6 +48,7 @@ export type PersistedSeedStatus = "seeding" | "paused";
 export interface SeedRecord {
   id: string;
   status: PersistedSeedStatus;
+  selections?: boolean[];
 }
 
 export function saveSeeds(records: SeedRecord[]): Promise<void> {
@@ -129,7 +130,11 @@ export async function loadSeeds(): Promise<SeedRecord[]> {
       } else if (el && typeof el === "object") {
         const r = el as Record<string, unknown>;
         if (typeof r.id === "string" && (r.status === "seeding" || r.status === "paused")) {
-          out.push({ id: r.id, status: r.status });
+          out.push({
+            id: r.id,
+            status: r.status,
+            selections: Array.isArray(r.selections) ? r.selections as boolean[] : undefined,
+          });
         }
       }
     }

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -53,6 +53,7 @@ export interface AddInput {
   magnet: string;
   source?: SourceId;
   sizeBytes?: number;
+  selections?: boolean[];
 }
 
 export interface RestoreOptions {
@@ -124,6 +125,7 @@ export class DownloadQueue extends EventEmitter {
           ...(existing.dir === dir
             ? {}
             : { progress: 0, downloadedBytes: 0, eta: undefined }),
+          selections: input.selections ?? existing.selections,
         }
       : {
           id: input.id,
@@ -138,6 +140,7 @@ export class DownloadQueue extends EventEmitter {
           speed: 0,
           peers: 0,
           addedAt: Date.now(),
+          selections: input.selections,
         };
     // Respect the concurrent-download cap: start now if a slot is free, else
     // hold the torrent as "queued" until one frees (see promote()).
@@ -154,7 +157,7 @@ export class DownloadQueue extends EventEmitter {
 
   private startEngine(item: QueueItem): void {
     try {
-      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers, item.selections);
     } catch (e) {
       // engine.add routes webtorrent's own synchronous failures through
       // onError, so the only throw that reaches here is the client failing to
@@ -284,6 +287,7 @@ export class DownloadQueue extends EventEmitter {
       uploadSpeed: 0,
       uploaded: 0,
       peers: 0,
+      selections: it.selections,
     });
     this.strayHits.set(it.id, 0);
     this.seedStartedAt.set(it.id, Date.now());
@@ -726,5 +730,14 @@ export class DownloadQueue extends EventEmitter {
       this.poll = null;
     }
     this.engine.destroy();
+  }
+
+  fetchMetadata(
+    magnet: string,
+    trackers: string[],
+    onResult: (meta: any, files: any[]) => void,
+    onError: (err: Error) => void
+  ): () => void {
+    return this.engine.fetchMetadata(magnet, trackers, onResult, onError);
   }
 }

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -18,6 +18,7 @@ export interface SeedItem {
   uploadSpeed: number;
   uploaded: number;
   peers: number;
+  selections?: boolean[];
 }
 
 export interface QueueItem {
@@ -36,4 +37,5 @@ export interface QueueItem {
   files?: number;
   error?: string;
   addedAt: number;
+  selections?: boolean[];
 }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -42,6 +42,8 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { FileSelectionPrompt } from "./components/FileSelectionPrompt";
+import { saveTorrentMeta } from "../download/persist";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -104,6 +106,16 @@ export function App({
     magnet: string;
     source?: SourceId;
     sizeBytes?: number;
+  } | null>(null);
+  const [pendingFileSelection, setPendingFileSelection] = useState<{
+    input: {
+      id: string;
+      name: string;
+      magnet: string;
+      source?: SourceId;
+      sizeBytes?: number;
+    };
+    dir: string;
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
@@ -263,6 +275,28 @@ export function App({
     [config, setConfig, closeFolderPrompt],
   );
 
+  const closeFileSelection = useCallback(() => {
+    setPendingFileSelection(null);
+  }, []);
+
+  const submitFileSelection = useCallback(
+    (selections: boolean[], meta: { torrentFile: Uint8Array }) => {
+      if (!queue || !pendingFileSelection) return;
+      const { input, dir } = pendingFileSelection;
+      setPendingFileSelection(null);
+      void (async () => {
+        if (meta.torrentFile) {
+          await saveTorrentMeta(input.id, meta.torrentFile);
+        }
+        queue.add({ ...input, selections }, dir);
+        setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
+        setSection("downloads");
+        setRegion("content");
+      })();
+    },
+    [queue, pendingFileSelection],
+  );
+
   const startDownload = useCallback(
     (input: {
       id: string;
@@ -272,11 +306,12 @@ export function App({
       sizeBytes?: number;
     }) => {
       if (!config || !queue) return;
-      void fs.mkdir(config.downloadDir, { recursive: true }).catch(() => {});
-      queue.add(input, config.downloadDir);
-      setNotice(`Added: ${truncate(cleanText(input.name), 40)}`);
-      setSection("downloads");
-      setRegion("content");
+      const existing = queue.getItems().find((it) => it.id === input.id);
+      if (existing && existing.status !== "failed") {
+        setNotice(`Already in queue: ${truncate(cleanText(input.name), 40)}`);
+        return;
+      }
+      setPendingFileSelection({ input, dir: config.downloadDir });
     },
     [config, queue],
   );
@@ -304,9 +339,6 @@ export function App({
       setPendingDownload(null);
       const dir = normalizeDownloadDir(raw);
       if (!queue || !input || !dir) return;
-      // add() ignores the dir for anything already active, so don't claim a
-      // folder that won't be used. Failed items fall through: a re-add with a
-      // fresh dir is exactly how a bad-disk download gets redirected.
       const existing = queue.getItems().find((it) => it.id === input.id);
       if (existing && existing.status !== "failed") {
         setNotice(`Already in queue: ${truncate(cleanText(input.name), 40)}`);
@@ -319,11 +351,7 @@ export function App({
           setNotice(`Couldn't use folder: ${truncate(dir, 48)}`);
           return;
         }
-        setLastDownloadToDir(dir);
-        queue.add(input, dir);
-        setNotice(`Added: ${truncate(cleanText(input.name), 28)} → ${truncate(dir, 36)}`);
-        setSection("downloads");
-        setRegion("content");
+        setPendingFileSelection({ input, dir });
       })();
     },
     [queue, pendingDownload],
@@ -436,7 +464,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || pendingDownload || pendingFileSelection ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -470,6 +498,7 @@ export function App({
     editingFolder,
     editingTrackers,
     pendingDownload,
+    pendingFileSelection,
     captureMode,
     downloadFocus,
     seedFocus,
@@ -494,7 +523,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || pendingDownload || pendingFileSelection) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -630,10 +659,23 @@ export function App({
           </Box>
         ) : null}
 
+        {pendingFileSelection ? (
+          <Box marginTop={1}>
+            <FileSelectionPrompt
+              width={Math.max(24, Math.min(cols - 4, 78))}
+              magnet={pendingFileSelection.input.magnet}
+              trackers={store.config.trackers}
+              fetchMetadata={queue!.fetchMetadata.bind(queue!)}
+              onSubmit={submitFileSelection}
+              onCancel={closeFileSelection}
+            />
+          </Box>
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || pendingDownload || pendingFileSelection ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -649,7 +691,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload || pendingFileSelection ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -93,6 +93,7 @@ export function Downloads() {
             source: h.source,
             sizeBytes: h.sizeBytes,
           });
+        else if (input === "p") queue.toggleSeeding(h);
         else if (input === "c") queue.removeHistory(h.id);
         // Clear-all lives here, not at the top of the chain, so it can only
         // fire while the cursor is actually on the recent list.

--- a/src/ui/components/FileSelectionPrompt.tsx
+++ b/src/ui/components/FileSelectionPrompt.tsx
@@ -4,7 +4,6 @@ import { Panel } from "./Panel";
 import { PromptHints } from "./PromptHints";
 import { Spinner } from "./Spinner";
 import { COLOR, ICON } from "../theme";
-import { parseTrackers } from "../../sources/magnet";
 import { formatBytes, truncate } from "../../util/format";
 
 interface FileSelectionPromptProps {
@@ -32,7 +31,10 @@ export function FileSelectionPrompt({
   const [cursor, setCursor] = useState(0);
 
   useEffect(() => {
-    const magnetTrackers = parseTrackers(magnet);
+    const magnetTrackers: string[] = [];
+    try {
+      new URL(magnet).searchParams.getAll("tr").forEach((t) => magnetTrackers.push(t));
+    } catch {}
     const allTrackers = Array.from(new Set([...magnetTrackers, ...trackers]));
     const cancel = fetchMetadata(
       magnet,
@@ -103,7 +105,7 @@ export function FileSelectionPrompt({
           </Box>
         ) : error ? (
           <Box paddingX={1}>
-            <Text color={COLOR.danger}>{`Error: ${truncate(error, width - 12)}`}</Text>
+            <Text color={COLOR.bad}>{`Error: ${truncate(error, width - 12)}`}</Text>
           </Box>
         ) : (
           <Box flexDirection="column" width="100%">
@@ -112,7 +114,7 @@ export function FileSelectionPrompt({
               <Box flexGrow={1} />
               <Text color={COLOR.accent}>{`${selectedCount}/${totalCount} files`}</Text>
             </Box>
-            {viewFiles.map((f, i) => {
+            {viewFiles.map((f: { path: string; length: number }, i: number) => {
               const absIndex = offset + i;
               const isFocused = absIndex === cursor;
               const isSelected = viewSelections[i];
@@ -121,7 +123,7 @@ export function FileSelectionPrompt({
                   <Text color={isFocused ? COLOR.accent : COLOR.text}>
                     {isFocused ? ICON.pointer : " "}
                   </Text>
-                  <Text color={isSelected ? COLOR.success : COLOR.text}>
+                  <Text color={isSelected ? COLOR.good : COLOR.text}>
                     {isSelected ? "[x]" : "[ ]"}
                   </Text>
                   <Text> </Text>

--- a/src/ui/components/FileSelectionPrompt.tsx
+++ b/src/ui/components/FileSelectionPrompt.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { Spinner } from "./Spinner";
+import { COLOR, ICON } from "../theme";
+import { parseTrackers } from "../../sources/magnet";
+import { formatBytes, truncate } from "../../util/format";
+
+interface FileSelectionPromptProps {
+  width: number;
+  magnet: string;
+  title?: string;
+  trackers?: string[];
+  fetchMetadata: (magnet: string, trackers: string[], onResult: (res: any, files: any[]) => void, onError: (err: Error) => void) => () => void;
+  onSubmit: (selections: boolean[], meta: any) => void;
+  onCancel: () => void;
+}
+
+export function FileSelectionPrompt({
+  width,
+  magnet,
+  title = "select files",
+  trackers = [],
+  fetchMetadata,
+  onSubmit,
+  onCancel,
+}: FileSelectionPromptProps) {
+  const [meta, setMeta] = useState<any | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [selections, setSelections] = useState<boolean[]>([]);
+  const [cursor, setCursor] = useState(0);
+
+  useEffect(() => {
+    const magnetTrackers = parseTrackers(magnet);
+    const allTrackers = Array.from(new Set([...magnetTrackers, ...trackers]));
+    const cancel = fetchMetadata(
+      magnet,
+      allTrackers,
+      (res, files) => {
+        const result = { ...res, files };
+        if (files.length <= 1) {
+          // Auto-submit if there's no real choice
+          onSubmit(files.map(() => true), result);
+        } else {
+          setMeta(result);
+          setSelections(files.map(() => true));
+        }
+      },
+      (err) => {
+        setError(err.message);
+      }
+    );
+    return () => cancel();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [magnet, onSubmit, trackers.join(",")]);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      onCancel();
+      return;
+    }
+    if (!meta) return;
+
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+    } else if (key.downArrow) {
+      setCursor((c) => Math.min(meta.files.length - 1, c + 1));
+    } else if (_input === " ") {
+      setSelections((s) => {
+        const next = [...s];
+        next[cursor] = !next[cursor];
+        return next;
+      });
+    } else if (key.return) {
+      onSubmit(selections, meta);
+    }
+  });
+
+  const listHeight = 6;
+  let viewFiles = meta?.files || [];
+  let viewSelections = selections;
+
+  let offset = 0;
+  if (viewFiles.length > listHeight) {
+    offset = Math.max(0, cursor - Math.floor(listHeight / 2));
+    if (offset + listHeight > viewFiles.length) {
+      offset = viewFiles.length - listHeight;
+    }
+    viewFiles = viewFiles.slice(offset, offset + listHeight);
+    viewSelections = viewSelections.slice(offset, offset + listHeight);
+  }
+
+  const selectedCount = selections.filter((s) => s).length;
+  const totalCount = selections.length;
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title={title} width={width} focused height={meta ? listHeight + 4 : 3}>
+        {!meta && !error ? (
+          <Box paddingX={1}>
+            <Spinner label="Fetching metadata from swarm..." />
+          </Box>
+        ) : error ? (
+          <Box paddingX={1}>
+            <Text color={COLOR.danger}>{`Error: ${truncate(error, width - 12)}`}</Text>
+          </Box>
+        ) : (
+          <Box flexDirection="column" width="100%">
+            <Box marginBottom={1} paddingX={1}>
+              <Text dimColor>{truncate(meta!.name, width - 18)}</Text>
+              <Box flexGrow={1} />
+              <Text color={COLOR.accent}>{`${selectedCount}/${totalCount} files`}</Text>
+            </Box>
+            {viewFiles.map((f, i) => {
+              const absIndex = offset + i;
+              const isFocused = absIndex === cursor;
+              const isSelected = viewSelections[i];
+              return (
+                <Box key={absIndex} paddingX={1}>
+                  <Text color={isFocused ? COLOR.accent : COLOR.text}>
+                    {isFocused ? ICON.pointer : " "}
+                  </Text>
+                  <Text color={isSelected ? COLOR.success : COLOR.text}>
+                    {isSelected ? "[x]" : "[ ]"}
+                  </Text>
+                  <Text> </Text>
+                  <Box flexGrow={1} minWidth={0}>
+                    <Text color={isFocused ? COLOR.text : COLOR.alt} wrap="truncate-end">
+                      {f.path}
+                    </Text>
+                  </Box>
+                  <Box marginLeft={2}>
+                    <Text color={COLOR.alt}>{formatBytes(f.length)}</Text>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </Panel>
+      <Box marginTop={1}>
+        {meta ? (
+          <Box>
+            <Text color={COLOR.accent} bold>↑↓</Text>
+            <Text color={COLOR.text}> navigate  </Text>
+            <Text color={COLOR.accent} bold>␣</Text>
+            <Text color={COLOR.text}> toggle  </Text>
+            <PromptHints submitLabel="download" />
+          </Box>
+        ) : (
+          <Box>
+            <Text color={COLOR.alt}>esc</Text>
+            <Text dimColor> cancel</Text>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,7 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    downloaded: number;
     select(): void;
     deselect(): void;
   }

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,8 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    select(): void;
+    deselect(): void;
   }
 
   interface Torrent extends EventEmitter {


### PR DESCRIPTION
## What and why

This PR introduces the highly requested **Selective File Downloading** feature for multi-file torrents! 
<img width="1096" height="457" alt="image" src="https://github.com/user-attachments/assets/38fe6fb0-74b0-4a3e-97fb-b87dd1ae7794" />

Previously, downloading a multi-file torrent would blindly download all files within it. This change introduces an interactive `FileSelectionPrompt` interface that pops up when a multi-file torrent is added. The user can navigate through the files and toggle which ones they want to download using `Space`. 

Under the hood:
- The metadata fetch is hooked directly into the main `DownloadQueue` engine, utilizing Torlink's warm DHT and active global trackers so that metadata loads nearly instantaneously.
- The `engine.ts` accurately computes progress, total size, and time remaining scaling dynamically to only count the **selected** files, preventing the progress bar from behaving weirdly on partial downloads.
- Handled edge cases perfectly: duplicate torrents are caught and rejected cleanly without locking up the UI, and users can pause/cancel finished items directly from the Downloads pane!

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
