### PR TITLE
Highlight Selected Items

### DIFF
--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -188,10 +188,17 @@ export function Downloads() {
                 </Text>
               </Box>
               <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text dimColor>{it.totalBytes > 0 ? formatBytes(it.totalBytes) : "-"}</Text>
+                <Text 
+					dimColor={!here}
+					bold={here}
+				>{it.totalBytes > 0 ? formatBytes(it.totalBytes) : "-"}</Text>
               </Box>
               <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text color={it.source ? ss.color : undefined} dimColor={!it.source || !here}>
+                <Text 
+					color={it.source ? ss.color : undefined} 
+					dimColor={!it.source || !here}
+					bold={here}
+				>
                   {it.source ? ss.tag : "mag"}
                 </Text>
               </Box>
@@ -245,13 +252,23 @@ export function Downloads() {
               </Text>
             </Box>
             <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-              <Text dimColor>{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
+              <Text 
+				dimColor={!here}
+				bold={here}
+			  >{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
             </Box>
             <Box width={12} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-              <Text dimColor>{when || "-"}</Text>
+              <Text 
+				dimColor={!here}
+				bold={here}
+			  >{when || "-"}</Text>
             </Box>
             <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-              <Text color={h.source ? ss.color : undefined} dimColor={!h.source || !here}>
+              <Text 
+				color={h.source ? ss.color : undefined} 
+				dimColor={!h.source || !here}
+				bold={here}
+			  >
                 {h.source ? ss.tag : "mag"}
               </Text>
             </Box>

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -188,18 +188,18 @@ export function Downloads() {
                 </Text>
               </Box>
               <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text 
-					dimColor={!here}
-					bold={here}
-				>{it.totalBytes > 0 ? formatBytes(it.totalBytes) : "-"}</Text>
+                <Text
+                  dimColor={!here}
+                  bold={here}
+                >{it.totalBytes > 0 ? formatBytes(it.totalBytes) : "-"}
+                </Text>
               </Box>
               <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text 
-					color={it.source ? ss.color : undefined} 
-					dimColor={!it.source || !here}
-					bold={here}
-				>
-                  {it.source ? ss.tag : "mag"}
+                <Text
+                  color={it.source ? ss.color : undefined}
+                  dimColor={!it.source || !here}
+                  bold={here}
+                >{it.source ? ss.tag : "mag"}
                 </Text>
               </Box>
             </Box>
@@ -252,24 +252,25 @@ export function Downloads() {
               </Text>
             </Box>
             <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-              <Text 
-				dimColor={!here}
-				bold={here}
-			  >{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
+              <Text
+                dimColor={!here}
+                bold={here}
+              >{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}
+              </Text>
             </Box>
             <Box width={12} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-              <Text 
-				dimColor={!here}
-				bold={here}
-			  >{when || "-"}</Text>
+              <Text
+                dimColor={!here}
+                bold={here}
+              >{when || "-"}
+              </Text>
             </Box>
             <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-              <Text 
-				color={h.source ? ss.color : undefined} 
-				dimColor={!h.source || !here}
-				bold={here}
-			  >
-                {h.source ? ss.tag : "mag"}
+              <Text
+                color={h.source ? ss.color : undefined}
+                dimColor={!h.source || !here}
+                bold={here}
+              >{h.source ? ss.tag : "mag"}
               </Text>
             </Box>
           </Box>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -465,10 +465,11 @@ export function Results() {
                       {showStats ? (
                         <>
                           <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                            <Text 
-								dimColor={!here}
-								bold={here}
-							>{r.sizeBytes > 0 ? formatBytes(r.sizeBytes) : "-"}</Text>
+                            <Text
+                              dimColor={!here}
+                              bold={here}
+                            >{r.sizeBytes > 0 ? formatBytes(r.sizeBytes) : "-"}
+                            </Text>
                           </Box>
                           <Box width={9} flexShrink={0} marginLeft={1} justifyContent="flex-end">
                             <Text
@@ -483,19 +484,19 @@ export function Results() {
                         </>
                       ) : (
                         <Box width={12} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                          <Text 
-							dimColor={!here}
-							bold={here}
-						  >{formatRelative(r.added) || "-"}</Text>
+                          <Text
+                            dimColor={!here}
+                            bold={here}
+                          >{formatRelative(r.added) || "-"}
+                          </Text>
                         </Box>
                       )}
                       <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                        <Text 
-							color={ss.color} 
-							dimColor={!here}
-							bold={here}
-						>
-                          {ss.tag}
+                        <Text
+                          color={ss.color}
+                          dimColor={!here}
+                          bold={here}
+                        >{ss.tag}
                         </Text>
                       </Box>
                     </Box>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -11,7 +11,7 @@ import { getSource, SOURCES } from "../../sources/registry";
 import { stickCursor, wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
 import { filterResults } from "../filter";
-import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
+import { COLOR, COLOR_HIGHLIGHTED, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Source, TorrentResult } from "../../sources/types";
 
@@ -465,10 +465,17 @@ export function Results() {
                       {showStats ? (
                         <>
                           <Box width={10} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                            <Text dimColor>{r.sizeBytes > 0 ? formatBytes(r.sizeBytes) : "-"}</Text>
+                            <Text 
+								dimColor={!here}
+								bold={here}
+							>{r.sizeBytes > 0 ? formatBytes(r.sizeBytes) : "-"}</Text>
                           </Box>
                           <Box width={9} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                            <Text color={r.seeders > 0 ? COLOR.good : undefined} dimColor={r.seeders === 0}>
+                            <Text 
+								color = { here ? ( r.seeders > 0 ? COLOR_HIGHLIGHTED.good : undefined ) : ( r.seeders > 0 ? COLOR.good : undefined )}
+								dimColor = { !here }
+								bold={here}
+							>
                               {r.seeders || r.leechers
                                 ? `${formatCount(r.seeders)}:${formatCount(r.leechers)}`
                                 : "-"}

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -488,7 +488,11 @@ export function Results() {
                         </Box>
                       )}
                       <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                        <Text color={ss.color} dimColor={!here}>
+                        <Text 
+							color={ss.color} 
+							dimColor={!here}
+							bold={here}
+						>
                           {ss.tag}
                         </Text>
                       </Box>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -11,7 +11,7 @@ import { getSource, SOURCES } from "../../sources/registry";
 import { stickCursor, wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
 import { filterResults } from "../filter";
-import { COLOR, COLOR_HIGHLIGHTED, GUTTER, ICON, sourceStyle } from "../theme";
+import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Source, TorrentResult } from "../../sources/types";
 
@@ -471,12 +471,11 @@ export function Results() {
 							>{r.sizeBytes > 0 ? formatBytes(r.sizeBytes) : "-"}</Text>
                           </Box>
                           <Box width={9} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                            <Text 
-								color = { here ? ( r.seeders > 0 ? COLOR_HIGHLIGHTED.good : undefined ) : ( r.seeders > 0 ? COLOR.good : undefined )}
-								dimColor = { !here }
-								bold={here}
-							>
-                              {r.seeders || r.leechers
+                            <Text
+                              color={r.seeders > 0 ? COLOR.good : undefined}
+                              dimColor={!here}
+                              bold={here}
+                            >{r.seeders || r.leechers
                                 ? `${formatCount(r.seeders)}:${formatCount(r.leechers)}`
                                 : "-"}
                             </Text>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -484,7 +484,10 @@ export function Results() {
                         </>
                       ) : (
                         <Box width={12} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                          <Text dimColor>{formatRelative(r.added) || "-"}</Text>
+                          <Text 
+							dimColor={!here}
+							bold={here}
+						  >{formatRelative(r.added) || "-"}</Text>
                         </Box>
                       )}
                       <Box width={4} flexShrink={0} marginLeft={1} justifyContent="flex-end">

--- a/src/ui/components/Seeding.tsx
+++ b/src/ui/components/Seeding.tsx
@@ -162,10 +162,12 @@ export function Seeding() {
                 </Text>
               </Box>
               <Box width={STATUS_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text 
-					color={st.color} 
-					bold={here}
-				>{truncate(st.text, STATUS_W)}</Text>
+                <Text
+                  color={st.color}
+                  dimColor={!here}
+                  bold={here}
+                >{truncate(st.text, STATUS_W)}
+                </Text>
               </Box>
               <Box width={SRC_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
                 <Text

--- a/src/ui/components/Seeding.tsx
+++ b/src/ui/components/Seeding.tsx
@@ -155,10 +155,11 @@ export function Seeding() {
                 </Text>
               </Box>
               <Box width={SIZE_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text 
-					dimColor={!here}
-					bold={here}
-				>{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
+                <Text
+                  dimColor={!here}
+                  bold={here}
+                >{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}
+                </Text>
               </Box>
               <Box width={STATUS_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
                 <Text 
@@ -167,12 +168,11 @@ export function Seeding() {
 				>{truncate(st.text, STATUS_W)}</Text>
               </Box>
               <Box width={SRC_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text 
-					color={h.source ? ss.color : undefined} 
-					dimColor={!here}
-					bold={here}
-				>
-                  {h.source ? ss.tag : "mag"}
+                <Text
+                  color={h.source ? ss.color : undefined} 
+                  dimColor={!h.source || !here}
+                  bold={here}
+                >{h.source ? ss.tag : "mag"}
                 </Text>
               </Box>
             </Box>

--- a/src/ui/components/Seeding.tsx
+++ b/src/ui/components/Seeding.tsx
@@ -155,13 +155,23 @@ export function Seeding() {
                 </Text>
               </Box>
               <Box width={SIZE_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text dimColor>{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
+                <Text 
+					dimColor={!here}
+					bold={here}
+				>{h.sizeBytes > 0 ? formatBytes(h.sizeBytes) : "-"}</Text>
               </Box>
               <Box width={STATUS_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text color={st.color} dimColor={st.dim}>{truncate(st.text, STATUS_W)}</Text>
+                <Text 
+					color={st.color} 
+					bold={here}
+				>{truncate(st.text, STATUS_W)}</Text>
               </Box>
               <Box width={SRC_W} flexShrink={0} marginLeft={1} justifyContent="flex-end">
-                <Text color={h.source ? ss.color : undefined} dimColor={!h.source || !here}>
+                <Text 
+					color={h.source ? ss.color : undefined} 
+					dimColor={!here}
+					bold={here}
+				>
                   {h.source ? ss.tag : "mag"}
                 </Text>
               </Box>

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -12,7 +12,7 @@ export const COLOR = {
 
 export const COLOR_HIGHLIGHTED = {
   text: "#ffffff",
-  good: "#c9f3d8",
+  good: "#add7bc",
   warn: "#f5dda5",
   bad: "#f7adbb",
 } as const;

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -10,13 +10,6 @@ export const COLOR = {
   bright: "#d8b4fe",
 } as const;
 
-export const COLOR_HIGHLIGHTED = {
-  text: "#ffffff",
-  good: "#add7bc",
-  warn: "#f5dda5",
-  bad: "#f7adbb",
-} as const;
-
 export const ICON = {
   done: "✓",
   error: "✗",

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -10,6 +10,13 @@ export const COLOR = {
   bright: "#d8b4fe",
 } as const;
 
+export const COLOR_HIGHLIGHTED = {
+  text: "#ffffff",
+  good: "#c9f3d8",
+  warn: "#f5dda5",
+  bad: "#f7adbb",
+} as const;
+
 export const ICON = {
   done: "✓",
   error: "✗",


### PR DESCRIPTION
## Difficulty determining the size of the selected search result item.

When browsing through the search results it is difficult to determine the size of the currently selected item because there are no highlights. This PR resolves the issue by highlighting(changing color and bold) additional columns. 

<!-- What does this change do, and why? The diff shows the what; tell us the why. -->
The changes in this PR modify the accent color of some columns to have a bit of a lighter tint and making them bold so they are easily spotted among the rest of the search results.

The highlights were also added to Downloads and Seeding tabs.  

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [ ] New logic has a test (vitest; mock node built-ins for platform code)
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [ ] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)

Let me know if any changes are required! 

Thanks for working on this project :)

## Before Merge : 

<img width="1889" height="918" alt="image" src="https://github.com/user-attachments/assets/8ad401d7-500d-4139-b5c1-b3b61ef0adac" />

## After Merge : 

<img width="1881" height="913" alt="image" src="https://github.com/user-attachments/assets/005d87c9-1af4-48d2-b6e2-3096eae538de" />
