### PR TITLE
feat: add a Music tab fed by TPB, 1337x, and BitTorrented

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ A short, hand-picked list of trusted sources:
 | Movies | YTS, The Pirate Bay, 1337x, BitTorrented |
 | TV | EZTV, The Pirate Bay, 1337x, BitTorrented |
 | Anime | Nyaa, SubsPlease |
+| Music | The Pirate Bay, 1337x, BitTorrented |
 
-Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline.
+Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video, audio, and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline.
 
 ## Headless
 

--- a/preview/browse.svg
+++ b/preview/browse.svg
@@ -56,13 +56,13 @@
     <text x="204.8" y="282" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╭─</text>
     <text x="233.6" y="282" textLength="96" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Latest (5)</text>
     <text x="339.2" y="282" textLength="451.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">──────────────────────────────────────────────╮</text>
+    <text x="60.8" y="304" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Music</text>
     <rect x="208.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
     <text x="224" y="304" textLength="240" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">newest across all sources</text>
     <rect x="784.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="60.8" y="326" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Downloads</text>
     <rect x="208.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
     <rect x="784.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="60.8" y="348" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Seeding</text>
+    <text x="60.8" y="348" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Downloads</text>
     <rect x="208.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
     <text x="252.8" y="348" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">#</text>
     <text x="272" y="348" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Name</text>
@@ -70,6 +70,7 @@
     <text x="646.4" y="348" textLength="76.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Seed:Lch</text>
     <text x="742.4" y="348" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55" font-weight="600">Src</text>
     <rect x="784.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="60.8" y="370" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Seeding</text>
     <rect x="208.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
     <text x="224" y="370" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">❯</text>
     <text x="252.8" y="370" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1</text>
@@ -117,9 +118,9 @@
     <text x="387.2" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Sort</text>
     <text x="454.4" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">/</text>
     <text x="473.6" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Search</text>
-    <text x="560" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
-    <text x="598.4" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch</text>
-    <text x="684.8" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">?</text>
-    <text x="704" y="502" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Keys</text>
+    <text x="560" y="502" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">f</text>
+    <text x="579.2" y="502" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Filter</text>
+    <text x="665.6" y="502" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">tab</text>
+    <text x="704" y="502" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Switch  …</text>
   </g>
 </svg>

--- a/preview/downloads.svg
+++ b/preview/downloads.svg
@@ -48,8 +48,8 @@
     <text x="224" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">❯</text>
     <text x="243.2" y="216" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">↓</text>
     <text x="262.4" y="216" textLength="345.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Dune: Part Two (2024) [2160p BluRay]</text>
-    <text x="656" y="216" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">7.82 GB</text>
-    <text x="742.4" y="216" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2">YTS</text>
+    <text x="656" y="216" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" font-weight="600">7.82 GB</text>
+    <text x="742.4" y="216" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2" font-weight="600">YTS</text>
     <rect x="784.9" y="200" width="1.4" height="22" fill="#a78bfa"/>
     <text x="60.8" y="238" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Movies</text>
     <rect x="208.9" y="222" width="1.4" height="22" fill="#a78bfa"/>
@@ -77,6 +77,7 @@
     <rect x="208.9" y="266" width="1.4" height="22" fill="#a78bfa"/>
     <text x="224" y="282" textLength="230.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Recently downloaded  (2)</text>
     <rect x="784.9" y="266" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="60.8" y="304" textLength="48" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Music</text>
     <rect x="208.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
     <text x="243.2" y="304" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2" fill-opacity="0.55">✓</text>
     <text x="262.4" y="304" textLength="230.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Elden Ring: Shadow of t…</text>
@@ -84,9 +85,6 @@
     <text x="656" y="304" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1hr ago</text>
     <text x="752" y="304" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" fill-opacity="0.55">FG</text>
     <rect x="784.9" y="288" width="1.4" height="22" fill="#a78bfa"/>
-    <rect x="41.6" y="310" width="4.8" height="22" fill="#6b6577"/>
-    <text x="60.8" y="326" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">Downloads</text>
-    <text x="156.8" y="326" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">(1)</text>
     <rect x="208.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
     <text x="243.2" y="326" textLength="9.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#86d6a2" fill-opacity="0.55">✓</text>
     <text x="262.4" y="326" textLength="230.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Breaking Bad S05E14 108…</text>
@@ -94,9 +92,12 @@
     <text x="627.2" y="326" textLength="96" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">1d 1hr ago</text>
     <text x="732.8" y="326" textLength="38.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#f0c560" fill-opacity="0.55">EZTV</text>
     <rect x="784.9" y="310" width="1.4" height="22" fill="#a78bfa"/>
-    <text x="60.8" y="348" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Seeding</text>
+    <rect x="41.6" y="332" width="4.8" height="22" fill="#6b6577"/>
+    <text x="60.8" y="348" textLength="86.4" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#b9a7e6">Downloads</text>
+    <text x="156.8" y="348" textLength="28.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">(1)</text>
     <rect x="208.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
     <rect x="784.9" y="332" width="1.4" height="22" fill="#a78bfa"/>
+    <text x="60.8" y="370" textLength="67.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">Seeding</text>
     <rect x="208.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
     <rect x="784.9" y="354" width="1.4" height="22" fill="#a78bfa"/>
     <text x="204.8" y="392" textLength="585.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╰───────────────────────────────────────────────────────────╯</text>

--- a/preview/splash.svg
+++ b/preview/splash.svg
@@ -39,7 +39,7 @@
     <rect x="512" y="112" width="9.6" height="22" fill="#523e94"/>
     <rect x="531.2" y="112" width="9.6" height="22" fill="#4c3a8a"/>
     <text x="195.2" y="194" textLength="441.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#e9e4f5">A curated, terminal-native torrent downloader.</text>
-    <text x="262.4" y="216" textLength="316.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">games  ·  movies  ·  tv  ·  anime</text>
+    <text x="214.4" y="216" textLength="412.8" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill-opacity="0.55">games  ·  movies  ·  tv  ·  anime  ·  music</text>
     <text x="118.4" y="260" textLength="19.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">╭─</text>
     <text x="147.2" y="260" textLength="57.6" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa" font-weight="600">Search</text>
     <text x="214.4" y="260" textLength="499.2" lengthAdjust="spacingAndGlyphs" xml:space="preserve" fill="#a78bfa">───────────────────────────────────────────────────╮</text>

--- a/src/sources/bittorrented.test.ts
+++ b/src/sources/bittorrented.test.ts
@@ -1,5 +1,28 @@
-import { describe, it, expect } from "vitest";
-import { mapBittorrentedResults, bittorrented } from "./bittorrented";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mapBittorrentedResults, bittorrented, bittorrentedMusic } from "./bittorrented";
+import { fetchResilient } from "../util/net";
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: vi.fn() };
+});
+
+const mockFetch = vi.mocked(fetchResilient);
+
+const apiPage = (results: unknown[]): Response =>
+  ({ ok: true, status: 200, json: async () => ({ results }) }) as unknown as Response;
+
+const row = (hash: string, name: string): unknown => ({
+  torrent_infohash: hash,
+  torrent_name: name,
+});
+
+const askedFor = (call: number): URLSearchParams =>
+  new URL(String(mockFetch.mock.calls[call]![0])).searchParams;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
 
 describe("mapBittorrentedResults", () => {
   it("maps an API row to a torrent result with a built magnet, tagged by source id", () => {
@@ -53,12 +76,58 @@ describe("mapBittorrentedResults", () => {
   });
 });
 
+// The two sources are one search() apart: they differ only in the media type
+// they ask the API for and the id they stamp on the rows that come back. Swap
+// either half and the tabs still fill, just with the wrong media — so both
+// halves are asserted together, per source.
 describe("bittorrented", () => {
-  it("feeds Movies and TV only, never Games or Anime", () => {
+  it("feeds Movies and TV only, never Games, Anime or Music", () => {
     expect(bittorrented.id).toBe("bittorrented");
     expect(bittorrented.groups).toEqual(["Movies", "TV"]);
     expect(bittorrented.groups).not.toContain("Games");
     expect(bittorrented.groups).not.toContain("Anime");
+    expect(bittorrented.groups).not.toContain("Music");
     expect(bittorrented.reportsHealth).toBe(true);
+  });
+
+  it("asks the API for video and tags the rows bittorrented", async () => {
+    mockFetch.mockResolvedValueOnce(apiPage([row("b".repeat(40), "Old School (2003)")]));
+    const results = await bittorrented.search("old school");
+    expect(askedFor(0).get("type")).toBe("video");
+    expect(askedFor(0).get("q")).toBe("old school");
+    expect(results.map((r) => r.source)).toEqual(["bittorrented"]);
+  });
+});
+
+describe("bittorrentedMusic", () => {
+  it("feeds Music only, never the video categories", () => {
+    expect(bittorrentedMusic.id).toBe("bittorrented-music");
+    expect(bittorrentedMusic.groups).toEqual(["Music"]);
+    expect(bittorrentedMusic.groups).not.toContain("Movies");
+    expect(bittorrentedMusic.groups).not.toContain("TV");
+    expect(bittorrentedMusic.reportsHealth).toBe(true);
+  });
+
+  it("asks the API for audio and tags the rows bittorrented-music", async () => {
+    mockFetch.mockResolvedValueOnce(
+      apiPage([row("a".repeat(40), "Daft Punk - Discovery (2001) [FLAC]")]),
+    );
+    const results = await bittorrentedMusic.search("daft punk");
+    expect(askedFor(0).get("type")).toBe("audio");
+    expect(askedFor(0).get("q")).toBe("daft punk");
+    expect(results.map((r) => r.source)).toEqual(["bittorrented-music"]);
+  });
+
+  // "audio" is the API's own vocabulary and a 400 otherwise: it rejects the
+  // obvious "music" outright, so the value is pinned rather than inferred.
+  it("never sends the category name as the media type", async () => {
+    mockFetch.mockResolvedValueOnce(apiPage([]));
+    await bittorrentedMusic.search("daft punk");
+    expect(askedFor(0).get("type")).not.toBe("music");
+  });
+
+  it("skips the request entirely for queries the API would reject", async () => {
+    expect(await bittorrentedMusic.search("ab")).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/sources/bittorrented.ts
+++ b/src/sources/bittorrented.ts
@@ -3,11 +3,13 @@ import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 // BitTorrented is a general index (its own library plus a large DHT crawl).
-// torlink takes its video type only and feeds it to Movies and TV. Anime stays
-// with its dedicated sources (the API can't tell anime from any other video)
-// and Games stays FitGirl's alone. Its JSON API returns real swarm counts, so
-// reportsHealth is true.
+// torlink takes its video type and feeds it to Movies and TV, and its audio
+// type to Music. Anime stays with its dedicated sources (the API can't tell
+// anime from any other video) and Games stays FitGirl's alone. Its JSON API
+// returns real swarm counts, so reportsHealth is true.
 const BASE = "https://bittorrented.com";
+
+type MediaType = "video" | "audio";
 
 // The index requires a real query (the API rejects fewer than 3 characters), so
 // an empty browse returns nothing rather than erroring.
@@ -57,15 +59,19 @@ export function mapBittorrentedResults(results: BtResult[], id: SourceId): Torre
   return out;
 }
 
-async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
+async function search(
+  type: MediaType,
+  query: string,
+  opts: SearchOptions = {},
+): Promise<TorrentResult[]> {
   const q = query.trim();
   if (q.length < MIN_QUERY) return [];
 
-  // Video only: keeps the category tabs plain video and structurally excludes
-  // the index's other media types. One request per search.
+  // One media type per source: keeps each category tab plain (the video index
+  // never leaks audio into Movies/TV, and vice versa). One request per search.
   const params = new URLSearchParams({
     q,
-    type: "video",
+    type,
     limit: "50",
     sortBy: "seeders",
     sortOrder: "desc",
@@ -78,7 +84,11 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
   if (!res.ok) throw new HttpError(res.status, `BitTorrented returned ${res.status}`);
 
   const json = (await res.json()) as BtResponse;
-  return mapBittorrentedResults(json.results ?? [], "bittorrented");
+  return mapBittorrentedResults(json.results ?? [], sourceIdFor(type));
+}
+
+function sourceIdFor(type: MediaType): SourceId {
+  return type === "audio" ? "bittorrented-music" : "bittorrented";
 }
 
 export const bittorrented: Source = {
@@ -87,5 +97,14 @@ export const bittorrented: Source = {
   groups: ["Movies", "TV"],
   homepage: BASE,
   reportsHealth: true,
-  search,
+  search: (query, opts = {}) => search("video", query, opts),
+};
+
+export const bittorrentedMusic: Source = {
+  id: "bittorrented-music",
+  label: "BitTorrented",
+  groups: ["Music"],
+  homepage: BASE,
+  reportsHealth: true,
+  search: (query, opts = {}) => search("audio", query, opts),
 };

--- a/src/sources/piratebay.test.ts
+++ b/src/sources/piratebay.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tpbMovies, tpbTv, tpbMusic } from "./piratebay";
+import { fetchResilient } from "../util/net";
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: vi.fn() };
+});
+
+const mockFetch = vi.mocked(fetchResilient);
+
+const page = (items: unknown[]): Response =>
+  ({ ok: true, status: 200, json: async () => items }) as unknown as Response;
+
+// apibay returns every field as a string; category comes back like "101".
+const row = (category: string | undefined, i: number): Record<string, string | undefined> => ({
+  id: String(i),
+  name: `row-${category ?? "none"}-${i}`,
+  info_hash: String(i).padStart(40, "a"),
+  seeders: "5",
+  leechers: "2",
+  size: "1000",
+  num_files: "1",
+  added: "1700000000",
+  category,
+});
+
+// One row per category across the audio (1xx) and video (2xx) trees, plus a
+// row with no category at all. Any tab's search filter has to carve its exact
+// slice out of this; any drift in the boundary changes a list below.
+const SPECTRUM = [
+  "100",
+  "101",
+  "102",
+  "103",
+  "104",
+  "199",
+  "201",
+  "202",
+  "203",
+  "204",
+  "205",
+  "206",
+  "207",
+  "208",
+  "209",
+  "299",
+].map((c, i) => row(c, i + 1));
+const NO_CATEGORY = row(undefined, 90);
+
+// apibay answers an empty search with this single placeholder instead of [].
+const SENTINEL = {
+  id: "0",
+  name: "No results returned",
+  info_hash: "0000000000000000000000000000000000000000",
+  category: "0",
+};
+
+const askedUrl = (call: number): string => String(mockFetch.mock.calls[call]![0]);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("tpbMusic", () => {
+  it("feeds Music only, never the video tabs", () => {
+    expect(tpbMusic.id).toBe("tpb-music");
+    expect(tpbMusic.groups).toEqual(["Music"]);
+    expect(tpbMusic.reportsHealth).toBe(true);
+  });
+
+  it("searches keep Music (101) and FLAC (104) rows and drop every other category", async () => {
+    mockFetch.mockResolvedValueOnce(page([...SPECTRUM, NO_CATEGORY, SENTINEL]));
+    const results = await tpbMusic.search("daft punk");
+    // The URL carries the query; the boundary, not the exact param list, is
+    // this suite's concern.
+    expect(askedUrl(0)).toContain("/q.php?q=daft%20punk");
+    expect(results.map((r) => r.name)).toEqual(["row-101-2", "row-104-5"]);
+    expect(results.every((r) => r.source === "tpb-music")).toBe(true);
+  });
+
+  // 104 is not decoration: live apibay results for an artist search are
+  // majority FLAC, so dropping it would gut TPB's music coverage.
+  it("excludes audio books (102), sound clips (103), other audio (199) and music videos (203)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      page([row("102", 1), row("103", 2), row("199", 3), row("203", 4)]),
+    );
+    expect(await tpbMusic.search("some artist")).toEqual([]);
+  });
+
+  it("browses the music-only top100 leaf, not the parent audio feed", async () => {
+    mockFetch.mockResolvedValueOnce(page([row("101", 1)]));
+    await tpbMusic.search("");
+    // The 101 leaf is all music; the parent 100 feed mixes in audio books,
+    // which would need a shared-path filter change to keep out. Pinned so a
+    // feed swap is a conscious decision, not a drive-by.
+    expect(askedUrl(0)).toBe("https://apibay.org/precompiled/data_top100_101.json");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes browse rows through without the category filter, like every tab", async () => {
+    mockFetch.mockResolvedValueOnce(page([row("101", 1), row("104", 2), NO_CATEGORY]));
+    const results = await tpbMusic.search("");
+    expect(results).toHaveLength(3);
+  });
+
+  it("drops rows with no category from search results", async () => {
+    mockFetch.mockResolvedValueOnce(page([row("101", 1), NO_CATEGORY]));
+    const results = await tpbMusic.search("daft punk");
+    expect(results.map((r) => r.name)).toEqual(["row-101-1"]);
+  });
+
+  it("never surfaces apibay's no-results sentinel row", async () => {
+    mockFetch.mockResolvedValueOnce(page([SENTINEL]));
+    expect(await tpbMusic.search("qqqqzzzz")).toEqual([]);
+    mockFetch.mockResolvedValueOnce(page([SENTINEL, row("101", 1)]));
+    expect((await tpbMusic.search("")).map((r) => r.name)).toEqual(["row-101-1"]);
+  });
+});
+
+// The Movies and TV pins below assert the behavior those tabs shipped with.
+// The Music source reuses their search path untouched; these make sure that
+// stays true from either direction.
+describe("tpbMovies", () => {
+  it("filters searches to exactly the four movie categories", async () => {
+    mockFetch.mockResolvedValueOnce(page([...SPECTRUM, NO_CATEGORY, SENTINEL]));
+    const results = await tpbMovies.search("dune");
+    expect(results.map((r) => r.name)).toEqual([
+      "row-201-7",
+      "row-202-8",
+      "row-207-13",
+      "row-209-15",
+    ]);
+  });
+
+  it("browses the HD movies feed unfiltered, as before", async () => {
+    mockFetch.mockResolvedValueOnce(page([...SPECTRUM, NO_CATEGORY]));
+    const results = await tpbMovies.search("");
+    expect(askedUrl(0)).toBe("https://apibay.org/precompiled/data_top100_207.json");
+    expect(results).toHaveLength(SPECTRUM.length + 1);
+  });
+});
+
+describe("tpbTv", () => {
+  it("filters searches to exactly the two TV categories", async () => {
+    mockFetch.mockResolvedValueOnce(page([...SPECTRUM, NO_CATEGORY, SENTINEL]));
+    const results = await tpbTv.search("severance");
+    expect(results.map((r) => r.name)).toEqual(["row-205-11", "row-208-14"]);
+  });
+
+  it("browses the HD TV feed unfiltered, as before", async () => {
+    mockFetch.mockResolvedValueOnce(page([...SPECTRUM, NO_CATEGORY]));
+    const results = await tpbTv.search("");
+    expect(askedUrl(0)).toBe("https://apibay.org/precompiled/data_top100_208.json");
+    expect(results).toHaveLength(SPECTRUM.length + 1);
+  });
+});

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -6,9 +6,11 @@ const API = "https://apibay.org";
 
 const MOVIE_CATS = new Set([201, 202, 207, 209]);
 const TV_CATS = new Set([205, 208]);
+const MUSIC_CATS = new Set([101, 104]);
 
 const TOP_MOVIES = `${API}/precompiled/data_top100_207.json`;
 const TOP_TV = `${API}/precompiled/data_top100_208.json`;
+const TOP_MUSIC = `${API}/precompiled/data_top100_101.json`;
 
 interface ApibayItem {
   id?: string;
@@ -90,4 +92,13 @@ export const tpbTv: Source = {
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, TV_CATS, TOP_TV, "tpb-tv", opts),
+};
+
+export const tpbMusic: Source = {
+  id: "tpb-music",
+  label: "TPB",
+  groups: ["Music"],
+  homepage: "https://thepiratebay.org",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, MUSIC_CATS, TOP_MUSIC, "tpb-music", opts),
 };

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -3,7 +3,7 @@ import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
 import { nyaa } from "./nyaa";
 import { subsplease } from "./subsplease";
-import { tpbMovies, tpbTv } from "./piratebay";
+import { tpbMovies, tpbTv, tpbMusic } from "./piratebay";
 import { x1337Movies, x1337Tv } from "./x1337";
 import { yts } from "./yts";
 import type { Source, SourceGroup, SourceId } from "./types";
@@ -19,6 +19,7 @@ export const SOURCES: readonly Source[] = [
   nyaa,
   subsplease,
   bittorrented,
+  tpbMusic,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,4 +1,4 @@
-import { bittorrented } from "./bittorrented";
+import { bittorrented, bittorrentedMusic } from "./bittorrented";
 import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
 import { nyaa } from "./nyaa";
@@ -21,6 +21,7 @@ export const SOURCES: readonly Source[] = [
   bittorrented,
   tpbMusic,
   x1337Music,
+  bittorrentedMusic,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -4,7 +4,7 @@ import { fitgirl } from "./fitgirl";
 import { nyaa } from "./nyaa";
 import { subsplease } from "./subsplease";
 import { tpbMovies, tpbTv, tpbMusic } from "./piratebay";
-import { x1337Movies, x1337Tv } from "./x1337";
+import { x1337Movies, x1337Tv, x1337Music } from "./x1337";
 import { yts } from "./yts";
 import type { Source, SourceGroup, SourceId } from "./types";
 
@@ -20,6 +20,7 @@ export const SOURCES: readonly Source[] = [
   subsplease,
   bittorrented,
   tpbMusic,
+  x1337Music,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -27,7 +27,7 @@ export function getSource(id: SourceId): Source {
   return SOURCES.find((s) => s.id === id) ?? DEFAULT_SOURCE;
 }
 
-const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime"];
+const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime", "Music"];
 
 export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
   return GROUP_ORDER.map((group) => ({

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -6,6 +6,7 @@ export type SourceId =
   | "subsplease"
   | "tpb-movies"
   | "tpb-tv"
+  | "tpb-music"
   | "x1337-movies"
   | "x1337-tv"
   | "bittorrented";

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -10,7 +10,8 @@ export type SourceId =
   | "x1337-movies"
   | "x1337-tv"
   | "x1337-music"
-  | "bittorrented";
+  | "bittorrented"
+  | "bittorrented-music";
 
 export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music";
 

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -10,7 +10,7 @@ export type SourceId =
   | "x1337-tv"
   | "bittorrented";
 
-export type SourceGroup = "Games" | "Movies" | "TV" | "Anime";
+export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music";
 
 export interface TorrentResult {
   infoHash: string;

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -9,6 +9,7 @@ export type SourceId =
   | "tpb-music"
   | "x1337-movies"
   | "x1337-tv"
+  | "x1337-music"
   | "bittorrented";
 
 export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Music";

--- a/src/sources/x1337.test.ts
+++ b/src/sources/x1337.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { parseUploadDate } from "./x1337";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { parseUploadDate, x1337Movies, x1337Tv, x1337Music } from "./x1337";
+import { fetchResilient } from "../util/net";
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: vi.fn() };
+});
+
+const mockFetch = vi.mocked(fetchResilient);
 
 const detail = (span: string) =>
   `<ul class="list"><li><strong>Date uploaded</strong><span>${span}</span> </li></ul>`;
@@ -19,5 +27,76 @@ describe("parseUploadDate", () => {
   it("returns undefined when the field is missing or unparseable", () => {
     expect(parseUploadDate("<div>no date here</div>")).toBeUndefined();
     expect(parseUploadDate(detail("sometime"))).toBeUndefined();
+  });
+});
+
+const listPage = (rows: { path: string; name: string; seeds: number }[]): string =>
+  `<table class="table-list">` +
+  rows
+    .map(
+      (r) =>
+        `<tr><td class="coll-1"><a href="${r.path}">${r.name}</a></td>` +
+        `<td class="coll-2 seeds">${r.seeds}</td><td class="coll-3 leeches">1</td>` +
+        `<td class="coll-4 size mob">1.2 GB</td></tr>`,
+    )
+    .join("") +
+  `</table>`;
+
+const detailPage = `<a href="magnet:?xt=urn:btih:${"c".repeat(40)}&dn=x">magnet</a>`;
+
+const html = (body: string): Response =>
+  ({ ok: true, status: 200, text: async () => body }) as unknown as Response;
+
+// Serve by URL shape so a stray extra request can never exhaust the mock and
+// push the module's host rotation off the first mirror mid-suite.
+const serveList = (body: string): void => {
+  mockFetch.mockImplementation(async (url: string) =>
+    url.includes("/torrent/") ? html(detailPage) : html(body),
+  );
+};
+
+const askedPath = (call: number): string =>
+  new URL(String(mockFetch.mock.calls[call]![0])).pathname;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("x1337Music", () => {
+  it("feeds Music only, never the video tabs", () => {
+    expect(x1337Music.id).toBe("x1337-music");
+    expect(x1337Music.groups).toEqual(["Music"]);
+    expect(x1337Music.reportsHealth).toBe(true);
+  });
+
+  it("browses /popular-music when the query is empty", async () => {
+    serveList(listPage([{ path: "/torrent/1/a/", name: "Some Album FLAC", seeds: 9 }]));
+    const results = await x1337Music.search("");
+    expect(askedPath(0)).toBe("/popular-music");
+    expect(results.map((r) => r.source)).toEqual(["x1337-music"]);
+    expect(results[0]!.magnet).toContain("magnet:?xt=urn:btih:");
+  });
+
+  it("searches through /category-search with the query plus-joined and Music as the category", async () => {
+    serveList(listPage([{ path: "/torrent/2/b/", name: "Daft Punk Discovery", seeds: 5 }]));
+    const results = await x1337Music.search("daft punk");
+    expect(askedPath(0)).toBe("/category-search/daft+punk/Music/1/");
+    expect(results.map((r) => r.name)).toEqual(["Daft Punk Discovery"]);
+  });
+});
+
+// The slug map replaced a Movies/TV ternary; these pin that the two existing
+// tabs still ask for the same pages they always did.
+describe("x1337 browse slugs", () => {
+  it("keeps Movies on /popular-movies", async () => {
+    serveList(listPage([]));
+    await x1337Movies.search("");
+    expect(askedPath(0)).toBe("/popular-movies");
+  });
+
+  it("keeps TV on /popular-tv", async () => {
+    serveList(listPage([]));
+    await x1337Tv.search("");
+    expect(askedPath(0)).toBe("/popular-tv");
   });
 });

--- a/src/sources/x1337.ts
+++ b/src/sources/x1337.ts
@@ -81,14 +81,19 @@ async function detailInfo(
 
 async function search(
   query: string,
-  cat: "Movies" | "TV",
+  cat: "Movies" | "TV" | "Music",
   source: SourceId,
   opts: SearchOptions = {},
 ): Promise<TorrentResult[]> {
   const q = query.trim();
+  const popularSlug: Record<"Movies" | "TV" | "Music", string> = {
+    Movies: "movies",
+    TV: "tv",
+    Music: "music",
+  };
   const path = q
     ? `/category-search/${encodeURIComponent(q).replace(/%20/g, "+")}/${cat}/1/`
-    : `/popular-${cat === "Movies" ? "movies" : "tv"}`;
+    : `/popular-${popularSlug[cat]}`;
 
   let base = "";
   let html = "";
@@ -157,4 +162,13 @@ export const x1337Tv: Source = {
   homepage: "https://1337x.to",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, "TV", "x1337-tv", opts),
+};
+
+export const x1337Music: Source = {
+  id: "x1337-music",
+  label: "1337x",
+  groups: ["Music"],
+  homepage: "https://1337x.to",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, "Music", "x1337-music", opts),
 };

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -7,7 +7,7 @@ import type { SourceGroup, SourceId } from "../sources/types";
 
 export type View = "splash" | "browser";
 
-export type Category = "all" | "games" | "movies" | "tv" | "anime";
+export type Category = "all" | "games" | "movies" | "tv" | "anime" | "music";
 
 export type Section = Category | "downloads" | "seeding";
 
@@ -17,6 +17,7 @@ export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[]
   { key: "movies", label: "Movies", group: "Movies" },
   { key: "tv", label: "TV", group: "TV" },
   { key: "anime", label: "Anime", group: "Anime" },
+  { key: "music", label: "Music", group: "Music" },
 ];
 
 export type Region = "sidebar" | "content" | "help";

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -39,6 +39,7 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "tpb-music": { tag: "TPB", color: "#5fd0c5" },
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
+  "x1337-music": { tag: "1337", color: "#f6a55c" },
   bittorrented: { tag: "BT", color: "#7db8f0" },
 };
 

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -36,6 +36,7 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   subsplease: { tag: "SUB", color: "#b9a7e6" },
   "tpb-movies": { tag: "TPB", color: "#5fd0c5" },
   "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
+  "tpb-music": { tag: "TPB", color: "#5fd0c5" },
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
   bittorrented: { tag: "BT", color: "#7db8f0" },

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -41,6 +41,7 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
   "x1337-music": { tag: "1337", color: "#f6a55c" },
   bittorrented: { tag: "BT", color: "#7db8f0" },
+  "bittorrented-music": { tag: "BT", color: "#7db8f0" },
 };
 
 // Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or


### PR DESCRIPTION
## What and why

Adds a Music tab alongside Games/Movies/TV/Anime, fed by the three existing sources that carry music well: The Pirate Bay, 1337x, and BitTorrented. Each gets a dedicated music source id, so the tab, the outage copy, the source tags, and the `z` alive-only filter all work exactly like the existing tabs. No behaviour changes to any existing tab, and the shared TPB search path is untouched — the evidence for why it doesn't need to be is below.

The branch is six commits, one concern each: the Music group/category plumbing, then one commit per source (each shipping its own tests), then the README row, then the regenerated previews.

## How each source is queried

| Source | id | Search | Browse (empty query) |
|---|---|---|---|
| TPB | `tpb-music` | `q.php?q=…`, filtered client-side to the category set below — the same path Movies/TV use, unmodified | `precompiled/data_top100_101.json`, the music-only leaf feed |
| 1337x | `x1337-music` | `/category-search/<query>/Music/1/`, then magnet detail fetches, mirror rotation as before | `/popular-music` |
| BitTorrented | `bittorrented-music` | `/api/search/torrents?type=audio&…` (`audio` is the API's own vocabulary; it rejects queries under 3 chars, which return `[]` quietly) | none by design — the API is query-only |

All three report real swarm counts, so `reportsHealth` stays true.

## The TPB category boundary

`MUSIC_CATS = {101, 104}`:

| cat | name | in/out | why |
|---|---|---|---|
| 101 | Music | in | the tab |
| 104 | FLAC | in | it's music, and live searches are majority-FLAC (a `metallica` search today: 50 of 100 rows) — excluding it would gut TPB's coverage |
| 102 | Audio books | out | spoken word, not music |
| 103 | Sound clips | out | effects and samples; mirrors Movies excluding 204 (movie clips) |
| 199 | Audio other | out | mirrors Movies excluding 299 |
| 203 | Music videos | out | video, not audio; no tab claims it, deliberately |

## Why the shared TPB search path is left alone

The browse feed decides it. `data_top100_101.json` (the music leaf) returns 100 rows, 100% category 101 — verified live. The parent `data_top100_100.json` mixes in audio books (today: 8×101, 5×102, 87×104), so browsing it would either leak audiobooks into Music or force a filter change in the code path Movies and TV share. Browsing the leaf needs neither, and it mirrors the existing grain exactly: Movies searches four categories but browses the single 207 feed, TV searches two and browses 208. (A FLAC-only `…_104.json` feed also exists; one feed per tab keeps browse a single request, and 104 stays fully covered in search.) The one shared-file refactor, the x1337 popular-page slug map, replaces a Movies/TV ternary with identical output — both slugs are now pinned by tests.

## What the tests pin

- `piratebay.test.ts` (new): the 101/104-in, 102/103/199/203-out boundary; browse hitting the 101 leaf URL exactly; browse rows passing through unfiltered like every tab; no-category rows dropping from searches; apibay's "No results returned" placeholder never surfacing; and regression pins that Movies searches still return exactly {201, 202, 207, 209}, TV exactly {205, 208}, and both browse the same feeds as before, unfiltered.
- `x1337.test.ts`: Music browses `/popular-music` and searches `/category-search/<q>/Music/1/`; Movies and TV stay on `/popular-movies` and `/popular-tv`.
- `bittorrented.test.ts`: the music source asks `type=audio` and tags rows `bittorrented-music`; the video source never gained Music.

`npm run typecheck` is clean and `npm test` passes 306/306. Cross-platform, via a throwaway Actions matrix on my fork at this exact head: **all green on ubuntu-latest, windows-latest, and macos-latest** ([branch run](https://github.com/zanmlakar/torlink/actions/runs/31803227214)), and a matching matrix on `main` ([here](https://github.com/zanmlakar/torlink/actions/runs/31801010416)) confirms identical, empty failure sets — this branch introduces nothing platform-specific.

<details>
<summary>Live verification through the real source modules (2026-08-14)</summary>

- `tpbMusic.search("")` → 100 rows with magnets (the 101 leaf feed)
- `tpbMusic.search("daft punk")` → 75 rows after the category filter
- `x1337Music.search("")` → rows with magnets via mirror rotation (the first hosts 403 from this network; `1337xx.to` answered — the same rotation Movies/TV already rely on)
- `x1337Music.search("daft punk")` → 4 rows with magnets
- `bittorrentedMusic.search("daft punk")` → 5 rows
- Verifying TPB live also surfaced an apibay quirk that already affects Movies/TV: per-URL sentinel cache poisoning (`metallica` returns "No results returned" on the bare form while `&cat=0` returns 100 rows). That's its own concern, fixed separately in #155.

![The Music tab in the sidebar](https://raw.githubusercontent.com/zanmlakar/torlink/music_tab/preview/browse.svg)

</details>

Previews regenerated with `npm run previews` (zero drift against the committed SVGs), README source table updated, no new keys, no new `Store` fields.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
