### PR TITLE
fix: keep a torrent's own trackers in the magnet built from its file

### DIFF
--- a/src/parse-torrent.d.ts
+++ b/src/parse-torrent.d.ts
@@ -2,6 +2,7 @@ declare module "parse-torrent" {
   interface ParsedTorrent {
     infoHash: string;
     name?: string;
+    announce?: string[];
   }
   export default function parseTorrent(
     torrentId: Uint8Array | string,

--- a/src/sources/magnet.test.ts
+++ b/src/sources/magnet.test.ts
@@ -49,6 +49,20 @@ describe("buildMagnet", () => {
     // At least one non-UDP tracker, so UDP-blocked networks can still announce.
     expect(out).toContain(encodeURIComponent("http://tracker.opentrackr.org:1337/announce"));
   });
+  it("puts extra trackers ahead of the public defaults", () => {
+    const own = "http://private.example.org/announce?pk=xyz";
+    const out = buildMagnet("abc123", "Thing", [own]);
+    const mine = out.indexOf(`&tr=${encodeURIComponent(own)}`);
+    expect(mine).toBeGreaterThan(-1);
+    expect(mine).toBeLessThan(
+      out.indexOf(encodeURIComponent("udp://tracker.opentrackr.org:1337/announce")),
+    );
+  });
+  it("keeps one copy of a tracker that is also a default, and drops blanks", () => {
+    const dupe = "udp://tracker.opentrackr.org:1337/announce";
+    const out = buildMagnet("abc123", "Thing", [dupe, "  ", dupe]);
+    expect(out.split(`&tr=${encodeURIComponent(dupe)}`).length - 1).toBe(1);
+  });
 });
 
 describe("isInfoHash", () => {

--- a/src/sources/magnet.ts
+++ b/src/sources/magnet.ts
@@ -14,9 +14,18 @@ const TRACKERS = [
   "https://tracker.tamersunion.org:443/announce",
 ];
 
-export function buildMagnet(infoHash: string, name: string): string {
+// extraTrackers come first and win on duplicates: a torrent that carries its own
+// announce list means that list, and the public defaults are only a fallback.
+export function buildMagnet(infoHash: string, name: string, extraTrackers: string[] = []): string {
   const dn = encodeURIComponent(name);
-  const tr = TRACKERS.map((t) => `&tr=${encodeURIComponent(t)}`).join("");
+  const seen = new Set<string>();
+  const trackers = [...extraTrackers, ...TRACKERS].filter((t) => {
+    const url = t.trim();
+    if (!url || seen.has(url)) return false;
+    seen.add(url);
+    return true;
+  });
+  const tr = trackers.map((t) => `&tr=${encodeURIComponent(t)}`).join("");
   return `magnet:?xt=urn:btih:${infoHash}&dn=${dn}${tr}`;
 }
 

--- a/src/sources/torrentFile.test.ts
+++ b/src/sources/torrentFile.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { magnetFromTorrentFile } from "./torrentFile";
+
+// Hand-rolled bencode, so the fixture is a real .torrent parse-torrent accepts
+// rather than a checked-in binary blob.
+function bstr(s: string): Buffer {
+  const b = Buffer.from(s, "utf8");
+  return Buffer.concat([Buffer.from(`${b.length}:`), b]);
+}
+
+function makeTorrent(announce: string[]): Buffer {
+  const info = Buffer.concat([
+    Buffer.from("d"),
+    bstr("length"),
+    Buffer.from("i1024e"),
+    bstr("name"),
+    bstr("test.bin"),
+    bstr("piece length"),
+    Buffer.from("i16384e"),
+    bstr("pieces"),
+    Buffer.from("20:"),
+    Buffer.alloc(20, 7),
+    Buffer.from("e"),
+  ]);
+  const head: Buffer[] = [Buffer.from("d")];
+  if (announce[0]) head.push(bstr("announce"), bstr(announce[0]));
+  if (announce.length) {
+    head.push(bstr("announce-list"), Buffer.from("l"));
+    for (const url of announce) head.push(Buffer.from("l"), bstr(url), Buffer.from("e"));
+    head.push(Buffer.from("e"));
+  }
+  return Buffer.concat([...head, bstr("info"), info, Buffer.from("e")]);
+}
+
+let dir: string;
+
+beforeAll(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-torrentfile-"));
+});
+
+afterAll(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+async function write(name: string, data: Buffer): Promise<string> {
+  const file = path.join(dir, name);
+  await fs.writeFile(file, data);
+  return file;
+}
+
+describe("magnetFromTorrentFile", () => {
+  it("reads the info hash and name out of a .torrent", async () => {
+    const file = await write("plain.torrent", makeTorrent([]));
+    const parsed = await magnetFromTorrentFile(file);
+    expect(parsed?.name).toBe("test.bin");
+    expect(parsed?.infoHash).toMatch(/^[a-f0-9]{40}$/);
+  });
+
+  it("puts the torrent's own trackers in the magnet, ahead of the public ones", async () => {
+    const own = "http://private.example.org/announce?pk=xyz";
+    const file = await write("private.torrent", makeTorrent([own]));
+    const parsed = await magnetFromTorrentFile(file);
+    const mine = parsed!.magnet.indexOf(`&tr=${encodeURIComponent(own)}`);
+    expect(mine).toBeGreaterThan(-1);
+    expect(mine).toBeLessThan(
+      parsed!.magnet.indexOf(encodeURIComponent("udp://tracker.opentrackr.org:1337/announce")),
+    );
+  });
+
+  it("keeps one copy of a tracker the defaults already carry", async () => {
+    const dupe = "udp://tracker.opentrackr.org:1337/announce";
+    const file = await write("dupe.torrent", makeTorrent([dupe]));
+    const parsed = await magnetFromTorrentFile(file);
+    const hits = parsed!.magnet.split(`&tr=${encodeURIComponent(dupe)}`).length - 1;
+    expect(hits).toBe(1);
+  });
+
+  it("returns null for a missing file, a directory, an empty file, and junk", async () => {
+    expect(await magnetFromTorrentFile(path.join(dir, "nope.torrent"))).toBe(null);
+    expect(await magnetFromTorrentFile(dir)).toBe(null);
+    expect(await magnetFromTorrentFile(await write("empty.torrent", Buffer.alloc(0)))).toBe(null);
+    expect(
+      await magnetFromTorrentFile(await write("junk.torrent", Buffer.from("not a torrent"))),
+    ).toBe(null);
+  });
+
+  it("refuses a file too large to be metadata rather than reading it in", async () => {
+    const big = await write("big.torrent", Buffer.alloc(17 * 1024 * 1024));
+    expect(await magnetFromTorrentFile(big)).toBe(null);
+  });
+});

--- a/src/sources/torrentFile.ts
+++ b/src/sources/torrentFile.ts
@@ -2,14 +2,28 @@ import { promises as fs } from "node:fs";
 import parseTorrent from "parse-torrent";
 import { buildMagnet, type ParsedMagnet } from "./magnet";
 
+// A .torrent is metadata, not payload: even a torrent with tens of thousands of
+// pieces stays in the low megabytes. The cap is what keeps a mis-named disk
+// image dropped in the watch folder from being pulled into memory whole.
+const MAX_TORRENT_BYTES = 16 * 1024 * 1024;
+
 export async function magnetFromTorrentFile(path: string): Promise<ParsedMagnet | null> {
   try {
+    const stat = await fs.stat(path);
+    if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TORRENT_BYTES) return null;
     const buf = await fs.readFile(path);
     const parsed = await parseTorrent(new Uint8Array(buf));
     const infoHash = parsed?.infoHash?.toLowerCase();
     if (!infoHash) return null;
     const name = parsed.name || infoHash;
-    return { infoHash, name, magnet: buildMagnet(infoHash, name) };
+    // Carry the file's own announce list into the magnet. Without it a torrent
+    // that isn't on the public DHT — a private tracker, a small private swarm —
+    // sits at zero peers forever, and on a private tracker the passkey that
+    // makes an announce work at all lives in that URL.
+    const announce = Array.isArray(parsed.announce)
+      ? parsed.announce.filter((url): url is string => typeof url === "string")
+      : [];
+    return { infoHash, name, magnet: buildMagnet(infoHash, name, announce) };
   } catch {
     return null;
   }


### PR DESCRIPTION
## What and why

`magnetFromTorrentFile` parsed a `.torrent`, took the info hash and the name, and then rebuilt the
magnet from the public default trackers alone — the file's own announce list was dropped on the
floor. That is the path both the watch folder and `torlnk <file>.torrent` go through.

For a torrent that lives on the public DHT this is invisible. For one that doesn't — a private
tracker, a small private swarm, anything announce-only — it means zero peers forever, and the
failure looks like "the torrent is dead" rather than "we threw away the address". On a private
tracker it's worse than slower: the passkey that makes an announce work at all lives in that URL,
so without it there is no way in.

The file's trackers now go into the magnet ahead of the defaults and are deduplicated, so a
torrent that lists a tracker we already ship doesn't get it twice. `buildMagnet` takes them as an
optional third argument, so every existing caller is untouched.

One thing rode along, because it's in the same function and the same read: `magnetFromTorrentFile`
now stats before it reads and refuses a file too large to be metadata (16 MB). A `.torrent` stays
in the low megabytes even with tens of thousands of pieces, and a watch folder takes whatever gets
dropped into it, including a mis-named disk image. Happy to split it out if you'd rather.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes — with one caveat: on my Windows box 5 test files (`daemon/runtime`,
      `daemon/serve`, `daemon/watch`, `download/queue`, `download/queue.safemode`) fail to load
      `node-datachannel`. They fail identically on a clean `main` here, so it's my environment and
      not this change. Everything else passes, including the new tests.
- [x] New logic has a test — `src/sources/torrentFile.test.ts` (new) builds real bencode fixtures
      rather than checking in a binary blob, and covers the tracker order, the dedup, the size
      refusal, and the null paths (missing file, directory, empty, junk). `magnet.test.ts` covers
      `buildMagnet`'s new argument.
- [x] No new key
- [x] No new `Store` field
- [x] OS-touching code works on Windows, macOS, and Linux — `fs.stat` only
- [x] One concern, Conventional Commits title
