### PR TITLE
feat: accept a .torrent dragged onto the search field

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ torlink is a torrent finder that lives in your terminal, with zero setup and not
    npx torlnk
    ```
 
-That's the only thing you'll type. torlink opens straight to a search bar: search for what you want, paste in a magnet link or a bare infohash, or just press Enter on an empty box to browse the curated library. From there it's all keypresses, nothing to memorize, and `?` brings up the full list anytime.
+That's the only thing you'll type. torlink opens straight to a search bar: search for what you want, paste in a magnet link or a bare infohash, drag a `.torrent` file from your file manager onto the window, or just press Enter on an empty box to browse the curated library. From there it's all keypresses, nothing to memorize, and `?` brings up the full list anytime.
 
 ## Finding something
 

--- a/src/config/folder.ts
+++ b/src/config/folder.ts
@@ -1,13 +1,22 @@
 import os from "node:os";
 import path from "node:path";
 
+// node:path doesn't export its interface by name, so borrow it off a member.
+type PlatformPath = typeof path.win32;
+
 // We read the raw input field, so expand a leading ~ ourselves (~\ too, for
 // paths pasted from Windows). ~bob isn't us, so leave it alone.
-export function expandHome(input: string, home: string = os.homedir()): string {
+// `p` lets a caller reasoning about one platform's paths (and its tests) pass
+// path.win32 / path.posix instead of the host's flavour; it defaults to the host.
+export function expandHome(
+  input: string,
+  home: string = os.homedir(),
+  p: PlatformPath = path,
+): string {
   const trimmed = input.trim();
   if (trimmed === "~") return home;
   if (trimmed.startsWith("~/") || trimmed.startsWith("~\\")) {
-    return path.join(home, trimmed.slice(2));
+    return p.join(home, trimmed.slice(2));
   }
   return trimmed;
 }

--- a/src/sources/torrentPath.test.ts
+++ b/src/sources/torrentPath.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { resolveTorrentPath, unquote, fromFileUrl } from "./torrentPath";
+
+// Both platforms are exercised from either host: the point of the module is
+// that a path escaped by one OS's terminal is understood, and CI shouldn't
+// only check the half that matches the runner.
+const WIN = { windows: true, home: "C:\\Users\\u" };
+const NIX = { windows: false, home: "/home/u" };
+
+describe("unquote", () => {
+  it("strips a matching pair of double quotes and the trailing space a drop leaves", () => {
+    expect(unquote('"C:\\Users\\u\\a.torrent" ')).toBe("C:\\Users\\u\\a.torrent");
+  });
+  it("strips single quotes too", () => {
+    expect(unquote("'/home/u/a.torrent'")).toBe("/home/u/a.torrent");
+  });
+  it("leaves an unmatched or interior quote alone", () => {
+    expect(unquote('"/home/u/a.torrent')).toBe('"/home/u/a.torrent');
+    expect(unquote("/home/u/it's.torrent")).toBe("/home/u/it's.torrent");
+  });
+});
+
+describe("fromFileUrl", () => {
+  it("decodes a POSIX file URI", () => {
+    expect(fromFileUrl("file:///home/u/My%20Show.torrent", false)).toBe("/home/u/My Show.torrent");
+  });
+  it("drops the slash before a Windows drive letter", () => {
+    expect(fromFileUrl("file:///C:/Users/u/a.torrent", true)).toBe("C:/Users/u/a.torrent");
+  });
+  it("accepts the file://localhost/ form", () => {
+    expect(fromFileUrl("file://localhost/home/u/a.torrent", false)).toBe("/home/u/a.torrent");
+  });
+  it("returns null for a non-URI and for a broken escape", () => {
+    expect(fromFileUrl("/home/u/a.torrent", false)).toBe(null);
+    expect(fromFileUrl("file:///home/u/100%.torrent", false)).toBe(null);
+  });
+});
+
+describe("resolveTorrentPath", () => {
+  it("takes the quoted path with a trailing space that Windows Terminal drops", () => {
+    expect(resolveTorrentPath('"C:\\Users\\u\\Downloads\\My Show.torrent" ', WIN)).toBe(
+      "C:\\Users\\u\\Downloads\\My Show.torrent",
+    );
+  });
+  it("keeps Windows backslashes rather than reading them as escapes", () => {
+    expect(resolveTorrentPath("C:\\Users\\u\\a.torrent", WIN)).toBe("C:\\Users\\u\\a.torrent");
+  });
+  it("unescapes the backslashes macOS and Linux terminals add for spaces", () => {
+    expect(resolveTorrentPath("/home/u/My\\ Show\\ \\(2024\\).torrent", NIX)).toBe(
+      "/home/u/My Show (2024).torrent",
+    );
+  });
+  it("resolves the file:// URI GNOME Terminal pastes", () => {
+    expect(resolveTorrentPath("file:///home/u/My%20Show.torrent", NIX)).toBe(
+      "/home/u/My Show.torrent",
+    );
+  });
+  it("expands a typed ~ path", () => {
+    expect(resolveTorrentPath("~/Downloads/a.torrent", NIX)).toBe("/home/u/Downloads/a.torrent");
+  });
+  it("accepts an uppercase extension", () => {
+    expect(resolveTorrentPath("/home/u/A.TORRENT", NIX)).toBe("/home/u/A.TORRENT");
+  });
+  it("returns null for a search query, a magnet, and empty input", () => {
+    expect(resolveTorrentPath("the matrix 1999", NIX)).toBe(null);
+    expect(resolveTorrentPath("magnet:?xt=urn:btih:" + "a".repeat(40), NIX)).toBe(null);
+    expect(resolveTorrentPath("   ", NIX)).toBe(null);
+  });
+  it("returns null for a file that isn't a .torrent", () => {
+    expect(resolveTorrentPath('"C:\\Users\\u\\holiday.mp4"', WIN)).toBe(null);
+  });
+});

--- a/src/sources/torrentPath.ts
+++ b/src/sources/torrentPath.ts
@@ -1,0 +1,66 @@
+// A file dragged onto a terminal window never arrives as a clean path: every
+// emulator escapes it its own way. Windows Terminal and PowerShell wrap it in
+// double quotes (and leave a trailing space), macOS Terminal and iTerm2 escape
+// spaces and parens with backslashes, GNOME Terminal pastes a file:// URI.
+// Normalize all of those back to a plain path before we touch the disk.
+
+import os from "node:os";
+import path from "node:path";
+import { expandHome } from "../config/folder";
+
+export interface TorrentPathOptions {
+  home?: string;
+  // Platform of the *path*, not of the process: a Windows path keeps its
+  // backslashes, a POSIX one has them stripped as escapes. Defaults to the
+  // host, and is passed explicitly by the tests so all three shapes are
+  // checked on every OS rather than only on the one that produces them.
+  windows?: boolean;
+}
+
+// Strips one matching pair of surrounding quotes. Callers get a trimmed string
+// either way, so a dropped path's trailing space is gone before anything else.
+export function unquote(input: string): string {
+  const s = input.trim();
+  const first = s[0];
+  if (s.length >= 2 && (first === '"' || first === "'") && s[s.length - 1] === first) {
+    return s.slice(1, -1).trim();
+  }
+  return s;
+}
+
+// file:///home/u/a.torrent -> /home/u/a.torrent, file:///C:/u/a.torrent -> C:/u/a.torrent.
+// Decoded by hand rather than via fileURLToPath so the result depends on the
+// path's platform, not the running one. Returns null for anything not a file URI.
+export function fromFileUrl(input: string, windows: boolean): string | null {
+  const m = /^file:\/\/(?:localhost)?(\/.*)$/i.exec(input);
+  if (!m) return null;
+  let p: string;
+  try {
+    p = decodeURIComponent(m[1]!);
+  } catch {
+    return null; // a stray % that isn't an escape
+  }
+  // A Windows URI carries a leading slash before the drive letter: /C:/x -> C:/x.
+  if (windows && /^\/[a-z]:/i.test(p)) p = p.slice(1);
+  return p;
+}
+
+// Raw input field text -> a path to read, or null if this isn't a .torrent path
+// at all (an ordinary search query, a magnet link). Existence isn't checked
+// here; the caller reads the file and reports its own failure.
+export function resolveTorrentPath(raw: string, options: TorrentPathOptions = {}): string | null {
+  const windows = options.windows ?? process.platform === "win32";
+  const home = options.home ?? os.homedir();
+  const unquoted = unquote(raw);
+  if (!unquoted) return null;
+
+  const p = windows ? path.win32 : path.posix;
+  const url = fromFileUrl(unquoted, windows);
+  // Backslash is a path separator on Windows, so only POSIX unescapes: there
+  // `My\ Files` means one folder named "My Files".
+  const bare = url ?? (windows ? unquoted : unquoted.replace(/\\(.)/g, "$1"));
+  if (!/\.torrent$/i.test(bare)) return null;
+  // A URI is already absolute; only typed input can carry a ~.
+  const expanded = url ?? expandHome(bare, home, p);
+  return p.normalize(expanded);
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -16,6 +16,7 @@ import {
 import { logCrash } from "../util/crashlog";
 import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
+import { resolveTorrentPath } from "../sources/torrentPath";
 import { readClipboard, writeClipboard } from "../util/clipboard";
 import { openFolder } from "../util/openFolder";
 import { cleanText, formatBytes, truncate } from "../util/format";
@@ -152,7 +153,7 @@ export function App({
       const launch = initialMagnet
         ? parseInput(initialMagnet)
         : initialTorrent
-          ? await magnetFromTorrentFile(initialTorrent)
+          ? await magnetFromTorrentFile(resolveTorrentPath(initialTorrent) ?? initialTorrent)
           : null;
       if (launch) {
         await fs.mkdir(cfg.downloadDir, { recursive: true }).catch(() => {});
@@ -384,6 +385,25 @@ export function App({
     [queue, config],
   );
 
+  // A .torrent dragged onto the terminal lands in the search field as a path.
+  // Read it, hand the queue the magnet built from its metadata, and say so when
+  // it can't be read rather than quietly searching for the path text.
+  const startFromTorrentFile = useCallback(
+    (file: string) => {
+      setNotice(`Reading torrent file: ${truncate(file, 48)}`);
+      void (async () => {
+        const parsed = await magnetFromTorrentFile(file);
+        if (!parsed) {
+          setNotice(`Couldn't read a torrent from ${truncate(file, 48)}.`);
+          return;
+        }
+        startDownload({ id: parsed.infoHash, name: parsed.name, magnet: parsed.magnet });
+      })();
+      setView("browser");
+    },
+    [startDownload],
+  );
+
   const submitQuery = useCallback(
     (raw: string) => {
       const q = raw.trim();
@@ -398,13 +418,18 @@ export function App({
           setView("browser");
           return;
         }
+        const file = resolveTorrentPath(q);
+        if (file) {
+          startFromTorrentFile(file);
+          return;
+        }
       }
       setQuery(q);
       setView("browser");
       if (section === "downloads") setSection("all");
       setRegion("content");
     },
-    [section, startDownload],
+    [section, startDownload, startFromTorrentFile],
   );
 
   const pasteFromClipboard = useCallback(async () => {
@@ -420,8 +445,15 @@ export function App({
       setView("browser");
       return;
     }
+    // Copying a file in a file manager puts its path on the clipboard, so paste
+    // takes one too — same handling as a drag onto the search field.
+    const file = resolveTorrentPath(text);
+    if (file) {
+      startFromTorrentFile(file);
+      return;
+    }
     setNotice("No magnet link on the clipboard.");
-  }, [startDownload]);
+  }, [startDownload, startFromTorrentFile]);
 
   useEffect(() => {
     if (!notice) return;

--- a/src/ui/views/Splash.tsx
+++ b/src/ui/views/Splash.tsx
@@ -58,7 +58,7 @@ export function Splash({
           width={barWidth}
           value=""
           editing
-          placeholder="Search or paste a magnet link…"
+          placeholder="Search, paste a magnet, or drop a .torrent…"
           onSubmit={submitQuery}
           onExitDown={() => submitQuery("")}
         />


### PR DESCRIPTION
## What and why

Dragging a file onto a terminal window pastes its path into whatever is reading input. That's the
gesture people already reach for when they have a `.torrent` on disk, and torlink half-supported
it: the search field took a magnet or a bare infohash, but a path was just a search query, so the
obvious move silently searched for `C:\Users\...\thing.torrent` and found nothing. `torlnk
<file>.torrent` worked from the shell, but there was no way in from inside the running app.

The search field now recognises a `.torrent` path and downloads it. The work is in getting the
path back out of what the terminal actually pastes, because no two emulators agree:

| Emulator | What lands in the field |
| --- | --- |
| Windows Terminal, PowerShell | `"C:\Users\u\My Show.torrent"` plus a trailing space |
| macOS Terminal, iTerm2 | `/Users/u/My\ Show\ \(2024\).torrent` |
| GNOME Terminal | `file:///home/u/My%20Show.torrent` |

`resolveTorrentPath` unwraps all three. The backslash rule is split by platform — an escape on
macOS and Linux, a path separator on Windows — because unescaping a Windows path would destroy it.
It takes the platform as an option rather than reading `process.platform` only, so the tests drive
both from either host instead of covering only the half that matches the runner.

Two smaller things follow from the same helper: paste (`v`) takes a path too, since copying a file
in a file manager is how a path gets on the clipboard in the first place; and `torlnk
<file>.torrent` runs its argument through the same normalizer, so a shell-quoted or `file://`
argument works there as well.

A path that turns out not to be a readable torrent reports that, rather than falling back to a
search — the one thing worse than not supporting the gesture is supporting it silently badly.

No new key and no change to an existing one. `↵` on the search field already meant "do something
with this"; this widens what it accepts, next to the magnet and infohash cases that were already
there. The splash placeholder now says so.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes — with one caveat: on my Windows box 5 test files (`daemon/runtime`,
      `daemon/serve`, `daemon/watch`, `download/queue`, `download/queue.safemode`) fail to load
      `node-datachannel`. They fail identically on a clean `main` here, so it's my environment and
      not this change. Everything else passes, including the 15 new tests.
- [x] New logic has a test — `src/sources/torrentPath.test.ts`, covering all three emulator
      shapes on both platforms, `~` expansion, uppercase extensions, and the cases that must stay
      a search (plain query, magnet, blank, a non-torrent file).
- [x] No new key, so `HELP_GROUPS` / `footerHints` are unchanged
- [x] No new `Store` field, so `makeStore` is unchanged
- [x] OS-touching code works on Windows, macOS, and Linux — that's the substance of the change
- [x] One concern, Conventional Commits title

## Note on ordering

This is independent of my other PR (`fix: keep a torrent's own trackers…`) and the two touch
different files, so they merge in either order. They do compose, though: dropping a private
torrent's file is exactly the case where the discarded announce list mattered most.
