### PR TITLE
feat: cap download and upload speed with `r`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Active downloads sit up top with their progress, speed, and time left; when one 
 
 Downloads run in the background while you keep searching, so you can queue up as many as you want. They save to your downloads folder, and the Downloads pane keeps tabs on each one; press `o` anytime to change where that is, or grab one result with `shift+d` to send it somewhere else without touching the default. When something finishes it keeps seeding automatically so the next person can find it too, and the Seeding tab lets you pause or stop that anytime.
 
+If a download is eating the whole line, press `r` and cap it: type `5 MB/s` to limit downloads, or `5 MB/s, 1 MB/s` to cap uploads too. An empty field lifts the cap. The change applies right away, to whatever is already running, and it sticks across launches — the upload side matters as much as the download one, since a finished torrent keeps seeding and a saturated upstream slows everything else on the connection. `TORLINK_DOWNLOAD_LIMIT` and `TORLINK_UPLOAD_LIMIT` set the starting values for a headless run.
+
 <p align="center">
   <img src="preview/downloads.svg" alt="torlink's Downloads pane: live progress on top, recently downloaded below" style="max-width: 832px; width: 100%; height: auto;">
 </p>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,23 +1,55 @@
 import { promises as fs } from "node:fs";
 import { configFile, defaultDownloadDir } from "./paths";
 import { serializeWrites, writeJsonAtomic } from "../util/atomic";
+import { parseRate } from "../util/format";
 
 export interface Config {
   downloadDir: string;
   trackers: string[];
+  /** Global download throttle in bytes/sec; 0 means unlimited. */
+  downloadLimit: number;
+  /** Global upload throttle in bytes/sec; 0 means unlimited. */
+  uploadLimit: number;
 }
 
 export const defaultConfig: Config = {
   downloadDir: defaultDownloadDir,
   trackers: [],
+  // Unthrottled, exactly as the app behaved before the setting existed.
+  downloadLimit: 0,
+  uploadLimit: 0,
 };
+
+// The environment gets a say, but only as the starting value: once the config
+// file has a limit in it, that is the single source of truth, so a rate set
+// with `r` is not silently overridden on the next launch. Same shape as
+// TORLINK_MAX_DOWNLOADS, and the value takes the same units the prompt does
+// ("5 MB/s", "512 KB/s", a bare number read as MB/s).
+function envLimit(name: string): number {
+  const raw = process.env[name];
+  if (!raw) return 0;
+  return parseRate(raw) ?? 0;
+}
+
+function rateField(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? Math.floor(v) : fallback;
+}
+
+function fresh(): Config {
+  return {
+    ...defaultConfig,
+    trackers: [],
+    downloadLimit: envLimit("TORLINK_DOWNLOAD_LIMIT"),
+    uploadLimit: envLimit("TORLINK_UPLOAD_LIMIT"),
+  };
+}
 
 export async function loadConfig(): Promise<Config> {
   let raw: string;
   try {
     raw = await fs.readFile(configFile, "utf8");
   } catch {
-    return { ...defaultConfig, trackers: [] };
+    return fresh();
   }
   try {
     const parsed = JSON.parse(raw) as Partial<Config>;
@@ -29,10 +61,14 @@ export async function loadConfig(): Promise<Config> {
       trackers: Array.isArray(parsed.trackers)
         ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
         : [],
+      // A missing or unreadable limit falls back rather than failing the load:
+      // a config written by an older build must keep working.
+      downloadLimit: rateField(parsed.downloadLimit, envLimit("TORLINK_DOWNLOAD_LIMIT")),
+      uploadLimit: rateField(parsed.uploadLimit, envLimit("TORLINK_UPLOAD_LIMIT")),
     };
     return cfg;
   } catch {
-    return { ...defaultConfig, trackers: [] };
+    return fresh();
   }
 }
 

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -35,6 +35,9 @@ export async function startRuntime(overrideDir?: string): Promise<Runtime> {
   const cfg = await loadConfig();
   const queue = new DownloadQueue();
   queue.setTrackers(cfg.trackers);
+  // Headless runs honour the same saved limits the TUI does: a seedbox left
+  // running is exactly where a capped upstream matters most.
+  queue.setSpeedLimits(cfg.downloadLimit, cfg.uploadLimit);
   // Crash-boot breaker, mirroring the TUI: a marker left by the previous run
   // means it died mid-restore, so restore paused with the engine cold.
   const safe = wasBootInterrupted();

--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 const constructorCalls: Record<string, unknown>[] = [];
+const throttleCalls: { down: number[]; up: number[] } = { down: [], up: [] };
 
 vi.mock("webtorrent", () => {
   return {
@@ -14,6 +15,12 @@ vi.mock("webtorrent", () => {
       add(): EventEmitter {
         return new EventEmitter();
       }
+      throttleDownload(rate: number): void {
+        throttleCalls.down.push(rate);
+      }
+      throttleUpload(rate: number): void {
+        throttleCalls.up.push(rate);
+      }
       destroy(): void {}
     },
   };
@@ -21,6 +28,8 @@ vi.mock("webtorrent", () => {
 
 afterEach(() => {
   constructorCalls.length = 0;
+  throttleCalls.down.length = 0;
+  throttleCalls.up.length = 0;
   vi.resetModules();
 });
 
@@ -106,6 +115,67 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     expect(result).not.toBeNull();
     expect(result?.progress).toBe(0);
     expect(result?.total).toBe(0);
+    engine.destroy();
+  });
+});
+
+describe("TorrentEngine speed limits", () => {
+  const MAGNET = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000";
+
+  it("hands a limit set before the first torrent to the client's constructor", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    // The client is built lazily, on the first add: a limit set at launch has
+    // to survive until then, or the first torrent starts unthrottled.
+    engine.setSpeedLimits(1024 * 1024, 256 * 1024);
+    engine.add("test-id", MAGNET, "/downloads", {});
+    engine.destroy();
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]).toMatchObject({
+      downloadLimit: 1024 * 1024,
+      uploadLimit: 256 * 1024,
+    });
+  });
+
+  it("spells unlimited as -1, webtorrent's own sentinel", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    engine.add("test-id", MAGNET, "/downloads", {});
+    engine.destroy();
+    expect(constructorCalls[0]).toMatchObject({ downloadLimit: -1, uploadLimit: -1 });
+  });
+
+  it("applies a tightened limit to the live client, not just the next one", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    engine.add("test-id", MAGNET, "/downloads", {});
+    engine.setSpeedLimits(512 * 1024, 0);
+    engine.destroy();
+    expect(throttleCalls.down).toEqual([512 * 1024]);
+    expect(throttleCalls.up).toEqual([-1]);
+  });
+
+  it("keeps the limit across a client rebuild after destroy()", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    engine.setSpeedLimits(2 * 1024 * 1024, 0);
+    engine.add("test-id", MAGNET, "/downloads", {});
+    engine.destroy();
+    engine.add("second-id", MAGNET, "/downloads", {});
+    engine.destroy();
+    expect(constructorCalls).toHaveLength(2);
+    expect(constructorCalls[1]).toMatchObject({ downloadLimit: 2 * 1024 * 1024 });
+  });
+
+  it("survives a client that cannot throttle — a limit is never fatal", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    engine.add("test-id", MAGNET, "/downloads", {});
+    const client = (engine as unknown as { client: Record<string, unknown> }).client;
+    client.throttleDownload = () => {
+      throw new Error("not supported");
+    };
+    expect(() => engine.setSpeedLimits(1024, 1024)).not.toThrow();
     engine.destroy();
   });
 });

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -32,9 +32,41 @@ export function message(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
+// torlink stores a speed limit as bytes/sec with 0 meaning unlimited (the same
+// shape as TORLINK_MAX_DOWNLOADS). webtorrent spells unlimited as -1, so every
+// rate crosses that boundary through here.
+function rate(limit: number): number {
+  return Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : -1;
+}
+
 export class TorrentEngine {
   private client: WebTorrent | null = null;
   private torrents = new Map<string, Torrent>();
+
+  // Global throttle rates in torlink's units (bytes/sec, 0 = unlimited). Held
+  // on the engine rather than the client: the client is created lazily and
+  // recreated after destroy(), and both have to come up already throttled.
+  private downLimit = 0;
+  private upLimit = 0;
+
+  /**
+   * Set the global download / upload throttles, in bytes/sec (0 = unlimited).
+   * Applies to every torrent at once, live: unlike the concurrency cap, a
+   * tightened limit does slow whatever is already running, which is the whole
+   * point of capping a background download while you work.
+   */
+  setSpeedLimits(down: number, up: number): void {
+    this.downLimit = down;
+    this.upLimit = up;
+    const client = this.client;
+    if (!client) return;
+    try {
+      client.throttleDownload(rate(down));
+      client.throttleUpload(rate(up));
+    } catch {
+      // A throttle is a preference, never a reason to take the engine down.
+    }
+  }
 
   private ensureClient(): WebTorrent {
     if (!this.client) {
@@ -45,7 +77,14 @@ export class TorrentEngine {
       // the app the moment a download starts. NAT-PMP can never succeed
       // on macOS because the port is permanently taken, so disable it
       // and let UPnP handle NAT traversal instead.
-      const opts = process.platform === "darwin" ? { natPmp: false } : {};
+      // The throttles go in as constructor options rather than being applied
+      // after the fact: a limit set at launch has to hold for the very first
+      // torrent, and the client is only built once one is added.
+      const opts = {
+        downloadLimit: rate(this.downLimit),
+        uploadLimit: rate(this.upLimit),
+        ...(process.platform === "darwin" ? { natPmp: false } : {}),
+      };
       this.client = new WebTorrent(opts);
       this.client.on("error", () => {});
     }

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -92,6 +92,13 @@ export class DownloadQueue extends EventEmitter {
     this.trackers = trackers;
   }
 
+  // Global download / upload throttles in bytes/sec (0 = unlimited). Unlike
+  // setTrackers, this one does reach what is already running: the engine
+  // applies it to the live client as well as to every client built after it.
+  setSpeedLimits(down: number, up: number): void {
+    this.engine.setSpeedLimits(down, up);
+  }
+
   getItems(): QueueItem[] {
     return [...this.items.values()].sort((a, b) => b.addedAt - a.addedAt);
   }

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -18,7 +18,7 @@ import { parseInput } from "../sources/magnet";
 import { magnetFromTorrentFile } from "../sources/torrentFile";
 import { readClipboard, writeClipboard } from "../util/clipboard";
 import { openFolder } from "../util/openFolder";
-import { cleanText, formatBytes, truncate } from "../util/format";
+import { cleanText, formatBytes, formatBytesPerSec, truncate } from "../util/format";
 import {
   StoreContext,
   type CaptureMode,
@@ -43,6 +43,7 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { SpeedPrompt } from "./components/SpeedPrompt";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -97,6 +98,7 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  const [editingSpeed, setEditingSpeed] = useState(false);
   // A result waiting on the "download to" prompt (D); null when the prompt is
   // closed. lastDownloadToDir pre-fills the next prompt so queueing a batch
   // into the same alternate folder only costs one typed path per session.
@@ -121,6 +123,7 @@ export function App({
       const cfg = await loadConfig();
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
+      q.setSpeedLimits(cfg.downloadLimit, cfg.uploadLimit);
       // Crash-boot breaker: a marker left behind by the previous boot means it
       // died mid-restore, so this one restores everything paused with the
       // engine cold (safe mode) instead of walking into the same explosion.
@@ -213,6 +216,7 @@ export function App({
     (c: Config) => {
       setConfigState(c);
       queue?.setTrackers(c.trackers);
+      queue?.setSpeedLimits(c.downloadLimit, c.uploadLimit);
       void saveConfig(c);
     },
     [queue],
@@ -225,6 +229,26 @@ export function App({
   const closeTrackersPrompt = useCallback(() => {
     setEditingTrackers(false);
   }, []);
+
+  const closeSpeedPrompt = useCallback(() => {
+    setEditingSpeed(false);
+  }, []);
+
+  const setSpeedLimits = useCallback(
+    (limits: { down: number; up: number }) => {
+      closeSpeedPrompt();
+      if (!config) return;
+      if (limits.down === config.downloadLimit && limits.up === config.uploadLimit) {
+        setNotice("Speed limits unchanged.");
+        return;
+      }
+      setConfig({ ...config, downloadLimit: limits.down, uploadLimit: limits.up });
+      const down = limits.down > 0 ? formatBytesPerSec(limits.down) : "unlimited";
+      const up = limits.up > 0 ? formatBytesPerSec(limits.up) : "unlimited";
+      setNotice(`Speed limits: ${down} down, ${up} up.`);
+    },
+    [config, setConfig, closeSpeedPrompt],
+  );
 
   const setTrackers = useCallback(
     (list: string[]) => {
@@ -454,7 +478,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || editingSpeed || pendingDownload ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -490,6 +514,7 @@ export function App({
     showHelp,
     editingFolder,
     editingTrackers,
+    editingSpeed,
     pendingDownload,
     captureMode,
     downloadFocus,
@@ -517,7 +542,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || editingSpeed || pendingDownload) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -535,6 +560,11 @@ export function App({
       if (input === "t") {
         setShowHelp(false);
         setEditingTrackers(true);
+        return;
+      }
+      if (input === "r") {
+        setShowHelp(false);
+        setEditingSpeed(true);
         return;
       }
       if (input === "m") {
@@ -635,6 +665,18 @@ export function App({
           </Box>
         ) : null}
 
+        {editingSpeed ? (
+          <Box marginTop={1}>
+            <SpeedPrompt
+              width={Math.max(24, Math.min(cols - 4, 68))}
+              down={store.config.downloadLimit}
+              up={store.config.uploadLimit}
+              onSubmit={setSpeedLimits}
+              onCancel={closeSpeedPrompt}
+            />
+          </Box>
+        ) : null}
+
         {pendingDownload ? (
           <Box marginTop={1}>
             <FolderPrompt
@@ -656,7 +698,7 @@ export function App({
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || editingSpeed || pendingDownload ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -672,7 +714,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || editingSpeed || pendingDownload ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus, resultFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/SpeedPrompt.tsx
+++ b/src/ui/components/SpeedPrompt.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { TextField } from "./TextField";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { formatBytesPerSec, formatRates, parseRates } from "../../util/format";
+import { COLOR, ICON } from "../theme";
+
+interface SpeedPromptProps {
+  width: number;
+  /** Current limits in bytes/sec; 0 on both opens an empty field. */
+  down: number;
+  up: number;
+  onSubmit: (limits: { down: number; up: number }) => void;
+  onCancel: () => void;
+}
+
+// What the typed text will do, shown above the field as it changes: "5 MB/s"
+// and "5" mean the same thing but "5 KB" doesn't, so the reading has to be
+// visible before ↵ rather than after it.
+function status(text: string): string {
+  const parsed = parseRates(text);
+  if (!parsed) return "Unreadable — try 5 MB/s, or 5 MB/s, 1 MB/s for both.";
+  if (parsed.down <= 0 && parsed.up <= 0) return "No limit either way.";
+  const down = parsed.down > 0 ? `↓ ${formatBytesPerSec(parsed.down)}` : "↓ unlimited";
+  const up = parsed.up > 0 ? `↑ ${formatBytesPerSec(parsed.up)}` : "↑ unlimited";
+  return `${down}   ${up}`;
+}
+
+export function SpeedPrompt({ width, down, up, onSubmit, onCancel }: SpeedPromptProps) {
+  // Unlimited opens empty rather than as "0": the field's own emptiness is what
+  // clears the cap, so the two agree from the first keystroke.
+  const initial = formatRates(down, up);
+  const [fieldText, setFieldText] = useState(initial);
+
+  useInput((_input, key) => {
+    if (key.escape) onCancel();
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="speed limits" width={width} focused height={3}>
+        <Box>
+          <Text dimColor wrap="truncate-end">
+            {status(fieldText)}
+          </Text>
+        </Box>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Box flexGrow={1} minWidth={0}>
+            <TextField
+              defaultValue={initial}
+              placeholder="5 MB/s, 1 MB/s   (download, upload — empty for no limit)"
+              width={Math.max(1, width - 6)}
+              onChange={setFieldText}
+              onSubmit={(raw) => {
+                const parsed = parseRates(raw);
+                // An unreadable rate cancels rather than saving a wrong number;
+                // the status line has been saying so the whole time.
+                if (!parsed) onCancel();
+                else onSubmit(parsed);
+              }}
+            />
+          </Box>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <PromptHints submitLabel="save" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([134, 108, 77, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([10, 15, 19, 32]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([10, 15, 20, 33]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -20,6 +20,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "esc", label: "Back" },
       { keys: "o", label: "Default download folder" },
       { keys: "t", label: "Extra trackers" },
+      { keys: "r", label: "Speed limits" },
       { keys: "q", label: "Quit" },
     ],
   },
@@ -60,7 +61,9 @@ export const HELP_GROUPS: HelpGroup[] = [
 
 // Footer labels stay terse so the contextual hint row never wraps; the `?`
 // overlay (HELP_GROUPS) carries the full, descriptive list. Rare or
-// self-announcing actions (z) stay `?`-only to keep every row inside 80 cols.
+// self-announcing actions (z) stay `?`-only to keep every row inside 80 cols,
+// and so do the global settings prompts (o, t, r) — they apply everywhere, so
+// no one context is the right one to advertise them from.
 const NAVIGATE: Hint = { keys: "↑↓←→", label: "Move" };
 
 const ALWAYS: Hint = { keys: "?", label: "Keys" };

--- a/src/util/format.test.ts
+++ b/src/util/format.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
   formatBytes,
+  parseRate,
+  parseRates,
+  formatRates,
   parseSize,
   formatBytesPerSec,
   formatCount,
@@ -116,5 +119,87 @@ describe("stripControl", () => {
     expect(stripControl(hash)).toBe(hash);
     expect(stripControl("a  b")).toBe("a  b");
     expect(stripControl("")).toBe("");
+  });
+});
+
+describe("parseRate", () => {
+  it("reads a bare number as MB/s — the unit anyone capping a line thinks in", () => {
+    expect(parseRate("5")).toBe(5 * 1024 ** 2);
+    expect(parseRate("0.5")).toBe(0.5 * 1024 ** 2);
+  });
+
+  it("round-trips what formatBytesPerSec prints", () => {
+    for (const bytes of [256 * 1024, 1024 ** 2, 12 * 1024 ** 2]) {
+      expect(parseRate(formatBytesPerSec(bytes))).toBe(bytes);
+    }
+  });
+
+  it("takes the unit with or without the /s and the space", () => {
+    const half = 512 * 1024;
+    expect(parseRate("512KB")).toBe(half);
+    expect(parseRate("512 KB/s")).toBe(half);
+    expect(parseRate("512 kb / s")).toBe(half);
+    expect(parseRate("512 KiB/sec")).toBe(half);
+  });
+
+  it("uses powers of 1024, unlike parseSize's decimal KB", () => {
+    expect(parseRate("1 KB")).toBe(1024);
+    expect(parseSize("1 KB")).toBe(1000);
+  });
+
+  it("reads a comma as a decimal separator", () => {
+    expect(parseRate("1,5 MB/s")).toBe(1.5 * 1024 ** 2);
+  });
+
+  it("returns 0 for empty input — the field's emptiness clears the cap", () => {
+    expect(parseRate("")).toBe(0);
+    expect(parseRate("   ")).toBe(0);
+    expect(parseRate("0")).toBe(0);
+  });
+
+  it("returns null for anything unreadable, so a caller can tell it apart from 0", () => {
+    expect(parseRate("fast")).toBeNull();
+    expect(parseRate("-5")).toBeNull();
+    expect(parseRate("5 TB/s")).toBeNull();
+    expect(parseRate("5 MB/s please")).toBeNull();
+  });
+});
+
+describe("parseRates", () => {
+  it("takes both directions, download first", () => {
+    expect(parseRates("5 MB/s, 1 MB/s")).toEqual({
+      down: 5 * 1024 ** 2,
+      up: 1024 ** 2,
+    });
+  });
+
+  it("leaves upload unlimited when only one side is given", () => {
+    expect(parseRates("5 MB/s")).toEqual({ down: 5 * 1024 ** 2, up: 0 });
+  });
+
+  it("clears both on an empty field", () => {
+    expect(parseRates("")).toEqual({ down: 0, up: 0 });
+  });
+
+  it("caps upload alone when the download side is 0", () => {
+    expect(parseRates("0, 1 MB/s")).toEqual({ down: 0, up: 1024 ** 2 });
+  });
+
+  it("rejects the whole input when either side is unreadable", () => {
+    expect(parseRates("5 MB/s, fast")).toBeNull();
+    expect(parseRates("fast, 1 MB/s")).toBeNull();
+    expect(parseRates("1, 2, 3")).toBeNull();
+  });
+
+  it("round-trips through formatRates", () => {
+    const pairs = [
+      { down: 0, up: 0 },
+      { down: 5 * 1024 ** 2, up: 0 },
+      { down: 0, up: 1024 ** 2 },
+      { down: 256 * 1024, up: 512 * 1024 },
+    ];
+    for (const pair of pairs) {
+      expect(parseRates(formatRates(pair.down, pair.up))).toEqual(pair);
+    }
   });
 });

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -40,6 +40,63 @@ export function formatBytesPerSec(bytes?: number): string {
   return `${n.toFixed(n < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
 }
 
+const RATE_UNITS: Record<string, number> = {
+  B: 1,
+  KB: 1024,
+  KIB: 1024,
+  MB: 1024 ** 2,
+  MIB: 1024 ** 2,
+  GB: 1024 ** 3,
+  GIB: 1024 ** 3,
+};
+
+/**
+ * A typed speed limit, in bytes/sec. Returns 0 for empty input (no cap) and
+ * null for anything unreadable, so a caller can tell "clear it" from "I don't
+ * know what you meant".
+ *
+ * Powers of 1024, unlike parseSize's decimal KB: this is the inverse of
+ * formatBytesPerSec, and someone who types "512 KB/s" has to read "512 KB/s"
+ * back. A bare number is megabytes per second — the unit anyone capping a line
+ * is thinking in. The trailing "/s" is optional, and so is the space.
+ */
+export function parseRate(input: string): number | null {
+  const s = input.trim().toUpperCase();
+  if (!s) return 0;
+  const m = s.match(/^([\d.,]+)\s*(B|[KMG]I?B)?(?:\s*\/?\s*S(?:EC)?)?$/);
+  if (!m) return null;
+  const n = Number(m[1]!.replace(",", "."));
+  if (!Number.isFinite(n) || n < 0) return null;
+  if (n === 0) return 0;
+  const unit = m[2] ? RATE_UNITS[m[2]] : RATE_UNITS.MB;
+  return unit ? Math.round(n * unit) : null;
+}
+
+/**
+ * Both halves of the speed-limit prompt: "down, up", each side taking what
+ * parseRate takes. One field rather than two prompts because the pair is one
+ * setting — the same shape TrackersPrompt uses for a comma-separated list.
+ *
+ * An omitted upload side leaves upload unlimited; an empty field clears both.
+ * Returns null if either side is unreadable, so the prompt can say so rather
+ * than saving half of what was typed.
+ */
+export function parseRates(input: string): { down: number; up: number } | null {
+  const parts = input.split(",");
+  if (parts.length > 2) return null;
+  const down = parseRate(parts[0] ?? "");
+  if (down === null) return null;
+  const up = parts.length === 2 ? parseRate(parts[1]!) : 0;
+  if (up === null) return null;
+  return { down, up };
+}
+
+/** The inverse of parseRates, for pre-filling the prompt. */
+export function formatRates(down: number, up: number): string {
+  if (down <= 0 && up <= 0) return "";
+  return `${formatBytesPerSec(down) || "0"}, ${formatBytesPerSec(up) || "0"}`;
+}
+
 export function formatCount(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return "0";
   if (n < 10_000) return String(Math.round(n));

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -44,6 +44,10 @@ declare module "webtorrent" {
     lsd?: boolean;
     natPmp?: boolean;
     natUpnp?: boolean | "permanent";
+    // Global throttle rates in bytes/sec. -1 (webtorrent's own sentinel) leaves
+    // the direction unthrottled; the client reads these once, at construction.
+    downloadLimit?: number;
+    uploadLimit?: number;
   }
 
   class WebTorrent extends EventEmitter {
@@ -63,6 +67,10 @@ declare module "webtorrent" {
       cb?: (torrent: Torrent) => void,
     ): Torrent;
     get(torrentId: string): Torrent | null;
+    // Change a global throttle rate on a live client, in bytes/sec. -1 disables
+    // the limiter for that direction.
+    throttleDownload(rate: number): void;
+    throttleUpload(rate: number): void;
     remove(torrentId: string, cb?: (err?: Error) => void): void;
     destroy(cb?: (err?: Error) => void): void;
   }


### PR DESCRIPTION
## What and why

A torrent that saturates the line makes everything else on the connection unusable, and torlink
has no answer for it today. The only lever is `TORLINK_MAX_DOWNLOADS`, which limits how many
downloads run, not how fast any of them go — fewer torrents at full tilt is still full tilt.

`r` opens a prompt that takes both directions at once:

| Typed | Result |
| --- | --- |
| `5 MB/s` | downloads capped at 5 MB/s, uploads unlimited |
| `5 MB/s, 1 MB/s` | downloads 5 MB/s, uploads 1 MB/s |
| `0, 1 MB/s` | downloads unlimited, uploads 1 MB/s |
| *(empty)* | no cap either way |

One field rather than two prompts, because the pair is one setting — the same shape
`TrackersPrompt` already uses for a comma-separated list. The status line above the field reads
back what the text will do before `↵` commits it, since `5` and `5 MB/s` mean the same thing but
`5 KB` does not. An unreadable rate cancels rather than saving a wrong number.

The upload side isn't an afterthought. A finished download keeps seeding, and a saturated upstream
starves the ACKs every other connection depends on — so an uncapped upload slows a machine that
isn't downloading anything at all.

## How it works

Limits apply **live**, unlike the concurrency cap: tightening one slows what's already running,
which is the whole point of capping a background download while you work.

They're held on `TorrentEngine` rather than on the client, because the client is built lazily on
the first `add()` and rebuilt after `destroy()` — both have to come up already throttled. A limit
set at launch goes in as a constructor option; a limit changed later goes through
`throttleDownload`/`throttleUpload` on the live client. torlink stores bytes/sec with `0` meaning
unlimited (matching `maxDownloads`); webtorrent spells unlimited as `-1`, and exactly one function
crosses that boundary.

`TORLINK_DOWNLOAD_LIMIT` / `TORLINK_UPLOAD_LIMIT` seed the starting values — but only as a
starting value. Once the config file has a limit, that's the single source of truth, so a rate set
with `r` isn't silently overridden on the next launch. `watch`, `serve`, and `files` read the same
saved values; a seedbox is where a capped upstream matters most.

A throttle never throws. It's a preference, not a reason to take the engine down.

## Notes on the standards

- **Footer**: `r` is `?`-only, alongside `o` and `t`. The global settings prompts apply everywhere,
  so no one context is the right one to advertise them from — I updated the comment in
  `keymap.ts` to say so explicitly rather than leaving the next person to wonder.
- **No new `Store` field**, so `makeStore` in `scripts/render-previews-impl.tsx` is untouched.
- **`helpLayout.test.ts`** expectations moved (`gridH` `[10,15,19,32]` → `[10,15,20,33]`) because
  the `?` sheet gained a row. The numbers are derived from `HELP_GROUPS`, so this is the test
  doing its job.
- **No new gradient**, no palette changes.

## Tests

18 new cases: `parseRate` / `parseRates` / `formatRates` round-trips, unit handling, and the
0-vs-null distinction in `format.test.ts`; the constructor-option path, the live-throttle path,
the client rebuild, and the throw-safe path in `engine.test.ts`.

`npm test` goes from 229 to 247 passing.

> On my Windows checkout, 5 files (`daemon/{runtime,serve,watch}`, `download/queue{,.safemode}`)
> fail to load with `Cannot find module '../../../build/Release/node_datachannel.node'` — no C++
> toolchain here. That's identical on a clean `upstream/main`, so it's my environment, not this
> change. Everything that loads is green.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
