### PR TITLE
feat: search only the active tab's sources

### DIFF
--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SOURCES } from "../../sources/registry";
-import { StoreContext } from "../store";
+import { StoreContext, type Section } from "../store";
 import {
   KEY,
   makeTestStore,
@@ -13,9 +13,14 @@ import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
 import type { TorrentResult } from "../../sources/types";
 
 const searchState = vi.hoisted(() => ({ current: null as unknown }));
+// Every set of sources the component has asked to search, newest last.
+const searched = vi.hoisted(() => ({ calls: [] as string[][] }));
 
 vi.mock("../hooks/useConcurrentSearch", () => ({
-  useConcurrentSearch: () => searchState.current,
+  useConcurrentSearch: (_query: string, sources?: readonly { id: string }[]) => {
+    searched.calls.push((sources ?? []).map((s) => s.id));
+    return searchState.current;
+  },
 }));
 
 const t = (infoHash: string, name: string): TorrentResult => ({
@@ -53,6 +58,7 @@ let ui: RenderedUI | null = null;
 afterEach(() => {
   ui?.unmount();
   ui = null;
+  searched.calls.length = 0;
 });
 
 async function mount(results: TorrentResult[] = LIST): Promise<RenderedUI> {
@@ -183,5 +189,51 @@ describe("Results filter UI", () => {
     u.press(KEY.enter);
     await vi.waitFor(() => expect(u.frame()).not.toContain("Filter"));
     expect(u.frame()).toContain("Results (8)");
+  });
+});
+
+describe("Results source scope", () => {
+  async function mountOn(section: Section): Promise<RenderedUI> {
+    searchState.current = settled(LIST);
+    ui = renderUI(
+      <StoreContext.Provider value={makeTestStore({ query: "linux iso", section })}>
+        <Results />
+      </StoreContext.Provider>,
+    );
+    const u = ui;
+    await vi.waitFor(() => expect(u.frame()).toContain("Results"));
+    return u;
+  }
+
+  const asked = (): string[] => searched.calls.at(-1) ?? [];
+
+  it("searches only the active tab's sources", async () => {
+    await mountOn("anime");
+    // Anime is served by its two dedicated indexes; the movie and TV sources
+    // have nothing to contribute to the tab, so they are never asked.
+    expect([...asked()].sort()).toEqual(["nyaa", "subsplease"]);
+  });
+
+  it("searches a tab's shared sources too, not just its exclusive ones", async () => {
+    await mountOn("tv");
+    // BitTorrented serves both Movies and TV: being shared is not a reason to
+    // skip it here.
+    expect(asked()).toContain("bittorrented");
+    expect(asked()).not.toContain("fitgirl");
+  });
+
+  it("searches every source on the All tab", async () => {
+    await mountOn("all");
+    expect([...asked()].sort()).toEqual(SOURCES.map((s) => s.id).sort());
+  });
+
+  it("keeps the source set stable across re-renders of the same tab", async () => {
+    const u = await mountOn("movies");
+    const first = asked();
+    u.press("s"); // re-sort: a render with no change of tab
+    await vi.waitFor(() => expect(searched.calls.length).toBeGreaterThan(1));
+    // Same ids in the same order, so the hook's effect key does not change and
+    // a repaint never re-runs the search.
+    expect(asked()).toEqual(first);
   });
 });

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -132,7 +132,18 @@ export function Results() {
     listRows,
   } = useStore();
 
-  const search = useConcurrentSearch(query);
+  // The tab picks what gets searched, not only what gets shown: a category tab
+  // renders its own group and nothing else, so asking the other sources is work
+  // no one sees. Stable while the tab is — CATEGORIES and SOURCES are module
+  // constants.
+  const activeCat = CATEGORIES.find((c) => c.key === section);
+  const tabSources = useMemo(
+    () =>
+      activeCat?.group ? SOURCES.filter((s) => s.groups?.includes(activeCat.group!)) : SOURCES,
+    [activeCat],
+  );
+
+  const search = useConcurrentSearch(query, tabSources);
 
   const [sort, setSort] = useState<Sort>("none");
   const [hideDead, setHideDead] = useState(false);
@@ -289,10 +300,6 @@ export function Results() {
     () => Object.values(search.perSource).filter((s) => s.error).length,
     [search.perSource],
   );
-  const activeCat = CATEGORIES.find((c) => c.key === section);
-  const tabSources = activeCat?.group
-    ? SOURCES.filter((s) => s.groups?.includes(activeCat.group!))
-    : SOURCES;
   const tabErrored =
     tabSources.length > 0 && tabSources.every((s) => search.perSource[s.id]?.error);
   // Only the active tab's sources hold its spinner; other groups' stragglers
@@ -331,20 +338,23 @@ export function Results() {
       return <Spinner label={browsing ? "Loading…" : "Searching…"} />;
     }
     if (results.length === 0) {
-      if (erroredCount >= search.total) {
-        const downAll = SOURCES.filter((s) => search.perSource[s.id]?.error);
-        return (
-          <Text color={COLOR.warn}>
-            {`Couldn't reach any source. They may be down${outageCodes(downAll)}.`}
-          </Text>
-        );
-      }
-      if (tabErrored && activeCat) {
+      // The named-tab message comes first now. A category tab only queries its
+      // own group, so "every source errored" and "this tab's sources errored"
+      // are the same event there, and naming the tab says more.
+      if (tabErrored && activeCat?.group) {
         const down = tabSources.filter((s) => search.perSource[s.id]?.error);
         const who = down.length === 1 ? "The source" : `All ${down.length} sources`;
         return (
           <Text color={COLOR.warn}>
             {`Couldn't reach ${activeCat.label}. ${who} may be down${outageCodes(down)}.`}
+          </Text>
+        );
+      }
+      if (erroredCount >= search.total) {
+        const downAll = tabSources.filter((s) => search.perSource[s.id]?.error);
+        return (
+          <Text color={COLOR.warn}>
+            {`Couldn't reach any source. They may be down${outageCodes(downAll)}.`}
           </Text>
         );
       }
@@ -361,8 +371,6 @@ export function Results() {
           );
         }
       }
-      if (search.results.length > 0 && activeCat?.group)
-        return <Text dimColor>{`No ${activeCat.label.toLowerCase()} results yet. Try another tab or a search.`}</Text>;
       return (
         <Text dimColor>
           {browsing ? "Nothing new right now." : `No results for "${truncate(query, 28)}".`}

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { SOURCES } from "../../sources/registry";
 import { cachedSearch } from "../../sources/cache";
 import { HttpError } from "../../util/net";
-import type { SourceId, TorrentResult } from "../../sources/types";
+import type { Source, SourceId, TorrentResult } from "../../sources/types";
 
 export interface SourceState {
   loading: boolean;
@@ -24,9 +24,12 @@ export interface ConcurrentSearchState {
   total: number;
 }
 
-function blankPerSource(loading: boolean): Record<SourceId, SourceState> {
+function blankPerSource(
+  loading: boolean,
+  sources: readonly Source[],
+): Record<SourceId, SourceState> {
   const out = {} as Record<SourceId, SourceState>;
-  for (const s of SOURCES) out[s.id] = { loading, error: null, code: null, count: 0 };
+  for (const s of sources) out[s.id] = { loading, error: null, code: null, count: 0 };
   return out;
 }
 
@@ -48,13 +51,13 @@ function defaultOrder(list: TorrentResult[]): TorrentResult[] {
   });
 }
 
-function idleState(): ConcurrentSearchState {
+function idleState(sources: readonly Source[]): ConcurrentSearchState {
   return {
     results: [],
-    perSource: blankPerSource(false),
+    perSource: blankPerSource(false, sources),
     loading: false,
     done: 0,
-    total: SOURCES.length,
+    total: sources.length,
   };
 }
 
@@ -65,14 +68,34 @@ function idleState(): ConcurrentSearchState {
 // leading-throttle the queue hooks in store.ts use for `update` events.
 const RESULT_FLUSH_MS = 150;
 
-export function useConcurrentSearch(query: string): ConcurrentSearchState {
-  const [state, setState] = useState<ConcurrentSearchState>(idleState);
+/**
+ * Searches `sources` for `query`, streaming results in as each one answers.
+ *
+ * The caller passes the active tab's sources rather than the whole registry: a
+ * category tab renders its own group and nothing else, so querying the rest is
+ * work no one sees — and every source added from here on would otherwise cost
+ * every search another request. Defaults to the whole registry, which is what
+ * the All tab wants.
+ *
+ * Switching tabs re-runs the search, but cachedSearch holds each source+query
+ * for five minutes, so a tab already visited answers without touching the
+ * network.
+ */
+export function useConcurrentSearch(
+  query: string,
+  sources: readonly Source[] = SOURCES,
+): ConcurrentSearchState {
+  // The array identity changes on every render (the caller derives it from the
+  // active tab), so the effect keys off the ids instead. Same tab, same key,
+  // no re-search.
+  const sourceKey = sources.map((s) => s.id).join(",");
+  const [state, setState] = useState<ConcurrentSearchState>(() => idleState(sources));
 
   useEffect(() => {
     const ctrl = new AbortController();
     let alive = true;
     const collected: TorrentResult[] = [];
-    const per = blankPerSource(true);
+    const per = blankPerSource(true, sources);
     let done = 0;
     let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -80,16 +103,16 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
       setState({
         results: defaultOrder(dedupe(collected.slice())),
         perSource: { ...per },
-        loading: done < SOURCES.length,
+        loading: done < sources.length,
         done,
-        total: SOURCES.length,
+        total: sources.length,
       });
     };
 
     // Push the accumulated state to the UI, but no more than once per window.
     // The final source flushes immediately so "done" / loading:false is prompt.
     const scheduleFlush = (): void => {
-      if (done >= SOURCES.length) {
+      if (done >= sources.length) {
         if (timer) {
           clearTimeout(timer);
           timer = null;
@@ -109,10 +132,10 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
       perSource: { ...per },
       loading: true,
       done: 0,
-      total: SOURCES.length,
+      total: sources.length,
     });
 
-    for (const source of SOURCES) {
+    for (const source of sources) {
       cachedSearch(source, query, { signal: ctrl.signal })
         .then((res) => {
           if (!alive) return;
@@ -140,7 +163,8 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
       ctrl.abort();
       if (timer) clearTimeout(timer);
     };
-  }, [query]);
+    // sources is read through sourceKey, which is what actually identifies it.
+  }, [query, sourceKey]);
 
   return state;
 }


### PR DESCRIPTION
## What and why

The category tabs are a filter over one all-sources search. Opening **Anime** still costs a
request to YTS, both Pirate Bay feeds, both 1337x feeds, EZTV, BitTorrented and FitGirl — nine
sources queried, two rendered, seven answers discarded.

`useConcurrentSearch` now takes the list of sources to search, and `Results` hands it the active
tab's group. The **All** tab passes the whole registry, which is the parameter's default, so
nothing about All changes.

Two things follow:

- **Category searches get faster and quieter.** A tab waits only on sources it will actually show.
  The spinner already tracked just the tab's sources (`pending` is derived from `tabSources`), so
  the header was describing a narrower search than the one actually running — this closes that gap.
- **A new source stops taxing every other tab.** Adding one to a group costs only that group a
  request, which is what keeps the registry cheap to grow.

Switching tabs re-runs the hook rather than re-filtering in place, but `cachedSearch` already
holds each source+query for five minutes, so a tab you've already opened answers without touching
the network.

## Behaviour changes worth calling out

Two status lines move with it, and neither is cosmetic:

1. **The named-tab outage message now comes first.** On a category tab, "every source errored" and
   "this tab's sources errored" are now the same event — `search.total` counts only the tab's
   sources. Naming the tab (*"Couldn't reach Anime. All 2 sources may be down (503)."*) says more
   than *"Couldn't reach any source."*, so it wins. The generic message still covers All.

2. **"No <tab> results yet. Try another tab or a search." is gone.** It fired when the query had
   results on *some other* tab — which is precisely the work this PR stops doing, so the line
   could no longer be truthful. Those cases fall through to the existing
   *"No results for …"* / *"Nothing new right now."*.

The `results` useMemo keeps its group filter. It's a no-op for a category tab now, but it's still
what All relies on, and it stays the guard if a shared source (BitTorrented serves Movies *and*
TV) ever returns something outside the group that selected it.

## Grain notes

- The hook's effect keys off `sources.map(s => s.id).join(",")` rather than the array, since the
  caller derives a fresh array each render; `tabSources` is a `useMemo` over module constants, so
  the same tab always produces the same key and a repaint never re-runs a search. There's a test
  for exactly that.
- No new state, no new `Store` field, no key changes, no palette or gradient changes.
- The second parameter defaults to `SOURCES`, so any other caller keeps today's behaviour.

## Tests

Four new cases in `Results.test.tsx`, asserting on the source ids actually handed to the hook:
only the tab's sources on a category tab, shared sources included (BitTorrented on TV) while
unrelated ones aren't (FitGirl), the full registry on All, and a stable source set across a
re-render that isn't a tab change.

`npm test` goes from 229 to 233 passing.

> On my Windows checkout, 5 files (`daemon/{runtime,serve,watch}`, `download/queue{,.safemode}`)
> fail to load with `Cannot find module '../../../build/Release/node_datachannel.node'` — no C++
> toolchain here. Identical on a clean `upstream/main`, so it's my environment, not this change.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
