### PR TITLE
feat: add a Books tab for e-books, comics, and audio books

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ A short, hand-picked list of trusted sources:
 | Movies | YTS, The Pirate Bay, 1337x, BitTorrented |
 | TV | EZTV, The Pirate Bay, 1337x, BitTorrented |
 | Anime | Nyaa, SubsPlease |
+| Books | The Pirate Bay, BitTorrented |
 
-Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline.
+Games are the only category that can run code, so they come from FitGirl alone, a repacker with a long, trusted track record; everything else is plain video, text and subtitles. If a source is down, the search carries on without it, and torlink tells you which one is offline.
 
 ## Headless
 

--- a/src/sources/bittorrented.test.ts
+++ b/src/sources/bittorrented.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mapBittorrentedResults, bittorrented } from "./bittorrented";
+import { mapBittorrentedResults, bittorrented, bittorrentedBooks } from "./bittorrented";
 
 describe("mapBittorrentedResults", () => {
   it("maps an API row to a torrent result with a built magnet, tagged by source id", () => {
@@ -60,5 +60,18 @@ describe("bittorrented", () => {
     expect(bittorrented.groups).not.toContain("Games");
     expect(bittorrented.groups).not.toContain("Anime");
     expect(bittorrented.reportsHealth).toBe(true);
+  });
+});
+
+describe("BitTorrented media types", () => {
+  it("serves books from its own id, and never Games", () => {
+    expect(bittorrentedBooks.id).toBe("bittorrented-books");
+    expect(bittorrentedBooks.groups).toEqual(["Books"]);
+    // Games stay FitGirl's alone: a crawl can't vouch for what an installer runs.
+    for (const s of [bittorrented, bittorrentedBooks]) {
+      expect(s.groups).not.toContain("Games");
+    }
+    // One site, one label.
+    expect(bittorrentedBooks.label).toBe(bittorrented.label);
   });
 });

--- a/src/sources/bittorrented.ts
+++ b/src/sources/bittorrented.ts
@@ -3,9 +3,9 @@ import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
 // BitTorrented is a general index (its own library plus a large DHT crawl).
-// torlink takes its video type only and feeds it to Movies and TV. Anime stays
-// with its dedicated sources (the API can't tell anime from any other video)
-// and Games stays FitGirl's alone. Its JSON API returns real swarm counts, so
+// torlink asks it one media type per tab: video for Movies and TV, ebook for
+// Books. Anime stays with its dedicated sources (the API can't tell anime from
+// any other video) and Games stays FitGirl's alone. Its JSON API returns real swarm counts, so
 // reportsHealth is true.
 const BASE = "https://bittorrented.com";
 
@@ -57,15 +57,24 @@ export function mapBittorrentedResults(results: BtResult[], id: SourceId): Torre
   return out;
 }
 
-async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
+// The API's own type names. It rejects anything else with a 400, so these are
+// the ones the registry can ask for ("book" and "application" are not valid).
+type MediaType = "video" | "ebook";
+
+async function search(
+  query: string,
+  type: MediaType,
+  id: SourceId,
+  opts: SearchOptions = {},
+): Promise<TorrentResult[]> {
   const q = query.trim();
   if (q.length < MIN_QUERY) return [];
 
-  // Video only: keeps the category tabs plain video and structurally excludes
-  // the index's other media types. One request per search.
+  // One media type per request, so a tab structurally cannot show another's
+  // rows. One request per search.
   const params = new URLSearchParams({
     q,
-    type: "video",
+    type,
     limit: "50",
     sortBy: "seeders",
     sortOrder: "desc",
@@ -78,7 +87,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
   if (!res.ok) throw new HttpError(res.status, `BitTorrented returned ${res.status}`);
 
   const json = (await res.json()) as BtResponse;
-  return mapBittorrentedResults(json.results ?? [], "bittorrented");
+  return mapBittorrentedResults(json.results ?? [], id);
 }
 
 export const bittorrented: Source = {
@@ -87,5 +96,14 @@ export const bittorrented: Source = {
   groups: ["Movies", "TV"],
   homepage: BASE,
   reportsHealth: true,
-  search,
+  search: (query, opts = {}) => search(query, "video", "bittorrented", opts),
+};
+
+export const bittorrentedBooks: Source = {
+  id: "bittorrented-books",
+  label: "BitTorrented",
+  groups: ["Books"],
+  homepage: BASE,
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, "ebook", "bittorrented-books", opts),
 };

--- a/src/sources/piratebay.test.ts
+++ b/src/sources/piratebay.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchResilient } from "../util/net";
+import { tpbBooks, tpbMovies } from "./piratebay";
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: vi.fn() };
+});
+
+const mocked = vi.mocked(fetchResilient);
+
+// An apibay row, trimmed to what the mapper reads. The info hash has to be a
+// real 40-char hex string or the mapper drops the row.
+function row(n: number, category: string, name = `Row ${n}`) {
+  return {
+    id: String(n),
+    name,
+    info_hash: n.toString(16).padStart(40, "0"),
+    seeders: "10",
+    leechers: "1",
+    size: "1000",
+    category,
+  };
+}
+
+// Answers each URL from a table; anything unlisted rejects, so a test that
+// reaches for an unexpected feed fails loudly rather than silently.
+function serve(table: Record<string, unknown[]>): void {
+  mocked.mockImplementation(async (url: string) => {
+    const key = Object.keys(table).find((k) => url.includes(k));
+    if (!key) throw new Error(`unexpected request: ${url}`);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => table[key],
+    } as unknown as Response;
+  });
+}
+
+const names = (rows: { name: string }[]): string[] => rows.map((r) => r.name);
+
+beforeEach(() => {
+  mocked.mockReset();
+});
+
+describe("Pirate Bay books category filter", () => {
+  it("keeps e-books, comics and audio books together on one tab", async () => {
+    serve({
+      "q.php": [
+        row(1, "601", "textbook pdf"),
+        row(2, "602", "graphic novel cbz"),
+        row(3, "102", "novel audiobook"),
+        row(4, "699", "unrelated other"),
+        row(5, "101", "album mp3"),
+      ],
+    });
+
+    expect(names(await tpbBooks.search("something"))).toEqual([
+      "textbook pdf",
+      "graphic novel cbz",
+      "novel audiobook",
+    ]);
+  });
+
+  it("merges the two browse feeds books span", async () => {
+    serve({
+      data_top100_600: [row(1, "601", "ebook"), row(2, "699", "other")],
+      data_top100_102: [row(3, "102", "audiobook")],
+    });
+
+    expect(names(await tpbBooks.search("")).sort()).toEqual(["audiobook", "ebook"]);
+  });
+
+  it("still browses when one of the two feeds is down", async () => {
+    mocked.mockImplementation(async (url: string) => {
+      if (url.includes("data_top100_102")) throw new Error("feed down");
+      return {
+        ok: true,
+        status: 200,
+        json: async () => [row(1, "601", "ebook")],
+      } as unknown as Response;
+    });
+
+    // A partial list beats reporting the whole source offline.
+    expect(names(await tpbBooks.search(""))).toEqual(["ebook"]);
+  });
+
+  it("throws when every browse feed is down, so the tab reports the outage", async () => {
+    mocked.mockRejectedValue(new Error("all down"));
+    await expect(tpbBooks.search("")).rejects.toThrow();
+  });
+
+  it("keeps a row that carries no category rather than dropping it", async () => {
+    serve({ "q.php": [{ ...row(1, "", "unfiled release"), category: undefined }] });
+    expect(names(await tpbBooks.search("x"))).toEqual(["unfiled release"]);
+  });
+
+  it("leaves the movie tab's filter untouched, in search and in browse", async () => {
+    serve({ "q.php": [row(1, "207", "a movie"), row(2, "601", "an ebook")] });
+    expect(names(await tpbMovies.search("x"))).toEqual(["a movie"]);
+
+    // 207 is exactly what MOVIE_CATS admits, so the new browse-side filter is a
+    // no-op here — this is the regression guard for that.
+    serve({ data_top100_207: [row(1, "207", "top movie")] });
+    expect(names(await tpbMovies.search(""))).toEqual(["top movie"]);
+  });
+});
+
+describe("Pirate Bay tab wiring", () => {
+  it("gives books its own source id and group", () => {
+    expect(tpbBooks.id).toBe("tpb-books");
+    expect(tpbBooks.groups).toEqual(["Books"]);
+    // Same site, so it still reports real swarm counts.
+    expect(tpbBooks.reportsHealth).toBe(true);
+    // One site, one label: the tag answers who found a row, not what kind.
+    expect(tpbBooks.label).toBe(tpbMovies.label);
+  });
+});

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -7,8 +7,19 @@ const API = "https://apibay.org";
 const MOVIE_CATS = new Set([201, 202, 207, 209]);
 const TV_CATS = new Set([205, 208]);
 
-const TOP_MOVIES = `${API}/precompiled/data_top100_207.json`;
-const TOP_TV = `${API}/precompiled/data_top100_208.json`;
+// Everything you read or listen to as a book: e-books (601), comics (602) and
+// audio books (102). One tab rather than two — the format is already in the
+// torrent's name, and splitting them would only ask the same sources twice.
+const BOOK_CATS = new Set([601, 602, 102]);
+
+const top = (cat: number): string => `${API}/precompiled/data_top100_${cat}.json`;
+
+// Browse feeds, used when the query is empty. apibay publishes a top-100 per
+// category; books need two of them, since 600 (Other) carries e-books and
+// comics while audio books sit under Audio.
+const TOP_MOVIES = [top(207)];
+const TOP_TV = [top(208)];
+const TOP_BOOKS = [top(600), top(102)];
 
 interface ApibayItem {
   id?: string;
@@ -53,21 +64,32 @@ async function fetchItems(url: string, opts: SearchOptions): Promise<ApibayItem[
   return Array.isArray(json) ? json : [];
 }
 
+// Browse can need more than one feed (books span Other and Audio). One feed
+// answering is enough: a partial list beats reporting the whole source down.
+async function fetchBrowse(urls: readonly string[], opts: SearchOptions): Promise<ApibayItem[]> {
+  const settled = await Promise.allSettled(urls.map((u) => fetchItems(u, opts)));
+  const ok = settled.filter((s) => s.status === "fulfilled");
+  if (ok.length === 0) throw (settled[0] as PromiseRejectedResult).reason;
+  return ok.flatMap((s) => (s as PromiseFulfilledResult<ApibayItem[]>).value);
+}
+
 async function search(
   query: string,
   cats: Set<number>,
-  browseUrl: string,
+  browseUrls: readonly string[],
   source: SourceId,
   opts: SearchOptions,
 ): Promise<TorrentResult[]> {
   const q = query.trim();
-  const items = await fetchItems(
-    q ? `${API}/q.php?q=${encodeURIComponent(q)}` : browseUrl,
-    opts,
-  );
+  const items = q
+    ? await fetchItems(`${API}/q.php?q=${encodeURIComponent(q)}`, opts)
+    : await fetchBrowse(browseUrls, opts);
   const out: TorrentResult[] = [];
   for (const it of items) {
-    if (q && !cats.has(Number(it.category))) continue;
+    // Browse feeds are filtered as well as searches: 600 mixes e-books and
+    // comics with everything else filed under Other. A row with no category at
+    // all is kept — an unfiled row beats an empty tab.
+    if (it.category && !cats.has(Number(it.category))) continue;
     const r = toResult(it, source);
     if (r) out.push(r);
   }
@@ -90,4 +112,13 @@ export const tpbTv: Source = {
   homepage: "https://thepiratebay.org",
   reportsHealth: true,
   search: (query, opts = {}) => search(query, TV_CATS, TOP_TV, "tpb-tv", opts),
+};
+
+export const tpbBooks: Source = {
+  id: "tpb-books",
+  label: "TPB",
+  groups: ["Books"],
+  homepage: "https://thepiratebay.org",
+  reportsHealth: true,
+  search: (query, opts = {}) => search(query, BOOK_CATS, TOP_BOOKS, "tpb-books", opts),
 };

--- a/src/sources/registry.ts
+++ b/src/sources/registry.ts
@@ -1,9 +1,9 @@
-import { bittorrented } from "./bittorrented";
+import { bittorrented, bittorrentedBooks } from "./bittorrented";
 import { eztv } from "./eztv";
 import { fitgirl } from "./fitgirl";
 import { nyaa } from "./nyaa";
 import { subsplease } from "./subsplease";
-import { tpbMovies, tpbTv } from "./piratebay";
+import { tpbBooks, tpbMovies, tpbTv } from "./piratebay";
 import { x1337Movies, x1337Tv } from "./x1337";
 import { yts } from "./yts";
 import type { Source, SourceGroup, SourceId } from "./types";
@@ -19,6 +19,8 @@ export const SOURCES: readonly Source[] = [
   nyaa,
   subsplease,
   bittorrented,
+  tpbBooks,
+  bittorrentedBooks,
 ];
 
 export const DEFAULT_SOURCE: Source = SOURCES[0]!;
@@ -27,7 +29,7 @@ export function getSource(id: SourceId): Source {
   return SOURCES.find((s) => s.id === id) ?? DEFAULT_SOURCE;
 }
 
-const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime"];
+const GROUP_ORDER: readonly SourceGroup[] = ["Games", "Movies", "TV", "Anime", "Books"];
 
 export function sourcesByGroup(): { group: SourceGroup; sources: Source[] }[] {
   return GROUP_ORDER.map((group) => ({

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -8,9 +8,11 @@ export type SourceId =
   | "tpb-tv"
   | "x1337-movies"
   | "x1337-tv"
-  | "bittorrented";
+  | "tpb-books"
+  | "bittorrented"
+  | "bittorrented-books";
 
-export type SourceGroup = "Games" | "Movies" | "TV" | "Anime";
+export type SourceGroup = "Games" | "Movies" | "TV" | "Anime" | "Books";
 
 export interface TorrentResult {
   infoHash: string;

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -7,7 +7,7 @@ import type { SourceGroup, SourceId } from "../sources/types";
 
 export type View = "splash" | "browser";
 
-export type Category = "all" | "games" | "movies" | "tv" | "anime";
+export type Category = "all" | "games" | "movies" | "tv" | "anime" | "books";
 
 export type Section = Category | "downloads" | "seeding";
 
@@ -17,6 +17,10 @@ export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[]
   { key: "movies", label: "Movies", group: "Movies" },
   { key: "tv", label: "TV", group: "TV" },
   { key: "anime", label: "Anime", group: "Anime" },
+  // One tab for everything you read or listen to: e-books, PDFs, comics and
+  // audio books. The format is already in the torrent's name, so splitting
+  // them would only ask the same sources twice.
+  { key: "books", label: "Books", group: "Books" },
 ];
 
 export type Region = "sidebar" | "content" | "help";

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -38,7 +38,9 @@ export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
   "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
   "x1337-movies": { tag: "1337", color: "#f6a55c" },
   "x1337-tv": { tag: "1337", color: "#f6a55c" },
+  "tpb-books": { tag: "TPB", color: "#5fd0c5" },
   bittorrented: { tag: "BT", color: "#7db8f0" },
+  "bittorrented-books": { tag: "BT", color: "#7db8f0" },
 };
 
 // Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or


### PR DESCRIPTION
> **Revisits #118**, which proposed this as two tabs and was closed. I've argued the one-tab case
> below; if the answer is still no, closing this costs nothing. Also touches the same apibay
> browse-filter lines as #150 (Music) — whichever lands first, I'll rebase the other.

## What and why

Books are the other large category the curated list has no answer for, and both general sources
already carry them:

| Source | How it's asked |
| --- | --- |
| The Pirate Bay | apibay 601 (e-books) + 602 (comics) + 102 (audio books) |
| BitTorrented | `type=ebook` |

No new integration, no new site to trust — two source entries over indexes torlink already talks to.

## One tab, not two

#118 proposed **E-Books** and **Audiobooks** as separate categories. I think one tab is the better
shape, for three reasons:

1. **The format is already in the torrent's name.** `.epub`, `.pdf`, `.cbz`, `m4b`, "narrated by" —
   the row tells you what it is without a tab having to.
2. **They share every source.** Two tabs means asking the same two sites twice for what one
   request answers, and torlink is a client that cares about how many requests a tab costs.
3. **The user's intent is usually "this book".** Someone after a novel often doesn't care whether
   it arrives as EPUB or as narration — and if they do, the name says so.

The tab is also where FitGirl's exclusion logic points: books are inert text and audio, the same
class as video and subtitles, so they need no special trust treatment.

> Out of scope, deliberately: libgen-style single-book fetching. Those services publish
> thousand-book archive dumps, not one book per torrent, so they'd fit the tab badly.

## Browse needs two feeds

The two halves live under different apibay parents — 600 (Other) for e-books and comics, 102 for
audio books — so the empty-query view merges two top-100s. `fetchBrowse` settles for a partial
list: **one feed answering beats reporting the whole source down**, while *both* failing still
throws, so a real outage still reaches the tab's error line. Both paths are tested.

The category filter now runs over browse feeds too (`if (q && …)` → `if (it.category && …)`),
which it has to: 600 is a parent feed carrying far more than books. Movies and TV browse their own
leaf feeds (207, 208), which their category sets already admit, so the filter is a **no-op** for
them — there's a regression test pinning exactly that, in both search and browse. A row with no
category at all is kept rather than dropped: an unfiled row beats an empty tab.

## Grain notes

- `MediaType` in `bittorrented.ts` replaces the inline `"video"` literal, so the second value was a
  type entry rather than a new branch. `type=ebook` means the tab *structurally* cannot show a
  video row.
- Games stay FitGirl's alone — neither new entry claims that group, with a test for it.
- No new keys, no new `Store` fields, no palette or gradient changes. The new tags reuse their
  site's existing colour.

## Tests

`piratebay.test.ts` is new (7 cases): the three-category boundary, the two-feed merge, one feed
down (partial list), both down (throws), the unfiled-row rule, and Movies unchanged in search and
browse. Plus a wiring case in `bittorrented.test.ts`.

`npm test` goes from 229 to 237 passing.

> On my Windows checkout, 5 files (`daemon/{runtime,serve,watch}`, `download/queue{,.safemode}`)
> fail to load with `Cannot find module '../../../build/Release/node_datachannel.node'` — no C++
> toolchain here. Identical on a clean `upstream/main`, so it's my environment, not this change.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
