### PR TITLE
feat: add a Settings tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Type what you're looking for and press Enter. Results stream in from every sourc
 
 Active downloads sit up top with their progress, speed, and time left; when one finishes it drops into Recently downloaded just below, so the list stays tidy. Everything's still there when you come back, and anything interrupted picks up where it left off.
 
-Downloads run in the background while you keep searching, so you can queue up as many as you want. They save to your downloads folder, and the Downloads pane keeps tabs on each one; press `o` anytime to change where that is, or grab one result with `shift+d` to send it somewhere else without touching the default. When something finishes it keeps seeding automatically so the next person can find it too, and the Seeding tab lets you pause or stop that anytime.
+Downloads run in the background while you keep searching, so you can queue up as many as you want. They save to your downloads folder, and the Downloads pane keeps tabs on each one; press `o` anytime to change where that is, or grab one result with `shift+d` to send it somewhere else without touching the default. The Settings tab in the sidebar collects the same options in one place — the download folder, how many downloads run at once, extra trackers, and whether it checks for updates — and `←`/`→` steps a value while `↵` opens a field. When something finishes it keeps seeding automatically so the next person can find it too, and the Seeding tab lets you pause or stop that anytime.
 
 <p align="center">
   <img src="preview/downloads.svg" alt="torlink's Downloads pane: live progress on top, recently downloaded below" style="max-width: 832px; width: 100%; height: auto;">

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -81,6 +81,8 @@ function makeStore(
   return {
     config: { downloadDir: "~/Downloads/torlink" } as Config,
     setConfig: noop,
+    openFolderPrompt: noop,
+    openTrackersPrompt: noop,
     queue: fakeQueue(items, history, seeds),
     view: "browser",
     setView: noop,

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -5,19 +5,52 @@ import { serializeWrites, writeJsonAtomic } from "../util/atomic";
 export interface Config {
   downloadDir: string;
   trackers: string[];
+  /** Torrents allowed to download at once; 0 means no limit. */
+  maxDownloads: number;
+  /** Check the registry for a newer release, once per launch. */
+  checkForUpdates: boolean;
 }
 
-export const defaultConfig: Config = {
-  downloadDir: defaultDownloadDir,
-  trackers: [],
-};
+/** The values maxDownloads cycles through in the settings pane. */
+export const MAX_DOWNLOAD_CHOICES = [0, 1, 2, 3, 5, 8] as const;
+
+// The environment still gets a say, but only as the starting value: once the
+// config file exists it is the single source of truth, so a setting changed in
+// the pane is not silently overridden on the next launch.
+export function envMaxDownloads(): number {
+  const v = Number(process.env.TORLINK_MAX_DOWNLOADS);
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+}
+
+function envChecksUpdates(): boolean {
+  return !process.env.TORLINK_NO_UPDATE_CHECK;
+}
+
+function count(v: unknown, fallback: number): number {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? Math.floor(v) : fallback;
+}
+
+function bool(v: unknown, fallback: boolean): boolean {
+  return typeof v === "boolean" ? v : fallback;
+}
+
+// A function, not a constant: both defaults are read from the environment,
+// which a test (or the user) can change between calls.
+export function defaultConfig(): Config {
+  return {
+    downloadDir: defaultDownloadDir,
+    trackers: [],
+    maxDownloads: envMaxDownloads(),
+    checkForUpdates: envChecksUpdates(),
+  };
+}
 
 export async function loadConfig(): Promise<Config> {
   let raw: string;
   try {
     raw = await fs.readFile(configFile, "utf8");
   } catch {
-    return { ...defaultConfig, trackers: [] };
+    return defaultConfig();
   }
   try {
     const parsed = JSON.parse(raw) as Partial<Config>;
@@ -29,10 +62,14 @@ export async function loadConfig(): Promise<Config> {
       trackers: Array.isArray(parsed.trackers)
         ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
         : [],
+      // An unknown or missing value falls back rather than failing the load: a
+      // config written by a newer build must never brick an older one.
+      maxDownloads: count(parsed.maxDownloads, envMaxDownloads()),
+      checkForUpdates: bool(parsed.checkForUpdates, envChecksUpdates()),
     };
     return cfg;
   } catch {
-    return { ...defaultConfig, trackers: [] };
+    return defaultConfig();
   }
 }
 

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -17,6 +17,7 @@ import { deleteSeedData } from "./delete-data";
 import { disarmBootMarker } from "./bootguard";
 import type { QueueItem, SeedItem } from "./types";
 import type { SourceId } from "../sources/types";
+import { envMaxDownloads } from "../config/config";
 
 /**
  * A real seed never pulls data off the network: verifying on-disk files reads
@@ -45,13 +46,6 @@ const FETCH_METADATA_TIMEOUT_MS = 20_000;
 const POLL_MS = 500;
 const HISTORY_MAX = 500;
 
-// Max torrents allowed to actively download at once. Overflow waits as "queued"
-// and starts automatically when a slot frees. 0 / unset = unlimited (default).
-function readMaxDownloads(): number {
-  const v = Number(process.env.TORLINK_MAX_DOWNLOADS);
-  return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
-}
-
 export interface AddInput {
   id: string;
   name: string;
@@ -78,11 +72,11 @@ export class DownloadQueue extends EventEmitter {
   private trackers: string[] = [];
 
   // Max torrents allowed to download at once; overflow waits as "queued".
-  private readonly maxDownloads: number;
+  private maxDownloads: number;
 
   constructor(opts?: { maxDownloads?: number }) {
     super();
-    this.maxDownloads = opts?.maxDownloads ?? readMaxDownloads();
+    this.maxDownloads = opts?.maxDownloads ?? envMaxDownloads();
   }
 
   // Extra announce URLs appended to every torrent added from now on.
@@ -90,6 +84,21 @@ export class DownloadQueue extends EventEmitter {
   // for the next add / resume / re-seed.
   setTrackers(trackers: string[]): void {
     this.trackers = trackers;
+  }
+
+  /**
+   * Change the concurrency cap (0 = no limit).
+   *
+   * Raising it starts whatever was waiting. Lowering it does not stop anything
+   * already running — a download is not interrupted for a setting — so the
+   * count settles as items finish.
+   */
+  setMaxDownloads(n: number): void {
+    const next = Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+    if (next === this.maxDownloads) return;
+    this.maxDownloads = next;
+    this.promote();
+    this.changed();
   }
 
   getItems(): QueueItem[] {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -43,6 +43,7 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { Settings } from "./components/Settings";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -173,7 +174,7 @@ export function App({
   // Best-effort, once per launch, off the hot path: if a newer release exists,
   // surface a quiet banner. Any failure (offline, opt-out) just leaves it hidden.
   useEffect(() => {
-    if (process.env.TORLINK_NO_UPDATE_CHECK) return;
+    if (!config?.checkForUpdates) return;
     let alive = true;
     void (async () => {
       const latest = await fetchLatestVersion();
@@ -213,10 +214,21 @@ export function App({
     (c: Config) => {
       setConfigState(c);
       queue?.setTrackers(c.trackers);
+      queue?.setMaxDownloads(c.maxDownloads);
       void saveConfig(c);
     },
     [queue],
   );
+
+  const openFolderPrompt = useCallback(() => {
+    setShowHelp(false);
+    setEditingFolder(true);
+  }, []);
+
+  const openTrackersPrompt = useCallback(() => {
+    setShowHelp(false);
+    setEditingTrackers(true);
+  }, []);
 
   const closeFolderPrompt = useCallback(() => {
     setEditingFolder(false);
@@ -470,6 +482,8 @@ export function App({
       openDownloadFolder,
       exportTorrent,
       fetchAndExportTorrent,
+      openFolderPrompt,
+      openTrackersPrompt,
       notice,
       setNotice,
       quitAll,
@@ -495,6 +509,8 @@ export function App({
     downloadFocus,
     seedFocus,
     resultFocus,
+    openFolderPrompt,
+    openTrackersPrompt,
     startDownload,
     requestDownloadTo,
     copyMagnet,
@@ -528,13 +544,11 @@ export function App({
         return;
       }
       if (input === "o") {
-        setShowHelp(false);
-        setEditingFolder(true);
+        openFolderPrompt();
         return;
       }
       if (input === "t") {
-        setShowHelp(false);
-        setEditingTrackers(true);
+        openTrackersPrompt();
         return;
       }
       if (input === "m") {
@@ -545,11 +559,15 @@ export function App({
         setRegion(region === "sidebar" ? "content" : "sidebar");
         return;
       }
+      // A pane in "lateral" capture reads ←/→ itself (the settings values), so
+      // the global "move between panes" meaning steps aside while it has focus.
       if (key.rightArrow || input === "l") {
+        if (captureMode === "lateral") return;
         if (region === "sidebar") setRegion("content");
         return;
       }
       if (key.leftArrow || input === "h") {
+        if (captureMode === "lateral") return;
         if (region === "content") setRegion("sidebar");
         return;
       }
@@ -661,7 +679,9 @@ export function App({
         >
           <Sidebar />
           <Box flexGrow={1} flexDirection="column">
-            {section === "downloads" ? (
+            {section === "settings" ? (
+              <Settings />
+            ) : section === "downloads" ? (
               <Downloads />
             ) : section === "seeding" ? (
               <Seeding />

--- a/src/ui/components/Settings.test.tsx
+++ b/src/ui/components/Settings.test.tsx
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { StoreContext } from "../store";
+import { KEY, makeTestStore, renderUI } from "../testHarness";
+import { MAX_DOWNLOAD_CHOICES, type Config } from "../../config/config";
+import { Settings } from "./Settings";
+
+// Ink only reads these as arrows with the ESC byte in front; a bare "[C"
+// arrives as the two characters it looks like.
+const RIGHT = `${KEY.esc}[C`;
+const LEFT = `${KEY.esc}[D`;
+
+// The smallest listRows that shows all nine rows at once. Below it the pane
+// scrolls, which is correct behaviour but would make the "lists every setting"
+// assertion depend on where the cursor is.
+const FULL_PANE_ROWS = 11;
+
+function mount(overrides: Partial<Config> = {}, extra: Record<string, unknown> = {}) {
+  const onConfig = vi.fn();
+  const base = makeTestStore({ listRows: FULL_PANE_ROWS });
+  const store = {
+    ...base,
+    config: {
+      downloadDir: "~/Downloads/torlink",
+      trackers: [],
+      maxDownloads: 0,
+      checkForUpdates: true,
+      ...overrides,
+    } as Config,
+    setConfig: onConfig,
+    ...extra,
+  } as typeof base;
+  const ui = renderUI(
+    <StoreContext.Provider value={store}>
+      <Settings />
+    </StoreContext.Provider>,
+    { rows: 24 },
+  );
+  return { ui, onConfig };
+}
+
+const tick = (): Promise<void> => new Promise((r) => setTimeout(r, 30));
+
+// One keypress, then a frame. Two writes inside a single tick reach the same
+// render, and the second would read a cursor the first already moved.
+async function press(ui: { press: (b: string) => void }, ...keys: string[]): Promise<void> {
+  for (const k of keys) {
+    ui.press(k);
+    await tick();
+  }
+}
+
+describe("settings pane", () => {
+  it("lists every setting under its group", async () => {
+    const { ui } = mount();
+    await tick();
+    const frame = ui.frame();
+    for (const label of [
+      "Downloads",
+      "Folder",
+      "At once",
+      "Network",
+      "Trackers",
+      "Application",
+      "Update check",
+    ]) {
+      expect(frame, label).toContain(label);
+    }
+    ui.unmount();
+  });
+
+  it("steps the concurrency cap with the arrows, and saves it", async () => {
+    const { ui, onConfig } = mount({ maxDownloads: 0 });
+    await press(ui, "j", RIGHT); // past Folder, onto At once
+    expect(onConfig).toHaveBeenCalledTimes(1);
+    expect(onConfig.mock.calls[0]![0].maxDownloads).toBe(MAX_DOWNLOAD_CHOICES[1]);
+    ui.unmount();
+  });
+
+  it("wraps around the ends of a choice list rather than stopping", async () => {
+    // Unlimited is the first choice, so stepping back lands on the last one.
+    const { ui, onConfig } = mount({ maxDownloads: 0 });
+    await press(ui, "j", LEFT);
+    expect(onConfig.mock.calls[0]![0].maxDownloads).toBe(
+      MAX_DOWNLOAD_CHOICES[MAX_DOWNLOAD_CHOICES.length - 1],
+    );
+    ui.unmount();
+  });
+
+  it("skips headings and blank lines when the cursor moves", async () => {
+    // Four value rows over nine lines. Stepping down four times has to wrap
+    // back to the first one rather than parking on a heading or a spacer.
+    const openFolderPrompt = vi.fn();
+    const { ui, onConfig } = mount({}, { openFolderPrompt });
+    await press(ui, "j", "j", "j", "j", KEY.enter);
+    expect(openFolderPrompt).toHaveBeenCalledTimes(1);
+    // Folder is a prompt, so nothing was saved on the way round.
+    expect(onConfig).not.toHaveBeenCalled();
+    ui.unmount();
+  });
+
+  it("shows 0 as the word, so there is one way to say no ceiling", async () => {
+    const { ui } = mount({ maxDownloads: 0 });
+    await tick();
+    expect(ui.frame()).toContain("unlimited");
+    ui.unmount();
+  });
+
+  it("toggles the update check", async () => {
+    const { ui, onConfig } = mount({ checkForUpdates: true });
+    await press(ui, "j", "j", "j", RIGHT);
+    expect(onConfig).toHaveBeenCalledTimes(1);
+    expect(onConfig.mock.calls[0]![0].checkForUpdates).toBe(false);
+    ui.unmount();
+  });
+
+  it("opens the shared folder and tracker prompts rather than its own copies", async () => {
+    const openFolderPrompt = vi.fn();
+    const openTrackersPrompt = vi.fn();
+    const { ui } = mount({}, { openFolderPrompt, openTrackersPrompt });
+    await press(ui, KEY.enter); // Folder is the first stop
+    expect(openFolderPrompt).toHaveBeenCalledTimes(1);
+    await press(ui, "j", "j", KEY.enter); // Trackers
+    expect(openTrackersPrompt).toHaveBeenCalledTimes(1);
+    ui.unmount();
+  });
+
+  it("summarises saved trackers by count rather than listing them", async () => {
+    const { ui } = mount({ trackers: ["udp://a:1337/announce", "udp://b:1337/announce"] });
+    await tick();
+    expect(ui.frame()).toContain("2 trackers");
+    ui.unmount();
+  });
+
+  it("says so when no trackers are saved", async () => {
+    const { ui } = mount({ trackers: [] });
+    await tick();
+    expect(ui.frame()).toContain("none saved");
+    ui.unmount();
+  });
+
+  it("scrolls instead of crushing rows when the terminal is short", async () => {
+    // Five rows for nine rows of content: the window has to move, and the rows
+    // it does show have to keep their own lines.
+    const { ui } = mount({}, { listRows: 5 });
+    await tick();
+    expect(ui.frame()).toContain("Folder");
+    // Nothing from the last group can be on screen at this height.
+    expect(ui.frame()).not.toContain("Update check");
+    ui.unmount();
+  });
+});

--- a/src/ui/components/Settings.tsx
+++ b/src/ui/components/Settings.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { MAX_DOWNLOAD_CHOICES } from "../../config/config";
+import { truncate } from "../../util/format";
+import { useStore } from "../store";
+import { windowStart, wrapStep } from "../move";
+import { COLOR, ICON } from "../theme";
+
+// A row is either a value the arrow keys cycle through, or a text field that
+// opens as a prompt. Group headings and the blank line between groups are
+// rendered from the same list so the cursor maths only has to walk one array.
+//
+// The blank line is a row of its own rather than a margin on the heading: the
+// panel window is sized in rows, and a margin is a row the window does not
+// count. Four settings under three headings would then ask for more rows than
+// the window hands out, and Yoga crushes the overflow rather than scrolling it.
+type Row =
+  | { kind: "spacer" }
+  | { kind: "heading"; label: string }
+  | {
+      kind: "choice";
+      label: string;
+      value: string;
+      /** Moves the setting by ±1 through its own list of values. */
+      step: (delta: number) => void;
+    }
+  | { kind: "prompt"; label: string; value: string; open: () => void };
+
+// The rows the cursor can land on: everything that carries a value.
+type ValueRow = Extract<Row, { kind: "choice" | "prompt" }>;
+const selectable = (r: Row): r is ValueRow => r.kind === "choice" || r.kind === "prompt";
+
+export function Settings() {
+  const {
+    config,
+    setConfig,
+    region,
+    contentWidth,
+    listRows,
+    setCaptureMode,
+    openFolderPrompt,
+    openTrackersPrompt,
+  } = useStore();
+  const focused = region === "content";
+
+  // ←/→ belong to this pane while it has focus, or the app would read them as
+  // "jump to the sidebar" and every value change would also move the cursor.
+  useEffect(() => {
+    if (!focused) return;
+    setCaptureMode("lateral");
+    return () => setCaptureMode("none");
+  }, [focused, setCaptureMode]);
+
+  const cycle = <T,>(values: readonly T[], current: T, delta: number): T =>
+    values[wrapStep(Math.max(0, values.indexOf(current)), delta, values.length)]!;
+
+  const rows: Row[] = [
+    { kind: "heading", label: "Downloads" },
+    {
+      kind: "prompt",
+      label: "Folder",
+      value: config.downloadDir,
+      open: openFolderPrompt,
+    },
+    {
+      kind: "choice",
+      label: "At once",
+      value: config.maxDownloads === 0 ? "unlimited" : String(config.maxDownloads),
+      step: (d) =>
+        setConfig({
+          ...config,
+          maxDownloads: cycle(MAX_DOWNLOAD_CHOICES, config.maxDownloads as never, d),
+        }),
+    },
+    { kind: "spacer" },
+    { kind: "heading", label: "Network" },
+    {
+      kind: "prompt",
+      label: "Trackers",
+      value:
+        config.trackers.length === 0
+          ? "none saved"
+          : `${config.trackers.length} tracker${config.trackers.length === 1 ? "" : "s"}`,
+      open: openTrackersPrompt,
+    },
+    { kind: "spacer" },
+    { kind: "heading", label: "Application" },
+    {
+      kind: "choice",
+      label: "Update check",
+      value: config.checkForUpdates ? "on" : "off",
+      step: () => setConfig({ ...config, checkForUpdates: !config.checkForUpdates }),
+    },
+  ];
+
+  const stops = rows.flatMap((r, i) => (selectable(r) ? [i] : []));
+  const [stop, setStop] = useState(0);
+  const clamped = Math.min(stop, stops.length - 1);
+  const cursor = stops[clamped]!;
+
+  // Functional, not from the render closure: two keypresses inside one frame
+  // would otherwise both read the same cursor and the second would be lost.
+  const move = (delta: number): void =>
+    setStop((s) => wrapStep(Math.min(s, stops.length - 1), delta, stops.length));
+
+  useInput(
+    (input, key) => {
+      if (key.upArrow || input === "k") move(-1);
+      else if (key.downArrow || input === "j") move(1);
+      else {
+        const row = rows[cursor]!;
+        if (row.kind === "choice") {
+          if (key.rightArrow || input === "l" || key.return) row.step(1);
+          else if (key.leftArrow || input === "h") row.step(-1);
+        } else if (row.kind === "prompt" && (key.return || key.rightArrow || input === "l")) {
+          row.open();
+        }
+      }
+    },
+    { isActive: focused },
+  );
+
+  const panelH = Math.max(5, listRows - 1);
+  const visibleRows = Math.max(1, panelH - 1);
+  const start = windowStart(cursor, rows.length, visibleRows);
+  const visible = rows.slice(start, start + visibleRows);
+
+  const labelWidth = Math.max(...rows.filter(selectable).map((r) => r.label.length)) + 2;
+  // Two columns for the chevron on each side, two for the pointer gutter.
+  const valueWidth = Math.max(8, contentWidth - labelWidth - 6);
+
+  return (
+    <Panel title="settings" width={contentWidth} focused={focused} height={panelH}>
+      {visible.map((row, i) => {
+        const index = start + i;
+
+        if (row.kind === "spacer") {
+          // A space, not an empty string: Ink gives a Text node with no content
+          // no height, and the blank line has to occupy the row the window
+          // budgeted for it.
+          return (
+            <Box key={`s${index}`}>
+              <Text> </Text>
+            </Box>
+          );
+        }
+
+        if (row.kind === "heading") {
+          return (
+            <Box key={`h${index}`}>
+              <Text bold dimColor>
+                {row.label}
+              </Text>
+            </Box>
+          );
+        }
+
+        const here = index === cursor && focused;
+        return (
+          <Box key={row.label}>
+            <Box width={2} flexShrink={0}>
+              <Text color={COLOR.accent} bold>
+                {here ? ICON.pointer : ""}
+              </Text>
+            </Box>
+            <Box width={labelWidth} flexShrink={0}>
+              <Text color={here ? COLOR.accent : undefined} bold={here} dimColor={!here}>
+                {row.label}
+              </Text>
+            </Box>
+            <Box flexGrow={1} minWidth={0}>
+              {row.kind === "choice" ? (
+                // The chevrons only appear on the focused row: they are an
+                // affordance for the keys, not decoration on every line. Their
+                // two columns are still reserved when absent, so nothing shifts
+                // as the cursor moves.
+                <Text>
+                  <Text dimColor>{here ? "‹ " : "  "}</Text>
+                  <Text color={here ? COLOR.text : undefined} dimColor={!here}>
+                    {truncate(row.value, valueWidth)}
+                  </Text>
+                  <Text dimColor>{here ? " ›" : "  "}</Text>
+                </Text>
+              ) : (
+                // Two leading spaces so the value column lines up with the
+                // choice rows, which spend them on their chevron.
+                <Text>
+                  <Text dimColor>{"  "}</Text>
+                  <Text color={here ? COLOR.text : undefined} dimColor={!here}>
+                    {truncate(row.value, valueWidth)}
+                  </Text>
+                </Text>
+              )}
+            </Box>
+          </Box>
+        );
+      })}
+    </Panel>
+  );
+}

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -16,10 +16,13 @@ const LIBRARY: NavItem[] = [
   { key: "downloads", label: "Downloads" },
   { key: "seeding", label: "Seeding" },
 ];
+// Its own group at the foot of the rail: it is not a place torrents live, so
+// it does not belong beside Downloads and Seeding.
+const APP: NavItem[] = [{ key: "settings", label: "Settings" }];
 
 const BADGED = (key: Section): boolean => key === "downloads" || key === "seeding";
 
-const GROUPS: NavItem[][] = [FILTERS, LIBRARY];
+const GROUPS: NavItem[][] = [FILTERS, LIBRARY, APP];
 
 const NAV: NavItem[] = GROUPS.flat();
 

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -9,7 +9,7 @@ export type View = "splash" | "browser";
 
 export type Category = "all" | "games" | "movies" | "tv" | "anime";
 
-export type Section = Category | "downloads" | "seeding";
+export type Section = Category | "downloads" | "seeding" | "settings";
 
 export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[] = [
   { key: "all", label: "All" },
@@ -21,7 +21,13 @@ export const CATEGORIES: { key: Category; label: string; group?: SourceGroup }[]
 
 export type Region = "sidebar" | "content" | "help";
 
-export type CaptureMode = "none" | "text" | "esc";
+/**
+ * What a focused pane is taking off the global key handler. "text" is a field
+ * swallowing everything, "esc" a pane that owns escape as its own back action,
+ * "lateral" a pane that reads ←/→ itself — the settings pane changes a value
+ * with them, which would otherwise jump focus to the sidebar.
+ */
+export type CaptureMode = "none" | "text" | "esc" | "lateral";
 
 export type DownloadFocus = "downloading" | "paused" | "failed" | "recent";
 
@@ -77,6 +83,11 @@ export interface Store {
   // Fetches the .torrent metadata for a search result (via magnet if not yet
   // cached) and exports it to the configured download folder.
   fetchAndExportTorrent: (input: { id: string; name: string; magnet: string }) => void;
+
+  // The two settings prompts, so the settings pane can open the same fields
+  // `o` and `t` do rather than growing its own copies.
+  openFolderPrompt: () => void;
+  openTrackersPrompt: () => void;
 
   notice: string | null;
   setNotice: (s: string | null) => void;

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -142,6 +142,8 @@ export function makeTestStore(overrides: Partial<Store> = {}): Store {
   return {
     config: { downloadDir: "~/Downloads/torlink" } as Config,
     setConfig: noop,
+    openFolderPrompt: noop,
+    openTrackersPrompt: noop,
     queue: fakeQueue(),
     view: "browser",
     setView: noop,


### PR DESCRIPTION
## What and why

torlink's options are scattered, and half of them are invisible:

| Setting | How you reach it today |
| --- | --- |
| Download folder | `o` — if you already know the key |
| Extra trackers | `t` — same |
| Downloads at once | `TORLINK_MAX_DOWNLOADS`, i.e. edit a shell profile |
| Update check | `TORLINK_NO_UPDATE_CHECK`, same |

Nothing on screen says any of it exists. The `?` sheet lists `o` and `t`, but the two environment
variables appear nowhere in the UI at all — changing how many torrents run at once means restarting
the app with a different environment.

The sidebar gets a fourth destination listing them together, in three groups (Downloads, Network,
Application). `←`/`→` steps a value, `↵` opens a field.

**Nothing is retired.** `o` and `t` work exactly as before — and the pane opens *the very same
prompts*, rather than growing its own copies: the two openers moved onto the `Store` so both
callers share one implementation. No new keys, so no muscle memory to relearn.

## Two environment-only settings become saved settings

`TORLINK_MAX_DOWNLOADS` and `TORLINK_NO_UPDATE_CHECK` now seed the *starting* value, and the config
file takes over from there — so a value changed in the pane isn't silently overridden on the next
launch. Same precedence rule `downloadDir` already follows.

That means the queue's cap has to be changeable at runtime. `setMaxDownloads` promotes whatever was
waiting when the cap is raised, and **never interrupts a running download** when it's lowered — a
download isn't stopped for a setting, so the count settles as items finish. `envMaxDownloads` now
lives in `config.ts` and the queue imports it, instead of the two reading the same variable
separately.

## Two layout details worth keeping

**The blank line between groups is a row, not a margin.** The panel window is sized in rows and
doesn't count a margin, so with margins the pane asks for more rows than it's given and Yoga
silently crushes the overflow rather than scrolling it — the last settings just vanish. As a row,
the pane scrolls on a short terminal and every setting stays reachable. There's a test at
`listRows: 5`.

**The pane takes `←`/`→` while focused**, through a new `"lateral"` capture mode alongside the
existing `"text"` and `"esc"`. Without it the app reads those keys as "move between panes", so
every value change would also throw focus at the sidebar.

## Grain notes

- **New `Store` fields** (`openFolderPrompt`, `openTrackersPrompt`) — `makeStore` in
  `scripts/render-previews-impl.tsx` updated accordingly, as CONTRIBUTING requires, plus the test
  harness.
- Cursor movement goes through `wrapStep`; the row window through `windowStart`. No new movement
  code.
- No new keys, so `HELP_GROUPS`/`footerHints` are untouched.
- No new gradient, no palette changes — the pane uses the existing accent for the cursor and
  chevrons only.

> If #148 (speed limits) lands, its two rates are a natural fifth and sixth row in the Network
> group; I'll follow up with that rather than bundling it here.

## Tests

10 new cases in `Settings.test.tsx`: every setting rendered under its group, stepping and wrapping
a choice list, the cursor skipping headings and spacers, `unlimited` for 0, the update toggle, the
shared prompts being called rather than local copies, the tracker summary in both states, and the
short-terminal scroll.

`npm test` goes from 229 to 239 passing.

> On my Windows checkout, 5 files (`daemon/{runtime,serve,watch}`, `download/queue{,.safemode}`)
> fail to load with `Cannot find module '../../../build/Release/node_datachannel.node'` — no C++
> toolchain here. Identical on a clean `upstream/main`, so it's my environment, not this change.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
