### PR TITLE
feat: eight colour palettes, default unchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ torlink is a torrent finder that lives in your terminal, with zero setup and not
 
 That's the only thing you'll type. torlink opens straight to a search bar: search for what you want, paste in a magnet link or a bare infohash, or just press Enter on an empty box to browse the curated library. From there it's all keypresses, nothing to memorize, and `?` brings up the full list anytime.
 
+torlink looks the way it always has out of the box. If you'd rather it didn't, `shift+t` arrows through eight palettes and repaints as you go, so you see each one on the real interface before committing; `esc` puts back what you had.
+
 ## Finding something
 
 Type what you're looking for and press Enter. Results stream in from every source as they answer, tagged with size and how many people are sharing each one, so you can see what'll come down fast. Arrow to what you want and press `d` to save it, or `shift+d` to pick a different folder for just that download.

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,15 +1,18 @@
 import { promises as fs } from "node:fs";
 import { configFile, defaultDownloadDir } from "./paths";
 import { serializeWrites, writeJsonAtomic } from "../util/atomic";
+import { DEFAULT_THEME, isThemeId, type ThemeId } from "../ui/theme";
 
 export interface Config {
   downloadDir: string;
   trackers: string[];
+  theme: ThemeId;
 }
 
 export const defaultConfig: Config = {
   downloadDir: defaultDownloadDir,
   trackers: [],
+  theme: DEFAULT_THEME,
 };
 
 export async function loadConfig(): Promise<Config> {
@@ -29,6 +32,9 @@ export async function loadConfig(): Promise<Config> {
       trackers: Array.isArray(parsed.trackers)
         ? parsed.trackers.filter((t): t is string => typeof t === "string" && t.length > 0)
         : [],
+      // An unknown theme falls back rather than failing the load: a config
+      // written by a newer build must never brick an older one.
+      theme: isThemeId(parsed.theme) ? parsed.theme : DEFAULT_THEME,
     };
     return cfg;
   } catch {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -43,8 +43,9 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { ThemePrompt } from "./components/ThemePrompt";
 import { footerHints } from "./keymap";
-import { COLOR, ICON } from "./theme";
+import { applyTheme, COLOR, currentTheme, ICON, type ThemeId } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
 import { VERSION } from "../version";
 import { fetchLatestVersion, isNewer } from "../update/version";
@@ -97,6 +98,7 @@ export function App({
   const [showHelp, setShowHelp] = useState(false);
   const [editingFolder, setEditingFolder] = useState(false);
   const [editingTrackers, setEditingTrackers] = useState(false);
+  const [editingTheme, setEditingTheme] = useState(false);
   // A result waiting on the "download to" prompt (D); null when the prompt is
   // closed. lastDownloadToDir pre-fills the next prompt so queueing a batch
   // into the same alternate folder only costs one typed path per session.
@@ -119,6 +121,9 @@ export function App({
     let alive = true;
     void (async () => {
       const cfg = await loadConfig();
+      // Before anything renders: the palette is read at render time, so a
+      // saved theme applied later would show one frame of the default.
+      applyTheme(cfg.theme);
       const q = new DownloadQueue();
       q.setTrackers(cfg.trackers);
       // Crash-boot breaker: a marker left behind by the previous boot means it
@@ -216,6 +221,22 @@ export function App({
       void saveConfig(c);
     },
     [queue],
+  );
+
+  const closeThemePrompt = useCallback(() => {
+    setEditingTheme(false);
+  }, []);
+
+  const setTheme = useCallback(
+    (id: ThemeId) => {
+      closeThemePrompt();
+      if (!config) return;
+      applyTheme(id);
+      if (id === config.theme) return;
+      setConfig({ ...config, theme: id });
+      setNotice(`Theme: ${currentTheme().name}.`);
+    },
+    [config, setConfig, closeThemePrompt],
   );
 
   const closeFolderPrompt = useCallback(() => {
@@ -454,7 +475,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || editingTheme || pendingDownload ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -490,6 +511,7 @@ export function App({
     showHelp,
     editingFolder,
     editingTrackers,
+    editingTheme,
     pendingDownload,
     captureMode,
     downloadFocus,
@@ -517,7 +539,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || editingTheme || pendingDownload) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -535,6 +557,11 @@ export function App({
       if (input === "t") {
         setShowHelp(false);
         setEditingTrackers(true);
+        return;
+      }
+      if (input === "T") {
+        setShowHelp(false);
+        setEditingTheme(true);
         return;
       }
       if (input === "m") {
@@ -635,6 +662,17 @@ export function App({
           </Box>
         ) : null}
 
+        {editingTheme ? (
+          <Box marginTop={1}>
+            <ThemePrompt
+              width={Math.max(24, Math.min(cols - 4, 52))}
+              value={store.config.theme}
+              onSubmit={setTheme}
+              onCancel={closeThemePrompt}
+            />
+          </Box>
+        ) : null}
+
         {pendingDownload ? (
           <Box marginTop={1}>
             <FolderPrompt
@@ -656,7 +694,7 @@ export function App({
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || editingTheme || pendingDownload ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -672,7 +710,7 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
+          <Box display={showHelp || editingFolder || editingTrackers || editingTheme || pendingDownload ? "none" : "flex"}>
             <Footer hints={footerHints(region, section, downloadFocus, seedFocus, resultFocus)} />
           </Box>
         ) : null}

--- a/src/ui/components/HelpOverlay.tsx
+++ b/src/ui/components/HelpOverlay.tsx
@@ -2,9 +2,11 @@ import { Box, Text } from "ink";
 import { COL_GAP, FRAME, KEY_W, pickLayout } from "../helpLayout";
 import { HELP_GROUPS } from "../keymap";
 import { useStore } from "../store";
-import { COLOR, ICON, RULE, lerpHex } from "../theme";
+import { COLOR, ICON, rule, lerpHex } from "../theme";
 
-const CARD_BORDER = lerpHex(COLOR.accent, RULE, 0.55);
+// Derived at render time: a module constant would hold the palette that was
+// active at import, which is before any saved theme is applied.
+const cardBorder = (): string => lerpHex(COLOR.accent, rule(), 0.55);
 
 const FOOT_FULL = "Your downloaded files always stay on disk.";
 
@@ -22,7 +24,7 @@ export function HelpOverlay() {
       alignSelf="flex-start"
       width={width}
       borderStyle="round"
-      borderColor={CARD_BORDER}
+      borderColor={cardBorder()}
       paddingX={1}
       paddingY={short ? 0 : 1}
     >

--- a/src/ui/components/Panel.tsx
+++ b/src/ui/components/Panel.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Box, Text } from "ink";
-import { COLOR, RULE } from "../theme";
+import { COLOR, rule } from "../theme";
 
 interface PanelProps {
   title: string;
@@ -12,7 +12,7 @@ interface PanelProps {
 }
 
 export function Panel({ title, width, focused, count, height, children }: PanelProps) {
-  const color = focused ? COLOR.accent : RULE;
+  const color = focused ? COLOR.accent : rule();
   const w = Math.max(10, width);
   const cap = title.charAt(0).toUpperCase() + title.slice(1);
   const label = count ? `${cap} ${count}` : cap;

--- a/src/ui/components/ProgressBar.tsx
+++ b/src/ui/components/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Text } from "ink";
-import { COLOR, RULE, lerpHex } from "../theme";
+import { COLOR, rule, lerpHex } from "../theme";
 import { SHEEN_PEAK, SHEEN_TICK_MS, sheenCenter, sheenIntensity, sheenPeriod } from "../sheen";
 
 const DEEP = "#7c5cd6";
@@ -56,7 +56,7 @@ export function ProgressBar({
     return () => clearInterval(timer);
   }, [animate]);
 
-  const track = empty > 0 ? <Text color={RULE}>{"░".repeat(empty)}</Text> : null;
+  const track = empty > 0 ? <Text color={rule()}>{"░".repeat(empty)}</Text> : null;
 
   if (filled === 0) return <Text>{track}</Text>;
 

--- a/src/ui/components/Rule.tsx
+++ b/src/ui/components/Rule.tsx
@@ -1,6 +1,6 @@
 import { Text } from "ink";
-import { RULE } from "../theme";
+import { rule } from "../theme";
 
 export function Rule({ width }: { width: number }) {
-  return <Text color={RULE}>{"─".repeat(Math.max(1, width))}</Text>;
+  return <Text color={rule()}>{"─".repeat(Math.max(1, width))}</Text>;
 }

--- a/src/ui/components/Sidebar.tsx
+++ b/src/ui/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { Box, Text, useInput } from "ink";
 import { useStore, useQueueItems, CATEGORIES, type Section } from "../store";
 import { wrapStep } from "../move";
-import { ACCENT_RAMP, COLOR, GUTTER, ICON, RULE } from "../theme";
+import { accentRamp, COLOR, GUTTER, ICON, rule } from "../theme";
 
 interface NavItem {
   key: Section;
@@ -55,7 +55,7 @@ export function Sidebar() {
               <Box key={item.key}>
                 <Box width={GUTTER} flexShrink={0}>
                   {selected ? (
-                    <Text color={focused ? ACCENT_RAMP[1] : RULE} bold={focused}>
+                    <Text color={focused ? accentRamp()[1] : rule()} bold={focused}>
                       {ICON.bar}
                     </Text>
                   ) : null}

--- a/src/ui/components/ThemePrompt.tsx
+++ b/src/ui/components/ThemePrompt.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { Panel } from "./Panel";
+import { PromptHints } from "./PromptHints";
+import { applyTheme, COLOR, ICON, THEMES, type ThemeId } from "../theme";
+
+interface ThemePromptProps {
+  width: number;
+  value: ThemeId;
+  onSubmit: (id: ThemeId) => void;
+  onCancel: () => void;
+}
+
+const SWATCH = "██";
+
+export function ThemePrompt({ width, value, onSubmit, onCancel }: ThemePromptProps) {
+  const startIndex = Math.max(
+    0,
+    THEMES.findIndex((t) => t.id === value),
+  );
+  const [index, setIndex] = useState(startIndex);
+  const theme = THEMES[index]!;
+
+  // Live preview: the palette is repainted as the cursor moves, so the whole
+  // interface behind the prompt shows what the theme actually looks like
+  // rather than asking anyone to judge it from four swatches.
+  useEffect(() => {
+    applyTheme(theme.id);
+  }, [theme.id]);
+
+  useInput((input, key) => {
+    if (key.escape) {
+      // Put back what was there before: a preview that survived cancelling
+      // would be a change nobody asked for.
+      applyTheme(value);
+      onCancel();
+      return;
+    }
+    if (key.return) {
+      onSubmit(theme.id);
+      return;
+    }
+    if (key.rightArrow || key.downArrow || input === "l" || input === "j") {
+      setIndex((i) => (i + 1) % THEMES.length);
+    } else if (key.leftArrow || key.upArrow || input === "h" || input === "k") {
+      setIndex((i) => (i - 1 + THEMES.length) % THEMES.length);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" width={width}>
+      <Panel title="theme" width={width} focused height={3}>
+        <Box>
+          <Text dimColor wrap="truncate-end">
+            {`${index + 1} of ${THEMES.length} · everything behind this box is already wearing it`}
+          </Text>
+        </Box>
+        <Box>
+          <Text color={COLOR.accent}>{`${ICON.pointer} `}</Text>
+          <Text color={COLOR.text}>{theme.name}</Text>
+          <Text>{"  "}</Text>
+          <Text color={theme.deep}>{SWATCH}</Text>
+          <Text color={theme.accent}>{SWATCH}</Text>
+          <Text color={theme.bright}>{SWATCH}</Text>
+        </Box>
+      </Panel>
+      <Box marginTop={1}>
+        <PromptHints submitLabel="keep" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([134, 108, 77, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([10, 15, 19, 32]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([10, 15, 20, 33]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -20,6 +20,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "esc", label: "Back" },
       { keys: "o", label: "Default download folder" },
       { keys: "t", label: "Extra trackers" },
+      { keys: "shift+t", label: "Colour theme" },
       { keys: "q", label: "Quit" },
     ],
   },
@@ -60,7 +61,9 @@ export const HELP_GROUPS: HelpGroup[] = [
 
 // Footer labels stay terse so the contextual hint row never wraps; the `?`
 // overlay (HELP_GROUPS) carries the full, descriptive list. Rare or
-// self-announcing actions (z) stay `?`-only to keep every row inside 80 cols.
+// self-announcing actions (z) stay `?`-only to keep every row inside 80 cols,
+// and so do the global settings prompts (o, t, shift+t) — they apply
+// everywhere, so no one context is the right one to advertise them from.
 const NAVIGATE: Hint = { keys: "↑↓←→", label: "Move" };
 
 const ALWAYS: Hint = { keys: "?", label: "Keys" };

--- a/src/ui/theme.test.ts
+++ b/src/ui/theme.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  applyTheme,
+  COLOR,
+  currentTheme,
+  currentThemeId,
+  DEFAULT_THEME,
+  isThemeId,
+  paletteFor,
+  rule,
+  sourceStyle,
+  THEMES,
+  THEME_IDS,
+} from "./theme";
+
+afterEach(() => {
+  applyTheme(DEFAULT_THEME);
+});
+
+// The colours torlink shipped with, before any of this existed. The default
+// theme has to reproduce them exactly, or "no change unless you ask for one"
+// is not true.
+const BUILT_IN = {
+  accent: "#a78bfa",
+  text: "#e9e4f5",
+  alt: "#b9a7e6",
+  good: "#86d6a2",
+  warn: "#f0c560",
+  bad: "#ee7d92",
+  bright: "#d8b4fe",
+};
+
+describe("the default theme", () => {
+  it("reproduces the built-in palette exactly", () => {
+    for (const [key, value] of Object.entries(BUILT_IN)) {
+      expect(COLOR[key as keyof typeof BUILT_IN], key).toBe(value);
+    }
+  });
+
+  it("keeps the built-in rule colour", () => {
+    expect(rule()).toBe("#6b6577");
+  });
+
+  it("is what an unconfigured app starts on", () => {
+    expect(currentThemeId()).toBe(DEFAULT_THEME);
+    expect(THEMES[0]!.id).toBe(DEFAULT_THEME);
+  });
+});
+
+describe("applyTheme", () => {
+  it("repaints the shared palette in place, so live components follow", () => {
+    const before = COLOR.accent;
+    applyTheme("ocean");
+    expect(COLOR.accent).not.toBe(before);
+    expect(COLOR.accent).toBe("#38bdf8");
+    // Same object identity: components hold a reference to COLOR, not a copy.
+    expect(COLOR).toBe(COLOR);
+  });
+
+  it("moves the rule colour with the theme", () => {
+    applyTheme("forest");
+    expect(rule()).toBe("#3f6b52");
+  });
+
+  it("leaves the semantic colours alone — they mean something", () => {
+    for (const id of THEME_IDS) {
+      applyTheme(id);
+      expect(COLOR.good, id).toBe(BUILT_IN.good);
+      expect(COLOR.warn, id).toBe(BUILT_IN.warn);
+      expect(COLOR.bad, id).toBe(BUILT_IN.bad);
+    }
+  });
+
+  it("falls back to the default rather than throwing on an unknown id", () => {
+    applyTheme("nonsense");
+    expect(currentThemeId()).toBe(DEFAULT_THEME);
+    expect(COLOR.accent).toBe(BUILT_IN.accent);
+  });
+});
+
+describe("every palette", () => {
+  it("defines all seven colours as hex", () => {
+    for (const theme of THEMES) {
+      for (const key of ["accent", "bright", "soft", "text", "rule", "deep", "shade"] as const) {
+        expect(theme[key], `${theme.id}.${key}`).toMatch(/^#[0-9a-f]{6}$/);
+      }
+    }
+  });
+
+  it("has a unique id and a name", () => {
+    expect(new Set(THEME_IDS).size).toBe(THEMES.length);
+    for (const theme of THEMES) expect(theme.name.length, theme.id).toBeGreaterThan(0);
+  });
+
+  it("keeps body text readable on black", () => {
+    // Every palette is used on a dark terminal, so its body text has to clear
+    // a brightness floor — this catches a palette whose text is too dim.
+    for (const theme of THEMES) {
+      const text = paletteFor(theme).text;
+      const [r, g, b] = [1, 3, 5].map((i) => parseInt(text.slice(i, i + 2), 16));
+      const luma = (0.2126 * r! + 0.7152 * g! + 0.0722 * b!) / 255;
+      expect(luma, `${theme.id} text ${text}`).toBeGreaterThan(0.6);
+    }
+  });
+
+  it("is accepted by isThemeId, and nothing else is", () => {
+    for (const id of THEME_IDS) expect(isThemeId(id)).toBe(true);
+    for (const junk of ["", "Torlink", "purple", 3, null, undefined]) {
+      expect(isThemeId(junk), String(junk)).toBe(false);
+    }
+  });
+});
+
+describe("source tags", () => {
+  it("stay put across every palette, like the semantic colours", () => {
+    // A tag answers "who found this row", which is a fact about the source and
+    // not about the palette — and on Mono, tinting them toward one accent
+    // would collapse them into the same grey.
+    const before = THEME_IDS.map(() => sourceStyle("yts").color);
+    for (const id of THEME_IDS) {
+      applyTheme(id);
+      expect(sourceStyle("yts").color, id).toBe(before[0]);
+    }
+    expect(sourceStyle("yts").color).not.toBe(sourceStyle("eztv").color);
+  });
+
+  it("still answers for an unknown or missing source", () => {
+    expect(sourceStyle(undefined).tag).toBe("•");
+    expect(sourceStyle("gone" as never).tag).toBe("•");
+  });
+
+  it("gives every variant of one site the same tag and colour", () => {
+    // The tag answers "who found this row"; the tab already answers "what kind".
+    expect(sourceStyle("tpb-movies")).toEqual(sourceStyle("tpb-tv"));
+    expect(sourceStyle("x1337-movies")).toEqual(sourceStyle("x1337-tv"));
+  });
+});
+
+describe("currentTheme", () => {
+  it("returns the whole palette, not just its id", () => {
+    applyTheme("amber");
+    expect(currentTheme().name).toBe("Amber");
+    expect(currentTheme().accent).toBe(COLOR.accent);
+  });
+});

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,54 +1,5 @@
 import type { SourceId } from "../sources/types";
 
-export const COLOR = {
-  accent: "#a78bfa",
-  text: "#e9e4f5",
-  alt: "#b9a7e6",
-  good: "#86d6a2",
-  warn: "#f0c560",
-  bad: "#ee7d92",
-  bright: "#d8b4fe",
-} as const;
-
-export const ICON = {
-  done: "✓",
-  error: "✗",
-  pending: "·",
-  pointer: "❯",
-  dot: "·",
-  warn: "⚠",
-  bar: "▌",
-  down: "↓",
-  up: "↑",
-  peer: "•",
-  pause: "⏸",
-} as const;
-
-export const RULE = "#6b6577";
-
-export const GUTTER = 2;
-
-export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
-  fitgirl: { tag: "FG", color: COLOR.accent },
-  yts: { tag: "YTS", color: COLOR.good },
-  eztv: { tag: "EZTV", color: COLOR.warn },
-  nyaa: { tag: "NYAA", color: COLOR.bright },
-  subsplease: { tag: "SUB", color: "#b9a7e6" },
-  "tpb-movies": { tag: "TPB", color: "#5fd0c5" },
-  "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
-  "x1337-movies": { tag: "1337", color: "#f6a55c" },
-  "x1337-tv": { tag: "1337", color: "#f6a55c" },
-  bittorrented: { tag: "BT", color: "#7db8f0" },
-};
-
-// Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or
-// no longer exist (a removed source persisted in old history/seeds). Fall back to a
-// neutral tag rather than indexing SOURCE_STYLE and crashing on `undefined`.
-export function sourceStyle(id?: SourceId): { tag: string; color: string } {
-  const s = id ? (SOURCE_STYLE as Record<string, { tag: string; color: string }>)[id] : undefined;
-  return s ?? { tag: "•", color: COLOR.alt };
-}
-
 function rgb(hex: string): [number, number, number] {
   const n = parseInt(hex.slice(1), 16);
   return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
@@ -64,4 +15,254 @@ export function lerpHex(a: string, b: string, t: number): string {
   return `#${c(ar, br)}${c(ag, bg)}${c(ab, bb)}`;
 }
 
-export const ACCENT_RAMP: readonly [string, string] = [COLOR.accent, COLOR.bright];
+/**
+ * A palette is seven colours. Everything the UI paints comes from them, so
+ * adding one is a table entry rather than a code change.
+ *
+ * `torlink` is the built-in pastel violet, spelled out from the exact hexes
+ * the app has always used, so selecting it repaints nothing. The rest are
+ * alternatives; the default is unchanged.
+ */
+export interface Theme {
+  id: string;
+  name: string;
+  /** The cursor, the selected row, the bar's midpoint. */
+  accent: string;
+  /** The gradient's light end: the brightest tone in the palette. */
+  bright: string;
+  /** A softened accent, for secondary text. */
+  soft: string;
+  /**
+   * Body text: light enough to read on black, tinted enough that the theme
+   * shows in prose and not only in the highlights. Spelled out rather than
+   * derived — the built-in #e9e4f5 is not any single wash of #a78bfa toward
+   * white (its blue channel goes down, not up), and reproducing the default
+   * exactly matters more than saving a table column.
+   */
+  text: string;
+  /** Panel borders and rules. */
+  rule: string;
+  /** The gradient's dark end, under the accent. */
+  deep: string;
+  /** Darker still: the wordmark's shaded foot. */
+  shade: string;
+}
+
+export const THEMES: readonly Theme[] = [
+  {
+    id: "torlink",
+    name: "torlink",
+    accent: "#a78bfa",
+    bright: "#d8b4fe",
+    soft: "#b9a7e6",
+    text: "#e9e4f5",
+    rule: "#6b6577",
+    deep: "#7c5cd6",
+    shade: "#4c3a8a",
+  },
+  {
+    id: "rose",
+    name: "Rose",
+    accent: "#f472b6",
+    bright: "#fbcfe8",
+    soft: "#e5a3c4",
+    text: "#fde3f0",
+    rule: "#7a4a63",
+    deep: "#db2777",
+    shade: "#8a1f4c",
+  },
+  {
+    id: "ocean",
+    name: "Ocean",
+    accent: "#38bdf8",
+    bright: "#a5e8ff",
+    soft: "#8ec4de",
+    text: "#d7f2fe",
+    rule: "#3f5f73",
+    deep: "#0284c7",
+    shade: "#1e4a6b",
+  },
+  {
+    id: "forest",
+    name: "Forest",
+    accent: "#4ade80",
+    bright: "#bbf7d0",
+    soft: "#9bd4ae",
+    text: "#dbf8e6",
+    rule: "#3f6b52",
+    deep: "#16a34a",
+    shade: "#14532d",
+  },
+  {
+    id: "amber",
+    name: "Amber",
+    accent: "#fbbf24",
+    bright: "#fde68a",
+    soft: "#d8b878",
+    text: "#fef2d3",
+    rule: "#7a6338",
+    deep: "#d97706",
+    shade: "#78350f",
+  },
+  {
+    id: "ember",
+    name: "Ember",
+    accent: "#fb7185",
+    bright: "#fecdd3",
+    soft: "#dda3ad",
+    text: "#fee3e7",
+    rule: "#7a4048",
+    deep: "#e11d48",
+    shade: "#881337",
+  },
+  {
+    id: "mono",
+    name: "Mono",
+    accent: "#d4d4d8",
+    bright: "#f4f4f5",
+    soft: "#a1a1aa",
+    text: "#f6f6f7",
+    rule: "#5f5f66",
+    deep: "#a1a1aa",
+    shade: "#52525b",
+  },
+  {
+    id: "midnight",
+    name: "Midnight",
+    accent: "#818cf8",
+    bright: "#c7d2fe",
+    soft: "#9aa2d8",
+    text: "#e6e8fe",
+    rule: "#4a4f7a",
+    deep: "#4f46e5",
+    shade: "#312e81",
+  },
+];
+
+export type ThemeId = string;
+
+export const THEME_IDS: readonly string[] = THEMES.map((t) => t.id);
+
+export const DEFAULT_THEME = "torlink";
+
+export function isThemeId(v: unknown): v is ThemeId {
+  return typeof v === "string" && THEME_IDS.includes(v);
+}
+
+function themeById(id: ThemeId): Theme {
+  return THEMES.find((t) => t.id === id) ?? THEMES[0]!;
+}
+
+// Seeders green, warnings amber, failures red: these read as meaning, not as
+// decoration, so they stay put while the palette moves around them.
+const GOOD = "#86d6a2";
+const WARN = "#f0c560";
+const BAD = "#ee7d92";
+
+export interface Palette {
+  accent: string;
+  text: string;
+  alt: string;
+  good: string;
+  warn: string;
+  bad: string;
+  bright: string;
+  /** The gradient's dark end, and the wordmark's shaded foot. */
+  deep: string;
+  shade: string;
+}
+
+export function paletteFor(theme: Theme): Palette {
+  return {
+    accent: theme.accent,
+    text: theme.text,
+    alt: theme.soft,
+    good: GOOD,
+    warn: WARN,
+    bad: BAD,
+    bright: theme.bright,
+    deep: theme.deep,
+    shade: theme.shade,
+  };
+}
+
+// One mutable object rather than a React context: every component reads
+// COLOR.* at render time, so a theme switch only has to re-render the tree —
+// and the theme lives in Config, so setConfig already does that. A context
+// would mean touching every component file for no behavioural gain in a
+// single-process TUI.
+export const COLOR: Palette = paletteFor(themeById(DEFAULT_THEME));
+
+let activeTheme: ThemeId = DEFAULT_THEME;
+
+export function currentThemeId(): ThemeId {
+  return activeTheme;
+}
+
+export function currentTheme(): Theme {
+  return themeById(activeTheme);
+}
+
+/** Repaints the shared palette in place. Callers must re-render afterwards. */
+export function applyTheme(id: ThemeId): void {
+  const theme = themeById(id);
+  activeTheme = theme.id;
+  Object.assign(COLOR, paletteFor(theme));
+}
+
+/**
+ * Panel borders and rules.
+ *
+ * A function, not a constant: the old `RULE` and `ACCENT_RAMP` constants read
+ * COLOR once at import time, which is before any saved theme is applied — they
+ * would hold the default palette forever after a switch.
+ */
+export function rule(): string {
+  return currentTheme().rule;
+}
+
+/** The two-stop accent ramp, read at call time so it follows the theme. */
+export function accentRamp(): readonly [string, string] {
+  return [COLOR.accent, COLOR.bright];
+}
+
+export const ICON = {
+  done: "✓",
+  error: "✗",
+  pending: "·",
+  pointer: "❯",
+  dot: "·",
+  warn: "⚠",
+  bar: "▌",
+  down: "↓",
+  up: "↑",
+  peer: "•",
+  pause: "⏸",
+} as const;
+
+export const GUTTER = 2;
+
+// Fixed hues, like the semantic colours above and for the same reason: a tag
+// answers "who found this row", which is a fact about the source and not about
+// the palette. They also have to stay tellable apart from each other, and
+// tinting them all toward one accent would collapse them on Mono.
+export const SOURCE_STYLE: Record<SourceId, { tag: string; color: string }> = {
+  fitgirl: { tag: "FG", color: "#a78bfa" },
+  yts: { tag: "YTS", color: "#86d6a2" },
+  eztv: { tag: "EZTV", color: "#f0c560" },
+  nyaa: { tag: "NYAA", color: "#d8b4fe" },
+  subsplease: { tag: "SUB", color: "#b9a7e6" },
+  "tpb-movies": { tag: "TPB", color: "#5fd0c5" },
+  "tpb-tv": { tag: "TPB", color: "#5fd0c5" },
+  "x1337-movies": { tag: "1337", color: "#f6a55c" },
+  "x1337-tv": { tag: "1337", color: "#f6a55c" },
+  bittorrented: { tag: "BT", color: "#7db8f0" },
+};
+
+// Tolerant lookup: a source id may be absent (a pasted magnet / bare infohash) or
+// no longer exist (a removed source persisted in old history/seeds). Fall back to a
+// neutral tag rather than indexing and crashing on `undefined`.
+export function sourceStyle(id?: SourceId): { tag: string; color: string } {
+  const s = id ? (SOURCE_STYLE as Record<string, { tag: string; color: string }>)[id] : undefined;
+  return s ?? { tag: "•", color: COLOR.alt };
+}


### PR DESCRIPTION
> CONTRIBUTING says *"torlink is pastel-violet and quiet. There is exactly one gradient, the
> wordmark sheen. Please don't add a second gradient."* I read that as the bar this PR has to
> clear, not as a wall — so the whole design below is built around leaving the default alone.
> If the answer is still no, closing this costs nothing and I won't argue it twice.

## What and why

A terminal app sits on screen all day, next to everything else the user has themed. torlink's
violet is the one thing about it nobody can adjust — not because it's a bad violet, but because
it's the only one.

`shift+t` arrows through eight palettes. The **real interface repaints as the cursor moves**, so
you judge a palette on the actual UI rather than from four swatches in a box; `↵` keeps, `esc`
puts back exactly what was there.

## How the calm stays calm

**The default is untouched, byte for byte.** `torlink` is the first palette and the default,
spelled out from the exact hexes already in the codebase — accent `#a78bfa`, text `#e9e4f5`, alt
`#b9a7e6`, rule `#6b6577`, and the wordmark's own `#7c5cd6` / `#4c3a8a`. There's a test asserting
each one against a literal table, so this is checkable rather than a promise in a commit message.

**No second gradient.** There is still exactly one gradient idea — the wordmark sheen and the
progress bar that shares its ramp. This changes *which two colours it runs between*, nothing more.
Nothing new is animated, nothing new is coloured, and no element gains a gradient it didn't have.

**The semantic colours don't move.** Seeder green, warning amber, failure red mean something, so
they're identical on every palette (tested across all eight).

**The source tags don't move either.** A tag answers "who found this row" — a fact about the
source, not the palette. Tinting them toward one accent would also collapse them into each other
on Mono, which defeats the point of having distinct tags. So they stay exactly as they are today.

I also tried to keep the palettes themselves quiet: muted mid-tones, no neon, and a readability
floor on body text that's enforced by a luma assertion rather than by eye.

## Two constants had to become functions

This is the only structural change, and it's a latent bug either way:

`RULE` and `ACCENT_RAMP` were module constants that read `COLOR` **at import time** — which
happens before any saved config is loaded. As constants they'd hold the default palette forever
after a switch. Same for `HelpOverlay`'s `CARD_BORDER`, a module-level `lerpHex`. All three are
now called per render.

`COLOR` itself stays one mutable object that every component already reads at render time, so a
switch only needs a re-render — and since the theme lives in `Config`, `setConfig` already causes
one. A React context would have meant touching every component file for no behavioural gain in a
single-process TUI.

## Adding a palette

Seven colours, no code:

```ts
{ id: "slate", name: "Slate", accent: "…", bright: "…", soft: "…",
  text: "…", rule: "…", deep: "…", shade: "…" },
```

## Grain notes

- `shift+t` is a new key, so `HELP_GROUPS` has it. Like `o` and `t` it stays `?`-only in the
  footer — the global prompts apply everywhere, so no one context is right to advertise them from;
  I updated the comment in `keymap.ts` to say so.
- No new `Store` field, so `makeStore` is untouched.
- An unknown theme id in the config falls back to the default rather than failing the load, so a
  config from a newer build can't brick an older one.
- `helpLayout.test.ts` expectations moved (`gridH` `[10,15,19,32]` → `[10,15,20,33]`) because the
  `?` sheet gained a row — they're derived from `HELP_GROUPS`, so that's the test working.

## Tests

15 new cases in `theme.test.ts`: the default palette reproduced exactly, the rule colour, the
semantic colours fixed across all eight, source tags fixed across all eight and still distinct,
in-place repainting, the unknown-id fallback, per-palette hex validity, unique ids, and the body
text readability floor.

`npm test` goes from 229 to 244 passing.

> On my Windows checkout, 5 files (`daemon/{runtime,serve,watch}`, `download/queue{,.safemode}`)
> fail to load with `Cannot find module '../../../build/Release/node_datachannel.node'` — no C++
> toolchain here. Identical on a clean `upstream/main`, so it's my environment, not this change.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
