### PR TITLE
fix: retry apibay search when it answers with its no-results sentinel

### DIFF
--- a/src/sources/piratebay.test.ts
+++ b/src/sources/piratebay.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { tpbMovies } from "./piratebay";
+import { fetchResilient } from "../util/net";
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: vi.fn() };
+});
+
+const mockFetch = vi.mocked(fetchResilient);
+
+const page = (items: unknown[]): Response =>
+  ({ ok: true, status: 200, json: async () => items }) as unknown as Response;
+
+// apibay answers an empty search with this single placeholder instead of [].
+const SENTINEL = {
+  id: "0",
+  name: "No results returned",
+  info_hash: "0000000000000000000000000000000000000000",
+  category: "0",
+};
+
+const movieRow = {
+  id: "1",
+  name: "Dune Part Two 2024 1080p",
+  info_hash: "a".repeat(40),
+  seeders: "12",
+  leechers: "3",
+  size: "4000",
+  num_files: "2",
+  added: "1700000000",
+  category: "207",
+};
+
+const askedUrl = (call: number): string => String(mockFetch.mock.calls[call]![0]);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+// apibay caches search results per exact URL, and a query can be stuck with
+// the sentinel on one URL form while the alternate form answers fine (live:
+// q=metallica is poisoned bare but healthy with &cat=0; q=dune the other way
+// around). One retry on the other form re-rolls that cache key instead of
+// showing the user an empty column.
+describe("apibay sentinel retry", () => {
+  it("retries with cat=0 when a search comes back as the no-results sentinel", async () => {
+    mockFetch.mockResolvedValueOnce(page([SENTINEL]));
+    mockFetch.mockResolvedValueOnce(page([movieRow]));
+    const results = await tpbMovies.search("metallica");
+    expect(results.map((r) => r.name)).toEqual([movieRow.name]);
+    expect(askedUrl(0)).toBe("https://apibay.org/q.php?q=metallica");
+    expect(askedUrl(1)).toBe("https://apibay.org/q.php?q=metallica&cat=0");
+  });
+
+  it("asks once when the search returns real rows", async () => {
+    mockFetch.mockResolvedValueOnce(page([movieRow]));
+    await tpbMovies.search("dune");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns empty when both forms answer with the sentinel", async () => {
+    mockFetch.mockResolvedValueOnce(page([SENTINEL]));
+    mockFetch.mockResolvedValueOnce(page([SENTINEL]));
+    expect(await tpbMovies.search("qqqqzzzz")).toEqual([]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("never retries a browse, which hits the precompiled feed", async () => {
+    mockFetch.mockResolvedValueOnce(page([movieRow]));
+    await tpbMovies.search("");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(askedUrl(0)).toContain("/precompiled/");
+  });
+});

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -53,6 +53,21 @@ async function fetchItems(url: string, opts: SearchOptions): Promise<ApibayItem[
   return Array.isArray(json) ? json : [];
 }
 
+// apibay answers an empty search with one placeholder row instead of [].
+function isNoResultsSentinel(items: ApibayItem[]): boolean {
+  return items.length === 1 && items[0]?.id === "0";
+}
+
+// apibay caches search results per exact URL, and a query can be stuck with a
+// bogus sentinel on one URL form while the alternate form answers fine. One
+// retry on the explicit-category form re-rolls that cache key; a genuinely
+// empty search costs one extra request and still comes back empty.
+async function searchItems(q: string, opts: SearchOptions): Promise<ApibayItem[]> {
+  const items = await fetchItems(`${API}/q.php?q=${encodeURIComponent(q)}`, opts);
+  if (!isNoResultsSentinel(items)) return items;
+  return fetchItems(`${API}/q.php?q=${encodeURIComponent(q)}&cat=0`, opts);
+}
+
 async function search(
   query: string,
   cats: Set<number>,
@@ -61,10 +76,7 @@ async function search(
   opts: SearchOptions,
 ): Promise<TorrentResult[]> {
   const q = query.trim();
-  const items = await fetchItems(
-    q ? `${API}/q.php?q=${encodeURIComponent(q)}` : browseUrl,
-    opts,
-  );
+  const items = q ? await searchItems(q, opts) : await fetchItems(browseUrl, opts);
   const out: TorrentResult[] = [];
   for (const it of items) {
     if (q && !cats.has(Number(it.category))) continue;


### PR DESCRIPTION
## What and why

apibay's `q.php` caches search results per exact URL, and a query can get stuck with the single "No results returned" placeholder on one URL form while the alternate form answers fine. torlink always sends the bare form (`q.php?q=…`), so a poisoned query renders an empty TPB column in every tab even though the index has plenty. This retries once with `&cat=0` when the sentinel comes back: the poisoned case turns into results, a genuinely empty search costs one extra request and still comes back empty, and browses (precompiled feeds) never retry.

Measured against the live API today (2026-08-14), stable across repeated runs ~40 minutes apart:

| query | `q.php?q=…` | `q.php?q=…&cat=0` |
|---|---|---|
| metallica | sentinel (5/5) | 100 rows (4/4) |
| abba | sentinel (3/3) | 100 rows |
| pink floyd | sentinel (3/3) | 100 rows |
| dune | 100 rows (3/3) | sentinel (3/3) |
| daft punk · taylor swift · oppenheimer · breaking bad · ubuntu | 100 rows | 100 rows |

Whichever form is poisoned, the other answered in every observed case — hence retry-on-sentinel rather than swapping forms wholesale (`dune` shows a swap would just move the hole). Live through the patched module: `tpbMovies.search("metallica")` goes from 0 rows to 9, `"abba"` from 0 to 8.

The four new tests pin the retry URL, the single-request happy path, the both-forms-empty case, and that browses never retry.

Found while verifying #141's TPB music source against the live API; it affects Movies and TV identically today, so it ships separately as its own concern.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts`
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx`
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
