### PR TITLE
ci: pin workflow dependencies to immutable refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,13 @@ jobs:
         node: [22, 24]
 
     steps:
-      - uses: actions/checkout@v7
+      # Actions are pinned to commit SHAs, not tags: a tag is a mutable pointer
+      # its owner can repoint at any commit, so `@v7` is an open invitation to
+      # run code nobody here reviewed. The trailing comment is the human-readable
+      # version, and Dependabot rewrites both halves together on an update.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: ${{ matrix.node }}
           cache: npm

--- a/.github/workflows/threatcrush-scan.yml
+++ b/.github/workflows/threatcrush-scan.yml
@@ -30,14 +30,15 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v7
+      # Pinned to commit SHAs, not tags — see the note in ci.yml.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       # 22 is this repo's floor (`engines.node`) and the low end of the CI
       # matrix. Not 24: ThreatCrush pulls in better-sqlite3, which ships
       # prebuilt binaries for 22 but not yet for 24, where the install falls
       # through to a node-gyp source build and fails. A security gate that
       # cannot install is a security gate that does not run.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
 
@@ -45,10 +46,16 @@ jobs:
       # whether a security gate runs at all. Retry before giving up; a
       # transient registry blip is not a security signal and should not read
       # like one.
+      #
+      # Pinned to an exact version rather than `@latest`: a global install runs
+      # the package's install scripts on this runner, so `@latest` means an
+      # upstream publish changes what executes here with no diff and no review.
+      # Bump this deliberately. The `--format` probe below stays regardless —
+      # it now guards a bad bump instead of a surprise release.
       - name: Install ThreatCrush
         run: |
           for attempt in 1 2 3; do
-            if npm install -g "@profullstack/threatcrush@latest"; then
+            if npm install -g "@profullstack/threatcrush@0.11.2"; then
               exit 0
             fi
             delay=$((attempt * 10))
@@ -147,7 +154,7 @@ jobs:
       - name: Upload to the Security tab
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3
         with:
           sarif_file: threatcrush.sarif
           category: threatcrush
@@ -231,7 +238,7 @@ jobs:
 
       - name: Upload SARIF artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: threatcrush-sarif
           path: threatcrush.sarif
@@ -247,7 +254,7 @@ jobs:
       - name: Comment on PR
         if: always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/vu1nz-scan.yml
+++ b/.github/workflows/vu1nz-scan.yml
@@ -1,7 +1,10 @@
-# Managed by sh1pt Actions Fleet
-# pack: vu1nz-scan@1.0.1
-# install: sh1pt-actions-store
-# hash: sha256:69dca6b225e64533cd02750003f56fd1ccb4f178c37f48d4398a8254a3fe887b
+# Derived from the `vu1nz-scan@1.0.1` pack, with third-party references pinned
+# to immutable commits (see the steps below).
+#
+# The sh1pt fleet header is dropped for the same reason threatcrush-scan.yml
+# drops it: this file is no longer byte-identical to the pack, so the pack's
+# content hash no longer describes it, and a stale hash that nothing verifies
+# is worse than no hash at all.
 name: vu1nz security scan
 
 on:
@@ -18,14 +21,25 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      # Pinned to commit SHAs, not tags — see the note in ci.yml. checkout moves
+      # v4 -> v7 here to match ci.yml and threatcrush-scan.yml; the step passes
+      # no inputs, so the bump is the version number and nothing else.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
+      # Pinned to a commit, not the default branch. `pip install git+…` with no
+      # rev installs whatever HEAD happens to be at the moment the job runs, and
+      # this step's output later executes with ANTHROPIC_API_KEY and a repo
+      # token in scope. The pin is not an endorsement of the code at this
+      # commit — it only guarantees the job keeps running the same code, so a
+      # change upstream is a visible diff here rather than a silent swap.
       - name: Install vu1nz
-        run: pip install --quiet git+https://github.com/profullstack/vu1nz-gh-actions.git
+        run: |
+          pip install --quiet \
+            "git+https://github.com/profullstack/vu1nz-gh-actions.git@a6055f69d6fedd4d1a7355088dc5c06b84fa3e24"
 
       - name: Load env file
         env:
@@ -172,7 +186,7 @@ jobs:
         # always written to the job summary.
         if: always() && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## What and why

Every third-party reference in `.github/workflows` resolved through a mutable pointer: `@v7` on the actions, `@latest` on the ThreatCrush install, and a bare `git+https://…` for vu1nz that installs whatever `HEAD` is at the moment the job runs. A tag is a ref its owner can repoint at any commit, so all three mean these workflows can execute code nobody here reviewed, with no diff to show for it. That matters most on the two security workflows, which run with `ANTHROPIC_API_KEY` and a repo token in scope — the job that is supposed to catch a supply-chain problem was itself the softest way in.

Each reference now names a commit, with the human-readable version in a trailing comment so Dependabot rewrites both halves together. The pins are not an endorsement of the pinned code — they only guarantee a change upstream arrives as a visible diff rather than a silent swap.

| Reference | Pinned to |
|---|---|
| `actions/checkout` | `3d3c42e5…` (`v7`) |
| `actions/setup-node` | `82076278…` (`v7`) |
| `actions/setup-python` | `a26af69b…` (`v5`) |
| `actions/upload-artifact` | `ea165f8d…` (`v4`) |
| `actions/github-script` | `f28e40c7…` (`v7`) |
| `github/codeql-action` | `f3712979…` (`v3`) |
| `@profullstack/threatcrush` | `0.11.2` |
| `vu1nz-gh-actions` | `a6055f69…` |

Each of the six action SHAs was checked against the major tag its comment claims, by dereferencing `refs/tags/<v>` upstream. ThreatCrush pins to `0.11.2`, currently also its `latest`; the existing `--format` probe stays and now guards a bad bump instead of a surprise release.

Two things that are not pure mechanism, called out so they are not missed in the diff:

- **`checkout` moves `v4` → `v7` in `vu1nz-scan.yml`**, to match `ci.yml` and `threatcrush-scan.yml`. That step passes no inputs, so the bump is the version number and nothing else.
- **`vu1nz-scan.yml` loses its sh1pt fleet header**, the same way `threatcrush-scan.yml` already had. The file is no longer byte-identical to the pack, so the pack's content hash no longer describes it, and a stale hash that nothing verifies is worse than no hash at all.

`coinpay.yml` has the same unpinned-action problem but raises a separate question — whether the workflow should exist at all — so it is split out into its own PR rather than decided here. This PR is independent of it and can merge on its own.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (45 files, 311 tests)
- [ ] New logic has a test (vitest; mock node built-ins for platform code) — n/a, no source change
- [ ] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a
- [ ] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [ ] OS-touching code works on Windows, macOS, and Linux — n/a, CI config only
- [x] One concern, with a Conventional Commits title
