### PR TITLE
feat: look up what a search result actually is

### DIFF
--- a/src/meta/cinemeta.test.ts
+++ b/src/meta/cinemeta.test.ts
@@ -1,0 +1,519 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  CINEMETA,
+  fetchMeta,
+  imdbFromNumeric,
+  mapCatalog,
+  mapMeta,
+  metaUrl,
+  normalizeImdbId,
+  pickEpisode,
+  posterUrlFor,
+  searchCatalog,
+  searchUrl,
+} from "./cinemeta";
+import { fetchResilient } from "../util/net";
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: vi.fn() };
+});
+
+const mockFetch = vi.mocked(fetchResilient);
+
+// Trimmed captures of real Cinemeta responses. Long lists are cut down; field names and value
+// shapes are verbatim, including `director: null` on series and the poster host.
+const MATRIX_POSTER =
+  "https://m.media-amazon.com/images/M/MV5BN2NmN2VhMTQtMDNiOS00NDlhLTliMjgtODE2ZTY0ODQyNDRhXkEyXkFqcGc@._V1_SX300.jpg";
+
+const catalogBody = {
+  metas: [
+    {
+      id: "tt0133093",
+      imdb_id: "tt0133093",
+      type: "movie",
+      name: "The Matrix",
+      releaseInfo: "1999",
+      poster: MATRIX_POSTER,
+    },
+    {
+      id: "tt10838180",
+      imdb_id: "tt10838180",
+      type: "movie",
+      name: "The Matrix Resurrections",
+      releaseInfo: "2021",
+    },
+  ],
+};
+
+const movieBody = {
+  meta: {
+    id: "tt0133093",
+    imdb_id: "tt0133093",
+    type: "movie",
+    name: "The Matrix",
+    releaseInfo: "1999",
+    imdbRating: "8.7",
+    runtime: "136 min",
+    genres: ["Action", "Sci-Fi"],
+    cast: ["Keanu Reeves", "Laurence Fishburne", "Carrie-Anne Moss"],
+    director: ["Lana Wachowski", "Lilly Wachowski"],
+    description: "A computer hacker learns from mysterious rebels about the true nature of his reality.",
+    poster: MATRIX_POSTER,
+  },
+};
+
+const seriesBody = {
+  meta: {
+    id: "tt0903747",
+    imdb_id: "tt0903747",
+    type: "series",
+    name: "Breaking Bad",
+    releaseInfo: "2008–2013",
+    imdbRating: "9.5",
+    runtime: "49 min",
+    genres: ["Crime", "Drama", "Thriller"],
+    cast: ["Bryan Cranston", "Aaron Paul", "Anna Gunn"],
+    director: null,
+    description: "A chemistry teacher diagnosed with cancer turns to manufacturing methamphetamine.",
+    poster: "https://images.metahub.space/poster/medium/tt0903747/img",
+    videos: [
+      {
+        id: "tt0903747:5:13",
+        season: 5,
+        number: 13,
+        episode: 13,
+        title: "To'hajiilee",
+        overview: "Jesse's plan to hit Walt where he really lives is a success.",
+        released: "2013-09-08T00:00:00.000Z",
+      },
+      {
+        id: "tt0903747:5:14",
+        season: 5,
+        number: 14,
+        episode: 14,
+        title: "Ozymandias",
+        overview: "Walt goes on the run.",
+        released: "2013-09-15T00:00:00.000Z",
+      },
+    ],
+  },
+};
+
+// Cinemeta answers HTTP 200 with this for an id it does not know.
+const stubBody = {
+  meta: {
+    id: "tt99999999",
+    type: "movie",
+    behaviorHints: { defaultVideoId: null, hasScheduledVideos: false },
+  },
+};
+
+const ok = (body: unknown, headers: Record<string, string> = {}): Response =>
+  ({
+    ok: true,
+    status: 200,
+    headers: new Headers(headers),
+    json: vi.fn(async () => body),
+  }) as unknown as Response;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("searchUrl", () => {
+  it("percent-encodes path separators and fragments in the query", () => {
+    expect(searchUrl("movie", "a/b#c")).toBe(`${CINEMETA}/catalog/movie/top/search=a%2Fb%23c.json`);
+  });
+
+  it("keeps a dot verbatim, which cannot break out of the segment once slashes are encoded", () => {
+    // encodeURIComponent leaves "." alone by design. That is safe here because a traversal needs
+    // a separator, and every "/" is escaped — "../.." stays one opaque segment.
+    expect(searchUrl("movie", "Mr. Robot")).toBe(`${CINEMETA}/catalog/movie/top/search=Mr.%20Robot.json`);
+    expect(searchUrl("series", "../../etc/passwd")).toBe(
+      `${CINEMETA}/catalog/series/top/search=..%2F..%2Fetc%2Fpasswd.json`,
+    );
+  });
+
+  it("routes by kind", () => {
+    expect(searchUrl("series", "breaking bad")).toContain("/catalog/series/top/");
+  });
+
+  // A "\ud800" escape in a tracker payload survives JSON.parse and cleanText as a lone surrogate,
+  // and encodeURIComponent throws URIError on one. These helpers are exported and called directly,
+  // so the guarantee has to hold here, not only inside the callers' try/catch.
+  it("drops a lone surrogate instead of throwing", () => {
+    expect(searchUrl("movie", "\uD800")).toBe(`${CINEMETA}/catalog/movie/top/search=.json`);
+    expect(searchUrl("movie", "\uDFFF")).toBe(`${CINEMETA}/catalog/movie/top/search=.json`);
+    expect(searchUrl("movie", "a\uD800b")).toBe(`${CINEMETA}/catalog/movie/top/search=ab.json`);
+    expect(searchUrl("movie", "a\uDC00b")).toBe(`${CINEMETA}/catalog/movie/top/search=ab.json`);
+    // Reversed pair: each half is unpaired in context, so both go.
+    expect(searchUrl("movie", "a\uDC00\uD800b")).toBe(`${CINEMETA}/catalog/movie/top/search=ab.json`);
+  });
+
+  it("keeps a well-formed astral character", () => {
+    expect(searchUrl("movie", "Dune \u{1F600}")).toBe(
+      `${CINEMETA}/catalog/movie/top/search=Dune%20%F0%9F%98%80.json`,
+    );
+  });
+});
+
+describe("metaUrl", () => {
+  it("builds the meta document url for a kind and id", () => {
+    expect(metaUrl("movie", "tt0133093")).toBe(`${CINEMETA}/meta/movie/tt0133093.json`);
+    expect(metaUrl("series", "tt0903747")).toBe(`${CINEMETA}/meta/series/tt0903747.json`);
+  });
+
+  it("drops a lone surrogate instead of throwing", () => {
+    expect(metaUrl("movie", "\uD800")).toBe(`${CINEMETA}/meta/movie/.json`);
+    expect(metaUrl("movie", "\uDFFF")).toBe(`${CINEMETA}/meta/movie/.json`);
+    expect(metaUrl("movie", "tt013\uD8003093")).toBe(`${CINEMETA}/meta/movie/tt0133093.json`);
+    expect(metaUrl("series", "tt090\uDC003747")).toBe(`${CINEMETA}/meta/series/tt0903747.json`);
+  });
+
+  it("keeps a well-formed astral character", () => {
+    expect(metaUrl("movie", "tt0133093\u{1F600}")).toBe(
+      `${CINEMETA}/meta/movie/tt0133093%F0%9F%98%80.json`,
+    );
+  });
+});
+
+describe("normalizeImdbId", () => {
+  it("accepts a well-formed id", () => {
+    expect(normalizeImdbId("tt0133093")).toBe("tt0133093");
+    expect(normalizeImdbId("TT0133093")).toBe("tt0133093");
+    expect(normalizeImdbId("  tt0133093  ")).toBe("tt0133093");
+    expect(normalizeImdbId("tt1234567890")).toBe("tt1234567890");
+  });
+
+  it("takes the series id out of an episode id", () => {
+    expect(normalizeImdbId("tt0903747:5:14")).toBe("tt0903747");
+  });
+
+  it("rejects anything that would not survive being put in a url path", () => {
+    expect(normalizeImdbId("../etc")).toBeUndefined();
+    expect(normalizeImdbId("tt")).toBeUndefined();
+    expect(normalizeImdbId("")).toBeUndefined();
+    expect(normalizeImdbId("12")).toBeUndefined();
+    expect(normalizeImdbId("tt0133093/../../admin")).toBeUndefined();
+    expect(normalizeImdbId("tt0133093?x=1")).toBeUndefined();
+    expect(normalizeImdbId("tt12345678901")).toBeUndefined();
+    expect(normalizeImdbId("tt01330 93")).toBeUndefined();
+    expect(normalizeImdbId(undefined)).toBeUndefined();
+    expect(normalizeImdbId(133093)).toBeUndefined();
+    expect(normalizeImdbId({ id: "tt0133093" })).toBeUndefined();
+  });
+});
+
+describe("imdbFromNumeric", () => {
+  it("prefixes and validates a numeric id", () => {
+    expect(imdbFromNumeric("32308214")).toBe("tt32308214");
+    expect(imdbFromNumeric(133093)).toBe("tt0133093");
+    expect(imdbFromNumeric("0133093")).toBe("tt0133093");
+  });
+
+  it("rejects non-numeric input rather than forging an id", () => {
+    expect(imdbFromNumeric("tt0133093")).toBeUndefined();
+    expect(imdbFromNumeric("12x")).toBeUndefined();
+    expect(imdbFromNumeric("")).toBeUndefined();
+    expect(imdbFromNumeric("12345678901")).toBeUndefined();
+    expect(imdbFromNumeric(null)).toBeUndefined();
+  });
+});
+
+describe("posterUrlFor", () => {
+  it("rewrites a known Amazon rendition down to a thumbnail", () => {
+    const raw = "https://m.media-amazon.com/images/M/MV5BabcXkFqcGc@._V1_SX250.jpg";
+    expect(posterUrlFor("tt0133093", raw)).toBe(
+      "https://m.media-amazon.com/images/M/MV5BabcXkFqcGc@._V1_SX120.jpg",
+    );
+  });
+
+  it("falls back to metahub for any other poster, never echoing the raw url", () => {
+    const metahub = "https://images.metahub.space/poster/small/tt0133093/img?format=jpeg";
+    expect(posterUrlFor("tt0133093")).toBe(metahub);
+    expect(posterUrlFor("tt0133093", "https://example.invalid/p.webp")).toBe(metahub);
+    // Right host, wrong shape: an unanchored match would let this through.
+    expect(posterUrlFor("tt0133093", "https://m.media-amazon.com/images/M/x._V1_SX250.jpg?q=1")).toBe(
+      metahub,
+    );
+    expect(posterUrlFor("tt0133093", "http://m.media-amazon.com/images/M/x._V1_SX250.jpg")).toBe(metahub);
+  });
+
+  it("returns nothing when the id would not be safe in a url path", () => {
+    expect(posterUrlFor("../../etc")).toBeUndefined();
+  });
+});
+
+describe("mapCatalog", () => {
+  it("maps catalog rows to hits", () => {
+    expect(mapCatalog(catalogBody, "movie")).toEqual([
+      { imdbId: "tt0133093", name: "The Matrix", releaseInfo: "1999", kind: "movie" },
+      { imdbId: "tt10838180", name: "The Matrix Resurrections", releaseInfo: "2021", kind: "movie" },
+    ]);
+  });
+
+  it("drops rows with no usable id or name instead of defaulting them", () => {
+    const hits = mapCatalog(
+      { metas: [{ id: "kitsu:42", name: "Some Anime" }, { id: "tt0133093" }, null, "x"] },
+      "movie",
+    );
+    expect(hits).toEqual([]);
+  });
+
+  it("returns [] for a body that is not a catalog", () => {
+    expect(mapCatalog(undefined, "movie")).toEqual([]);
+    expect(mapCatalog({}, "movie")).toEqual([]);
+    expect(mapCatalog({ metas: "nope" }, "movie")).toEqual([]);
+    expect(mapCatalog([], "movie")).toEqual([]);
+  });
+});
+
+describe("mapMeta", () => {
+  it("maps a movie", () => {
+    const meta = mapMeta(movieBody, "movie");
+    expect(meta).toMatchObject({
+      imdbId: "tt0133093",
+      kind: "movie",
+      title: "The Matrix",
+      year: "1999",
+      rating: "8.7",
+      runtime: "136 min",
+      genres: ["Action", "Sci-Fi"],
+      director: ["Lana Wachowski", "Lilly Wachowski"],
+    });
+    expect(meta?.plot).toContain("computer hacker");
+    // Never the raw poster: it is a 300px-wide rendition on a host we only trust in one shape.
+    expect(meta?.posterUrl).toBe(
+      "https://m.media-amazon.com/images/M/MV5BN2NmN2VhMTQtMDNiOS00NDlhLTliMjgtODE2ZTY0ODQyNDRhXkEyXkFqcGc@._V1_SX120.jpg",
+    );
+  });
+
+  it("returns null for the http-200 stub Cinemeta sends for an unknown id", () => {
+    expect(mapMeta(stubBody, "movie")).toBeNull();
+  });
+
+  it("returns null for anything that is not a meta document", () => {
+    expect(mapMeta(null, "movie")).toBeNull();
+    expect(mapMeta({}, "movie")).toBeNull();
+    expect(mapMeta({ meta: "x" }, "movie")).toBeNull();
+    expect(mapMeta({ meta: { name: "No Id Here" } }, "movie")).toBeNull();
+  });
+
+  it("survives director: null, which is what series always send", () => {
+    const meta = mapMeta(seriesBody, "series");
+    expect(meta?.director).toEqual([]);
+    expect(meta?.year).toBe("2008–2013");
+    expect(meta?.kind).toBe("series");
+    // The series poster is on metahub but in the wrong size and format, so it is rebuilt.
+    expect(meta?.posterUrl).toBe("https://images.metahub.space/poster/small/tt0903747/img?format=jpeg");
+  });
+
+  it("caps lists and plot length so one payload cannot flood the pane", () => {
+    const meta = mapMeta(
+      {
+        meta: {
+          id: "tt0133093",
+          name: "Capped",
+          genres: Array.from({ length: 20 }, (_, i) => `g${i}`),
+          cast: Array.from({ length: 40 }, (_, i) => `c${i}`),
+          director: Array.from({ length: 9 }, (_, i) => `d${i}`),
+          description: "x".repeat(2000),
+        },
+      },
+      "movie",
+    );
+    expect(meta?.genres).toHaveLength(6);
+    expect(meta?.cast).toHaveLength(12);
+    expect(meta?.director).toHaveLength(3);
+    expect(meta?.plot).toHaveLength(800);
+  });
+
+  // The list caps above bound how many entries survive, not how long one entry may be, and
+  // MAX_META_BYTES lets a 3 MB body through — so without a cap inside text() a single field is
+  // free to be the whole body. Both tests below are about the cap being at the funnel: they assert
+  // the length that leaves mapMeta, and that producing it did not cost a walk over the input.
+  describe("caps the length of a single remote string", () => {
+    // 2.9 MB, the size of a body that passes withinSizeCap. cleanText is linear, so cleaning this
+    // before slicing to MAX_PLOT costs ~295 ms against ~0.25 ms for slicing first; the assertion
+    // is deliberately an order of magnitude looser than that gap so it cannot flake on slow CI.
+    const HUGE = "lorem ipsum dolor sit amet ".repeat(112_000);
+
+    it("truncates a description without cleaning the whole thing first", () => {
+      const started = performance.now();
+      const meta = mapMeta({ meta: { id: "tt0133093", name: "Huge", description: HUGE } }, "movie");
+      const elapsed = performance.now() - started;
+
+      expect(meta?.plot).toHaveLength(800);
+      expect(meta?.plot?.startsWith("lorem ipsum")).toBe(true);
+      expect(elapsed).toBeLessThan(50);
+    });
+
+    it("caps a pathological cast entry before it can reach the pane's word wrapper", () => {
+      // One 1 MB token. Nothing overflows the pane — planPaneLines admits a block all or nothing,
+      // so the row is dropped — but wordWrapLines still walks it on every single render, which is
+      // ~176 ms per frame. Capping here is what keeps that off the render path entirely.
+      const meta = mapMeta(
+        {
+          meta: {
+            id: "tt0133093",
+            name: "Huge",
+            cast: ["a".repeat(1_000_000), "Keanu Reeves"],
+            genres: ["b".repeat(1_000_000)],
+          },
+        },
+        "movie",
+      );
+
+      for (const s of [...(meta?.cast ?? []), ...(meta?.genres ?? [])]) {
+        expect(s.length).toBeLessThanOrEqual(1500);
+      }
+      // The cap trims the offender, it does not drop it or the entries after it.
+      expect(meta?.cast?.[1]).toBe("Keanu Reeves");
+    });
+
+    it("leaves every legitimate field untouched", () => {
+      // Nothing Cinemeta really sends comes near the cap: the plot is cut to 800 right after, and
+      // the rest are names, years and runtimes.
+      const meta = mapMeta(movieBody, "movie");
+      expect(meta?.title).toBe("The Matrix");
+      expect(meta?.cast).toEqual(["Keanu Reeves", "Laurence Fishburne", "Carrie-Anne Moss"]);
+      expect(meta?.plot).toBe(movieBody.meta.description);
+    });
+
+    it("answers undefined for a field that is only whitespace up to the cap", () => {
+      // The blank check reads the capped string, so this cannot come back as "Untitled".
+      const meta = mapMeta(
+        { meta: { id: "tt0133093", name: "Padded", description: `${" ".repeat(2000)}real plot` } },
+        "movie",
+      );
+      expect(meta?.plot).toBeUndefined();
+    });
+  });
+
+  it("cleans terminal-hostile characters out of every string it keeps", () => {
+    const meta = mapMeta(
+      {
+        meta: {
+          id: "tt0133093",
+          // A hijacked provider could ship an OSC/CSI sequence in any of these fields.
+          name: "The \u001b[31mMatrix\u001b[0m",
+          genres: ["  Action\u0007  ", "", "   ", "Sci-Fi"],
+          description: "two\nlines\u200b here",
+        },
+      },
+      "movie",
+    );
+    expect(meta?.title).toBe("The [31mMatrix[0m");
+    // Blank entries are dropped rather than turning into cleanText's "Untitled" placeholder.
+    expect(meta?.genres).toEqual(["Action", "Sci-Fi"]);
+    // Junk code points are deleted, not replaced by a space, so the newline leaves no gap.
+    expect(meta?.plot).toBe("twolines here");
+  });
+});
+
+describe("pickEpisode", () => {
+  it("finds S05E14 in a videos array", () => {
+    expect(pickEpisode(seriesBody, 5, 14)).toEqual({
+      season: 5,
+      number: 14,
+      title: "Ozymandias",
+      overview: "Walt goes on the run.",
+    });
+  });
+
+  it("accepts a bare meta object as well as a whole response body", () => {
+    expect(pickEpisode(seriesBody.meta, 5, 13)?.title).toBe("To'hajiilee");
+  });
+
+  it("returns undefined when the episode is absent or the shape is wrong", () => {
+    expect(pickEpisode(seriesBody, 5, 99)).toBeUndefined();
+    expect(pickEpisode(seriesBody, 1, 14)).toBeUndefined();
+    expect(pickEpisode(movieBody, 1, 1)).toBeUndefined();
+    expect(pickEpisode(null, 1, 1)).toBeUndefined();
+    expect(pickEpisode({ videos: "nope" }, 1, 1)).toBeUndefined();
+  });
+});
+
+describe("searchCatalog", () => {
+  it("requests the search catalog and maps the hits", async () => {
+    mockFetch.mockResolvedValueOnce(ok(catalogBody));
+    const hits = await searchCatalog("movie", "The Matrix");
+    expect(mockFetch.mock.calls[0]?.[0]).toBe(`${CINEMETA}/catalog/movie/top/search=The%20Matrix.json`);
+    expect(hits.map((h) => h.imdbId)).toEqual(["tt0133093", "tt10838180"]);
+  });
+
+  it("does not call out for an empty query", async () => {
+    expect(await searchCatalog("movie", "   ")).toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns [] instead of throwing when the request fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ENOTFOUND"));
+    expect(await searchCatalog("movie", "The Matrix")).toEqual([]);
+  });
+
+  it("returns [] on a non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      headers: new Headers(),
+      json: async () => ({}),
+    } as unknown as Response);
+    expect(await searchCatalog("movie", "The Matrix")).toEqual([]);
+  });
+});
+
+describe("fetchMeta", () => {
+  it("fetches and maps a movie", async () => {
+    mockFetch.mockResolvedValueOnce(ok(movieBody));
+    const meta = await fetchMeta("movie", "tt0133093");
+    expect(mockFetch.mock.calls[0]?.[0]).toBe(`${CINEMETA}/meta/movie/tt0133093.json`);
+    expect(meta?.title).toBe("The Matrix");
+  });
+
+  it("attaches the requested episode to a series", async () => {
+    mockFetch.mockResolvedValueOnce(ok(seriesBody));
+    const meta = await fetchMeta("series", "tt0903747", { season: 5, episode: 14 });
+    expect(meta?.episode).toEqual({
+      season: 5,
+      number: 14,
+      title: "Ozymandias",
+      overview: "Walt goes on the run.",
+    });
+  });
+
+  it("keeps the series meta when the episode is not in the document", async () => {
+    mockFetch.mockResolvedValueOnce(ok(seriesBody));
+    const meta = await fetchMeta("series", "tt0903747", { season: 9, episode: 9 });
+    expect(meta?.title).toBe("Breaking Bad");
+    expect(meta?.episode).toBeUndefined();
+  });
+
+  it("returns null for the unknown-id stub even though the status is 200", async () => {
+    mockFetch.mockResolvedValueOnce(ok(stubBody));
+    expect(await fetchMeta("movie", "tt99999999")).toBeNull();
+  });
+
+  it("rejects an oversized body without parsing it", async () => {
+    const res = ok(movieBody, { "content-length": "5000000" });
+    mockFetch.mockResolvedValueOnce(res);
+    expect(await fetchMeta("movie", "tt0133093")).toBeNull();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it("parses a body whose declared size is under the cap", async () => {
+    mockFetch.mockResolvedValueOnce(ok(movieBody, { "content-length": "42000" }));
+    expect((await fetchMeta("movie", "tt0133093"))?.title).toBe("The Matrix");
+  });
+
+  it("never puts an unvalidated id in the url", async () => {
+    expect(await fetchMeta("movie", "../../admin")).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null instead of throwing when the request fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("timed out"));
+    expect(await fetchMeta("movie", "tt0133093")).toBeNull();
+  });
+});

--- a/src/meta/cinemeta.test.ts
+++ b/src/meta/cinemeta.test.ts
@@ -2,11 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   CINEMETA,
   fetchMeta,
-  imdbFromNumeric,
   mapCatalog,
   mapMeta,
   metaUrl,
-  normalizeImdbId,
   pickEpisode,
   posterUrlFor,
   searchCatalog,
@@ -175,49 +173,6 @@ describe("metaUrl", () => {
     expect(metaUrl("movie", "tt0133093\u{1F600}")).toBe(
       `${CINEMETA}/meta/movie/tt0133093%F0%9F%98%80.json`,
     );
-  });
-});
-
-describe("normalizeImdbId", () => {
-  it("accepts a well-formed id", () => {
-    expect(normalizeImdbId("tt0133093")).toBe("tt0133093");
-    expect(normalizeImdbId("TT0133093")).toBe("tt0133093");
-    expect(normalizeImdbId("  tt0133093  ")).toBe("tt0133093");
-    expect(normalizeImdbId("tt1234567890")).toBe("tt1234567890");
-  });
-
-  it("takes the series id out of an episode id", () => {
-    expect(normalizeImdbId("tt0903747:5:14")).toBe("tt0903747");
-  });
-
-  it("rejects anything that would not survive being put in a url path", () => {
-    expect(normalizeImdbId("../etc")).toBeUndefined();
-    expect(normalizeImdbId("tt")).toBeUndefined();
-    expect(normalizeImdbId("")).toBeUndefined();
-    expect(normalizeImdbId("12")).toBeUndefined();
-    expect(normalizeImdbId("tt0133093/../../admin")).toBeUndefined();
-    expect(normalizeImdbId("tt0133093?x=1")).toBeUndefined();
-    expect(normalizeImdbId("tt12345678901")).toBeUndefined();
-    expect(normalizeImdbId("tt01330 93")).toBeUndefined();
-    expect(normalizeImdbId(undefined)).toBeUndefined();
-    expect(normalizeImdbId(133093)).toBeUndefined();
-    expect(normalizeImdbId({ id: "tt0133093" })).toBeUndefined();
-  });
-});
-
-describe("imdbFromNumeric", () => {
-  it("prefixes and validates a numeric id", () => {
-    expect(imdbFromNumeric("32308214")).toBe("tt32308214");
-    expect(imdbFromNumeric(133093)).toBe("tt0133093");
-    expect(imdbFromNumeric("0133093")).toBe("tt0133093");
-  });
-
-  it("rejects non-numeric input rather than forging an id", () => {
-    expect(imdbFromNumeric("tt0133093")).toBeUndefined();
-    expect(imdbFromNumeric("12x")).toBeUndefined();
-    expect(imdbFromNumeric("")).toBeUndefined();
-    expect(imdbFromNumeric("12345678901")).toBeUndefined();
-    expect(imdbFromNumeric(null)).toBeUndefined();
   });
 });
 

--- a/src/meta/cinemeta.ts
+++ b/src/meta/cinemeta.ts
@@ -1,5 +1,6 @@
 import { fetchResilient, USER_AGENT } from "../util/net";
 import { cleanText } from "../util/format";
+import { normalizeImdbId } from "./imdbId";
 import type { CatalogHit, EpisodeMeta, Meta, MetaKind } from "./types";
 
 // Cinemeta is Stremio's public metadata addon: keyless, CORS-open, IMDb-keyed. torlink uses it
@@ -33,39 +34,11 @@ const AMAZON_POSTER = /^https:\/\/m\.media-amazon\.com\/images\/M\/[\w@.-]+\._V1
 // sane rendition rather than the ~200 KB original the API links to.
 const POSTER_WIDTH = "SX120";
 
-// An IMDb id is interpolated into a URL *path*, so it is attacker-controlled routing input the
-// moment it comes back from a remote catalog. Same class of rule as stripControl() in
-// util/format: validate the value you are about to hand to another system, not the value you
-// received. Anchored, digits only — "tt0133093/../../admin" and "tt0133093?x=1" both fail.
-const IMDB_ID = /^tt\d{7,10}$/;
-
 const MAX_GENRES = 6;
 const MAX_CAST = 12;
 const MAX_DIRECTORS = 3;
 const MAX_PLOT = 800;
 
-/**
- * Accept a remote value as an IMDb id only if it still looks like one after cleaning. Returns
- * undefined rather than throwing so callers can treat "no id" and "bad id" identically.
- */
-export function normalizeImdbId(raw: unknown): string | undefined {
-  if (typeof raw !== "string") return undefined;
-  const trimmed = raw.trim().toLowerCase();
-  // Series episodes arrive as "tt0944947:5:14"; the series id is the part before the first colon.
-  const base = trimmed.split(":", 1)[0] ?? "";
-  return IMDB_ID.test(base) ? base : undefined;
-}
-
-/**
- * Some sources (YTS, torrent indexes) carry the bare numeric IMDb id. Zero-pad to IMDb's minimum
- * width of seven, then run the same result-side validation — a caller could hand us anything.
- */
-export function imdbFromNumeric(raw: unknown): string | undefined {
-  const s = typeof raw === "number" ? String(raw) : typeof raw === "string" ? raw.trim() : "";
-  if (!/^\d+$/.test(s)) return undefined;
-  const candidate = `tt${s.padStart(7, "0")}`;
-  return IMDB_ID.test(candidate) ? candidate : undefined;
-}
 // Ceiling on any single remote string, applied before it is cleaned. MAX_META_BYTES lets a 3 MB
 // body through and the list caps below bound the *count* of entries, not the length of one — so
 // without this a single field is free to be the whole body. That costs twice, and both costs are

--- a/src/meta/cinemeta.ts
+++ b/src/meta/cinemeta.ts
@@ -1,0 +1,336 @@
+import { fetchResilient, USER_AGENT } from "../util/net";
+import { cleanText } from "../util/format";
+import type { CatalogHit, EpisodeMeta, Meta, MetaKind } from "./types";
+
+// Cinemeta is Stremio's public metadata addon: keyless, CORS-open, IMDb-keyed. torlink uses it
+// because a search row needs a title, a year and a poster with no account, no API key and no
+// per-user rate limit to explain to the user.
+//
+// Everything here fails soft. These calls are made from a React render path, so a dead provider,
+// a hostile payload or a slow network must degrade to "no metadata", never to a thrown exception
+// that unmounts the TUI. That is why every mapper is total and every network function returns
+// null/[] instead of rejecting.
+export const CINEMETA = "https://v3-cinemeta.strem.io";
+
+// One request per row of interest, so the budget is short: a stale poster is worthless once the
+// user has already scrolled past the row that wanted it.
+const TIMEOUT_MS = 6000;
+
+// A long-running series carries every episode in its meta document — One Piece is 1.35 MB — but
+// nothing legitimate approaches this. The cap exists so a hostile or broken upstream cannot make
+// us buffer an unbounded body into a terminal app's heap.
+const MAX_META_BYTES = 3_000_000;
+
+// Metahub is Stremio's own poster CDN, keyed by IMDb id, and it is the only host we will point
+// an image loader at besides Amazon's image server.
+const METAHUB = "https://images.metahub.space/poster/small";
+
+// Amazon's image server encodes the rendition in the filename. Anchored end to end so nothing
+// but a plain path under that host can match: this string ends up in an outbound request.
+const AMAZON_POSTER = /^https:\/\/m\.media-amazon\.com\/images\/M\/[\w@.-]+\._V1_SX\d+\.jpg$/;
+
+// The terminal renders posters as a few dozen character cells, so ask Amazon for the smallest
+// sane rendition rather than the ~200 KB original the API links to.
+const POSTER_WIDTH = "SX120";
+
+// An IMDb id is interpolated into a URL *path*, so it is attacker-controlled routing input the
+// moment it comes back from a remote catalog. Same class of rule as stripControl() in
+// util/format: validate the value you are about to hand to another system, not the value you
+// received. Anchored, digits only — "tt0133093/../../admin" and "tt0133093?x=1" both fail.
+const IMDB_ID = /^tt\d{7,10}$/;
+
+const MAX_GENRES = 6;
+const MAX_CAST = 12;
+const MAX_DIRECTORS = 3;
+const MAX_PLOT = 800;
+
+/**
+ * Accept a remote value as an IMDb id only if it still looks like one after cleaning. Returns
+ * undefined rather than throwing so callers can treat "no id" and "bad id" identically.
+ */
+export function normalizeImdbId(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim().toLowerCase();
+  // Series episodes arrive as "tt0944947:5:14"; the series id is the part before the first colon.
+  const base = trimmed.split(":", 1)[0] ?? "";
+  return IMDB_ID.test(base) ? base : undefined;
+}
+
+/**
+ * Some sources (YTS, torrent indexes) carry the bare numeric IMDb id. Zero-pad to IMDb's minimum
+ * width of seven, then run the same result-side validation — a caller could hand us anything.
+ */
+export function imdbFromNumeric(raw: unknown): string | undefined {
+  const s = typeof raw === "number" ? String(raw) : typeof raw === "string" ? raw.trim() : "";
+  if (!/^\d+$/.test(s)) return undefined;
+  const candidate = `tt${s.padStart(7, "0")}`;
+  return IMDB_ID.test(candidate) ? candidate : undefined;
+}
+// Ceiling on any single remote string, applied before it is cleaned. MAX_META_BYTES lets a 3 MB
+// body through and the list caps below bound the *count* of entries, not the length of one — so
+// without this a single field is free to be the whole body. That costs twice, and both costs are
+// real rather than theoretical:
+//
+//   - cleanText walks a string code point by code point, so running it over a 2.9 MB description
+//     and only then slicing to MAX_PLOT takes ~295 ms, against ~0.25 ms for slicing first. For
+//     scale, JSON.parse of that same body is ~2 ms.
+//   - a single oversized cast entry or genre survives into Meta and reaches wordWrapLines in
+//     MetaPane's planPaneLines, which re-runs on *every* render: ~176 ms per frame for a 1 MB
+//     token, i.e. a pane that re-wraps a megabyte on each keystroke. The row is ultimately
+//     dropped (planPaneLines admits a block all-or-nothing) so nothing overflows — the cost is
+//     paid in full for output that is thrown away.
+//
+// One cap here rather than one per call site: text() is the single funnel every remote string
+// passes through, so capping it is what makes "no unbounded string leaves this module" a property
+// instead of a checklist. 1500 cannot truncate anything legitimate — the longest field, the plot,
+// is cut to 800 immediately after, and every other string is a name, a year, a runtime or an
+// episode title.
+const MAX_FIELD = 1500;
+
+// An unpaired surrogate — half of an astral character, with no other half — is the one input that
+// makes encodeURIComponent throw URIError. It is remotely reachable: JSON.parse turns a "\ud800"
+// escape in a tracker payload into one, and cleanText() does not strip it. Half a character
+// carries no meaning, so it is dropped rather than substituted.
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+// The URL builders are exported and called directly, so "never throws" is part of their contract,
+// not just an accident of being wrapped in a try/catch upstream.
+function encodeSegment(s: string): string {
+  return encodeURIComponent(s.replace(LONE_SURROGATE, ""));
+}
+
+export function searchUrl(kind: MetaKind, query: string): string {
+  // The query is a path segment, not a query string, so it has to be percent-encoded or a title
+  // containing "/" or "#" would rewrite the route.
+  return `${CINEMETA}/catalog/${kind}/top/search=${encodeSegment(query)}.json`;
+}
+
+export function metaUrl(kind: MetaKind, imdbId: string): string {
+  return `${CINEMETA}/meta/${kind}/${encodeSegment(imdbId)}.json`;
+}
+
+/**
+ * Pick a poster URL we are willing to fetch. Never the raw `meta.poster`: it varies by host and
+ * can be WebP, which the terminal renderer cannot decode. A known Amazon rendition is rewritten
+ * down to a thumbnail; anything else falls back to metahub, which is keyed by the (validated)
+ * IMDb id and always answers baseline JPEG.
+ */
+export function posterUrlFor(imdbId: string, rawPoster?: string): string | undefined {
+  const id = normalizeImdbId(imdbId);
+  if (id === undefined) return undefined;
+  if (rawPoster !== undefined && AMAZON_POSTER.test(rawPoster)) {
+    // Anchored on the suffix, not on "SX\d+" anywhere: the opaque id before it can contain the
+    // same shape, and rewriting that would forge a URL for a different image.
+    return rawPoster.replace(/\._V1_SX\d+\.jpg$/, `._V1_${POSTER_WIDTH}.jpg`);
+  }
+  return `${METAHUB}/${id}/img?format=jpeg`;
+}
+
+// Remote strings reach a terminal, so they go through cleanText() at the boundary. cleanText()
+// substitutes "Untitled" for an empty result, which is right for a title and wrong for every
+// optional field — hence the blank check before, and the return of undefined rather than a
+// placeholder for anything the payload simply did not carry.
+function text(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  // Cap before anything else reads the string. cleanText and trim are both linear in their input,
+  // so doing either first would pay for the whole hostile value to produce something that is about
+  // to be cut down anyway. Testing the *capped* string for blankness rather than the original also
+  // keeps the two in agreement: a field padded with MAX_FIELD leading spaces answers undefined,
+  // instead of slipping past the blank check and coming back as cleanText's "Untitled" placeholder.
+  const capped = raw.slice(0, MAX_FIELD);
+  if (capped.trim() === "") return undefined;
+  return cleanText(capped);
+}
+
+function stringList(raw: unknown, cap: number): string[] {
+  // Cinemeta sends `null` (not `[]`) for director on series, and occasionally a bare string.
+  if (typeof raw === "string") {
+    const one = text(raw);
+    return one === undefined ? [] : [one];
+  }
+  if (!Array.isArray(raw)) return [];
+  const out: string[] = [];
+  for (const entry of raw) {
+    const v = text(entry);
+    if (v !== undefined) out.push(v);
+    if (out.length >= cap) break;
+  }
+  return out;
+}
+
+function toInt(raw: unknown): number | undefined {
+  if (typeof raw === "number") return Number.isFinite(raw) ? Math.trunc(raw) : undefined;
+  if (typeof raw !== "string") return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Map a catalog response to hits. Rows without a usable id or name are dropped, not defaulted. */
+export function mapCatalog(json: unknown, kind: MetaKind): CatalogHit[] {
+  const metas = asRecord(json)?.["metas"];
+  if (!Array.isArray(metas)) return [];
+  const out: CatalogHit[] = [];
+  for (const entry of metas) {
+    const row = asRecord(entry);
+    if (row === undefined) continue;
+    const imdbId = normalizeImdbId(row["imdb_id"]) ?? normalizeImdbId(row["id"]);
+    const name = text(row["name"]);
+    // A hit with no name cannot be scored against a release title, so it is noise.
+    if (imdbId === undefined || name === undefined) continue;
+    const releaseInfo = text(row["releaseInfo"]);
+    out.push({
+      imdbId,
+      name,
+      kind,
+      ...(releaseInfo !== undefined ? { releaseInfo } : {}),
+    });
+  }
+  return out;
+}
+
+/**
+ * Find one episode in a series meta document. Cinemeta numbers episodes in `number` and repeats
+ * it in `episode`; specials live in season 0, so an exact season match matters.
+ */
+export function pickEpisode(json: unknown, season: number, episode: number): EpisodeMeta | undefined {
+  const root = asRecord(json);
+  // Accepts either a whole response body or the inner meta object, because fetchMeta has the
+  // former and a caller re-reading a cached meta has the latter.
+  const videos = root?.["videos"] ?? asRecord(root?.["meta"])?.["videos"];
+  if (!Array.isArray(videos)) return undefined;
+  for (const entry of videos) {
+    const v = asRecord(entry);
+    if (v === undefined) continue;
+    const s = toInt(v["season"]);
+    const n = toInt(v["number"]) ?? toInt(v["episode"]);
+    if (s !== season || n !== episode) continue;
+    const title = text(v["title"] ?? v["name"]);
+    const overview = text(v["overview"] ?? v["description"]);
+    return {
+      season,
+      number: episode,
+      ...(title !== undefined ? { title } : {}),
+      ...(overview !== undefined ? { overview } : {}),
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Map a meta response, or return null if it is not a real hit.
+ *
+ * Cinemeta answers HTTP 200 for ids it has never heard of, with a stub body carrying only
+ * `{id, type, behaviorHints}`. The status code therefore proves nothing: the presence of
+ * `meta.name` is the only signal that separates a real record from that stub.
+ */
+export function mapMeta(json: unknown, kind: MetaKind): Meta | null {
+  const meta = asRecord(asRecord(json)?.["meta"]);
+  if (meta === undefined) return null;
+
+  const title = text(meta["name"]);
+  if (title === undefined) return null;
+
+  const imdbId = normalizeImdbId(meta["imdb_id"]) ?? normalizeImdbId(meta["id"]);
+  if (imdbId === undefined) return null;
+
+  const year = text(meta["releaseInfo"]);
+  const rating = text(meta["imdbRating"]);
+  const runtime = text(meta["runtime"]);
+  const plotRaw = text(meta["description"] ?? meta["plot"]);
+  // A synopsis is decoration next to a torrent row; anything past this is scroll, not information.
+  const plot = plotRaw === undefined ? undefined : plotRaw.slice(0, MAX_PLOT);
+  const rawPoster = typeof meta["poster"] === "string" ? meta["poster"] : undefined;
+  const posterUrl = posterUrlFor(imdbId, rawPoster);
+
+  return {
+    imdbId,
+    kind,
+    title,
+    genres: stringList(meta["genres"], MAX_GENRES),
+    cast: stringList(meta["cast"], MAX_CAST),
+    director: stringList(meta["director"], MAX_DIRECTORS),
+    ...(year !== undefined ? { year } : {}),
+    ...(rating !== undefined ? { rating } : {}),
+    ...(runtime !== undefined ? { runtime } : {}),
+    ...(plot !== undefined ? { plot } : {}),
+    ...(posterUrl !== undefined ? { posterUrl } : {}),
+  };
+}
+
+// A caller's cancellation and our own deadline are both reasons to stop, and the request should
+// honour whichever fires first.
+function deadline(signal?: AbortSignal): AbortSignal {
+  const timeout = AbortSignal.timeout(TIMEOUT_MS);
+  return signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
+}
+
+// Refuse an oversized body before reading it. content-length is advisory, but a truthful cap is
+// still worth having: it costs nothing and stops the common case of a genuinely huge document.
+function withinSizeCap(res: Response): boolean {
+  const declared = Number(res.headers.get("content-length"));
+  return !Number.isFinite(declared) || declared <= MAX_META_BYTES;
+}
+
+/**
+ * Search a Cinemeta catalog. Returns [] on any failure — a search row that cannot be enriched is
+ * a cosmetic loss, so nothing here is worth propagating to the caller.
+ */
+export async function searchCatalog(
+  kind: MetaKind,
+  query: string,
+  opts: { signal?: AbortSignal } = {},
+): Promise<CatalogHit[]> {
+  const q = query.trim();
+  if (q === "") return [];
+  try {
+    const res = await fetchResilient(searchUrl(kind, q), {
+      // One shot. This runs while the user is looking at the list; a backoff would deliver the
+      // answer long after the row it belonged to stopped being interesting.
+      retries: 0,
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: deadline(opts.signal),
+    });
+    if (!res.ok || !withinSizeCap(res)) return [];
+    return mapCatalog(await res.json(), kind);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch one title's metadata, optionally narrowed to a single episode. Returns null on failure,
+ * on an unknown id (the HTTP-200 stub) and on an oversized body.
+ */
+export async function fetchMeta(
+  kind: MetaKind,
+  imdbId: string,
+  opts: { signal?: AbortSignal; season?: number; episode?: number } = {},
+): Promise<Meta | null> {
+  const id = normalizeImdbId(imdbId);
+  if (id === undefined) return null;
+  try {
+    const res = await fetchResilient(metaUrl(kind, id), {
+      retries: 0,
+      headers: { "User-Agent": USER_AGENT, Accept: "application/json" },
+      signal: deadline(opts.signal),
+    });
+    if (!res.ok || !withinSizeCap(res)) return null;
+    const json: unknown = await res.json();
+    const meta = mapMeta(json, kind);
+    if (meta === null) return null;
+    const { season, episode } = opts;
+    if (season === undefined || episode === undefined) return meta;
+    const found = pickEpisode(json, season, episode);
+    // No matching video is normal (an unaired episode, a mis-parsed number): keep the series
+    // metadata rather than discarding a good hit over a missing row.
+    return found === undefined ? meta : { ...meta, episode: found };
+  } catch {
+    return null;
+  }
+}

--- a/src/meta/imdbId.test.ts
+++ b/src/meta/imdbId.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { imdbFromNumeric, normalizeImdbId } from "./imdbId";
+
+describe("normalizeImdbId", () => {
+  it("accepts a well-formed id", () => {
+    expect(normalizeImdbId("tt0133093")).toBe("tt0133093");
+    expect(normalizeImdbId("TT0133093")).toBe("tt0133093");
+    expect(normalizeImdbId("  tt0133093  ")).toBe("tt0133093");
+    expect(normalizeImdbId("tt1234567890")).toBe("tt1234567890");
+  });
+
+  it("takes the series id out of an episode id", () => {
+    expect(normalizeImdbId("tt0903747:5:14")).toBe("tt0903747");
+  });
+
+  it("rejects anything that would not survive being put in a url path", () => {
+    expect(normalizeImdbId("../etc")).toBeUndefined();
+    expect(normalizeImdbId("tt")).toBeUndefined();
+    expect(normalizeImdbId("")).toBeUndefined();
+    expect(normalizeImdbId("12")).toBeUndefined();
+    expect(normalizeImdbId("tt0133093/../../admin")).toBeUndefined();
+    expect(normalizeImdbId("tt0133093?x=1")).toBeUndefined();
+    expect(normalizeImdbId("tt12345678901")).toBeUndefined();
+    expect(normalizeImdbId("tt01330 93")).toBeUndefined();
+    expect(normalizeImdbId(undefined)).toBeUndefined();
+    expect(normalizeImdbId(133093)).toBeUndefined();
+    expect(normalizeImdbId({ id: "tt0133093" })).toBeUndefined();
+  });
+});
+
+describe("imdbFromNumeric", () => {
+  it("prefixes and validates a numeric id", () => {
+    expect(imdbFromNumeric("32308214")).toBe("tt32308214");
+    expect(imdbFromNumeric(133093)).toBe("tt0133093");
+    expect(imdbFromNumeric("0133093")).toBe("tt0133093");
+  });
+
+  it("rejects non-numeric input rather than forging an id", () => {
+    expect(imdbFromNumeric("tt0133093")).toBeUndefined();
+    expect(imdbFromNumeric("12x")).toBeUndefined();
+    expect(imdbFromNumeric("")).toBeUndefined();
+    expect(imdbFromNumeric("12345678901")).toBeUndefined();
+    expect(imdbFromNumeric(null)).toBeUndefined();
+  });
+});

--- a/src/meta/imdbId.ts
+++ b/src/meta/imdbId.ts
@@ -1,0 +1,35 @@
+// IMDb id validation, with no dependency on any particular metadata provider.
+//
+// This lives apart from cinemeta.ts because the torrent sources need it too: YTS, EZTV and The
+// Pirate Bay all carry an IMDb id on their rows, and validating it is their business whether or
+// not a metadata client ever runs. Keeping these two functions here means the lower sources/
+// layer never has to import the Cinemeta client to sanitise a field of its own payload.
+
+// An IMDb id is interpolated into a URL *path*, so it is attacker-controlled routing input the
+// moment it comes back from a remote catalog. Same class of rule as stripControl() in
+// util/format: validate the value you are about to hand to another system, not the value you
+// received. Anchored, digits only — "tt0133093/../../admin" and "tt0133093?x=1" both fail.
+const IMDB_ID = /^tt\d{7,10}$/;
+
+/**
+ * Accept a remote value as an IMDb id only if it still looks like one after cleaning. Returns
+ * undefined rather than throwing so callers can treat "no id" and "bad id" identically.
+ */
+export function normalizeImdbId(raw: unknown): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim().toLowerCase();
+  // Series episodes arrive as "tt0944947:5:14"; the series id is the part before the first colon.
+  const base = trimmed.split(":", 1)[0] ?? "";
+  return IMDB_ID.test(base) ? base : undefined;
+}
+
+/**
+ * Some sources (YTS, torrent indexes) carry the bare numeric IMDb id. Zero-pad to IMDb's minimum
+ * width of seven, then run the same result-side validation — a caller could hand us anything.
+ */
+export function imdbFromNumeric(raw: unknown): string | undefined {
+  const s = typeof raw === "number" ? String(raw) : typeof raw === "string" ? raw.trim() : "";
+  if (!/^\d+$/.test(s)) return undefined;
+  const candidate = `tt${s.padStart(7, "0")}`;
+  return IMDB_ID.test(candidate) ? candidate : undefined;
+}

--- a/src/meta/lookup.test.ts
+++ b/src/meta/lookup.test.ts
@@ -1,0 +1,379 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { isSearchableTitle, lookupMeta, metaCacheKey, metaKindFor, peekMeta } from "./lookup";
+import { fetchMeta, searchCatalog } from "./cinemeta";
+import type { CatalogHit, Meta } from "./types";
+import type { SourceId, TorrentResult } from "../sources/types";
+
+// The whole provider is mocked: no test here is allowed near a socket, and the point of these
+// tests is the orchestration around the provider, not the provider itself.
+vi.mock("./cinemeta", () => ({
+  searchCatalog: vi.fn(),
+  fetchMeta: vi.fn(),
+}));
+
+const mockSearch = vi.mocked(searchCatalog);
+const mockMeta = vi.mocked(fetchMeta);
+
+// The module-level cache has no reset hook — deliberately, mirroring sources/cache.ts — so every
+// test invents its own title and infoHash and nothing leaks between them.
+function row(over: Partial<TorrentResult> & { name: string; source?: SourceId }): TorrentResult {
+  return {
+    infoHash: over.name.toLowerCase().replace(/\W+/g, ""),
+    sizeBytes: 2.1e9,
+    seeders: 40,
+    leechers: 6,
+    source: "yts",
+    magnet: "magnet:?xt=urn:btih:deadbeef",
+    ...over,
+  };
+}
+
+function meta(imdbId: string, title: string): Meta {
+  return { imdbId, kind: "movie", title, genres: [], cast: [], director: [] };
+}
+
+function hit(imdbId: string, name: string, releaseInfo?: string): CatalogHit {
+  return { imdbId, name, kind: "movie", ...(releaseInfo !== undefined ? { releaseInfo } : {}) };
+}
+
+beforeEach(() => {
+  mockSearch.mockReset();
+  mockMeta.mockReset();
+  mockSearch.mockResolvedValue([]);
+  mockMeta.mockResolvedValue(null);
+});
+
+describe("isSearchableTitle", () => {
+  it("accepts titles that are legitimately two letters long", () => {
+    expect(isSearchableTitle("Up")).toBe(true);
+    expect(isSearchableTitle("It")).toBe(true);
+    expect(isSearchableTitle("Her")).toBe(true);
+  });
+
+  it("accepts an all-digit title", () => {
+    expect(isSearchableTitle("300")).toBe(true);
+    expect(isSearchableTitle("1917")).toBe(true);
+    expect(isSearchableTitle("2012")).toBe(true);
+  });
+
+  it("accepts accented and mixed-script titles on their Latin content", () => {
+    expect(isSearchableTitle("Amélie")).toBe(true);
+    expect(isSearchableTitle("Attack on Titan 進撃の巨人")).toBe(true);
+  });
+
+  it("rejects what a CJK-only fansub name parses down to", () => {
+    // Verbatim output of parseRelease("【喵萌奶茶屋】★07月新番★[花織同學][04][1080p][繁體]"):
+    // long, non-empty, and completely unsearchable. A length check waves it through.
+    expect(isSearchableTitle("★07月新番★[花織同學][04] [繁體]")).toBe(false);
+    expect(isSearchableTitle("【4月新番】【地。—关于地球的运动—】【01】")).toBe(false);
+  });
+
+  it("rejects a bare episode number and other non-Latin scripts", () => {
+    expect(isSearchableTitle("04")).toBe(false);
+    expect(isSearchableTitle("Брат")).toBe(false);
+    expect(isSearchableTitle("")).toBe(false);
+    expect(isSearchableTitle("   ")).toBe(false);
+  });
+});
+
+describe("metaKindFor", () => {
+  it("refuses a Games-only source outright", () => {
+    expect(metaKindFor(row({ name: "Ravenmoor Deluxe Edition", source: "fitgirl" }))).toBeNull();
+  });
+
+  it("lets a single-category source overrule the release name", () => {
+    // "S3" reads as a season marker to the parser, but YTS only ever publishes films.
+    expect(metaKindFor(row({ name: "Nightgale S3 2019 1080p", source: "yts" }))).toBe("movie");
+    expect(metaKindFor(row({ name: "Harbourlight 2019 1080p", source: "eztv" }))).toBe("series");
+    expect(metaKindFor(row({ name: "Ashfall 2021 1080p", source: "nyaa" }))).toBe("series");
+  });
+
+  it("falls back to the release name for a multi-category source", () => {
+    expect(metaKindFor(row({ name: "Coldwater 2018 1080p", source: "bittorrented" }))).toBe("movie");
+    expect(metaKindFor(row({ name: "Coldwater S02E04 1080p", source: "bittorrented" }))).toBe("series");
+  });
+
+  it("does not let the unknown-source fallback classify a row as a game", () => {
+    // getSource() answers DEFAULT_SOURCE (FitGirl, Games-only) for an id it does not know, which
+    // would turn every unrecognised source into "never query".
+    const unknown = row({ name: "Saltmarsh 2020 1080p", source: "not-a-source" as SourceId });
+    expect(metaKindFor(unknown)).toBe("movie");
+  });
+});
+
+describe("metaCacheKey", () => {
+  it("collapses one film's quality rows onto a single key", () => {
+    const a = row({ infoHash: "q1", name: "Tidewater (2018) [1080p BluRay]", imdbId: "tt3311111" });
+    const b = row({ infoHash: "q2", name: "Tidewater (2018) [2160p WEB]", imdbId: "tt3311111" });
+    expect(metaCacheKey(a)).toBe(metaCacheKey(b));
+  });
+
+  it("keeps two episodes of one series apart despite a shared series id", () => {
+    // EZTV publishes the series id on every episode row, so the id alone is not a unique key.
+    const e14 = row({ infoHash: "e14", name: "Foghorn S05E14 1080p", source: "eztv", imdbId: "tt3322222" });
+    const e15 = row({ infoHash: "e15", name: "Foghorn S05E15 1080p", source: "eztv", imdbId: "tt3322222" });
+    expect(metaCacheKey(e14)).not.toBe(metaCacheKey(e15));
+  });
+
+  it("collapses the same film arriving from different trackers", () => {
+    const tpb = row({ infoHash: "t1", name: "Saltbreak.2019.1080p.BluRay.x264-GRP", source: "tpb-movies" });
+    const x = row({ infoHash: "x1", name: "Saltbreak (2019) 1080p WEB-DL", source: "x1337-movies" });
+    expect(metaCacheKey(tpb)).toBe(metaCacheKey(x));
+  });
+
+  it("keeps a shared id apart when the two rows resolve to different kinds", () => {
+    // Same imdbId, but a movies feed and a TV feed disagree on what it is. They need different
+    // Cinemeta URLs (/meta/movie/... vs /meta/series/...), and Cinemeta's HTTP-200 stub for a
+    // wrong-type id would otherwise poison one feed's entry with the other's negative result.
+    const movie = row({
+      infoHash: "m1",
+      name: "Driftglass (2020) 1080p",
+      source: "tpb-movies",
+      imdbId: "tt3355555",
+    });
+    const series = row({
+      infoHash: "s1",
+      name: "Driftglass S01E01 1080p",
+      source: "tpb-tv",
+      imdbId: "tt3355555",
+    });
+    expect(metaKindFor(movie)).toBe("movie");
+    expect(metaKindFor(series)).toBe("series");
+    expect(metaCacheKey(movie)).not.toBe(metaCacheKey(series));
+  });
+});
+
+describe("lookupMeta", () => {
+  it("uses a source-provided id and never searches", async () => {
+    const found = meta("tt4400001", "Emberfall");
+    mockMeta.mockResolvedValue(found);
+
+    const r = row({ infoHash: "f1", name: "Emberfall (2021) [1080p BluRay]", imdbId: "tt4400001" });
+    await expect(lookupMeta(r)).resolves.toEqual(found);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockMeta).toHaveBeenCalledTimes(1);
+    expect(mockMeta).toHaveBeenCalledWith("movie", "tt4400001", expect.anything());
+  });
+
+  it("passes the episode coordinates through the id fast path", async () => {
+    mockMeta.mockResolvedValue(meta("tt4400002", "Nightpost"));
+    const r = row({ infoHash: "f2", name: "Nightpost S02E07 1080p", source: "eztv", imdbId: "tt4400002" });
+    await lookupMeta(r);
+    expect(mockMeta).toHaveBeenCalledWith(
+      "series",
+      "tt4400002",
+      expect.objectContaining({ season: 2, episode: 7 }),
+    );
+  });
+
+  it("fetches once for three quality rows of the same film", async () => {
+    mockMeta.mockResolvedValue(meta("tt4400003", "Glasshour"));
+    const rows = ["720p", "1080p", "2160p"].map((q, i) =>
+      row({ infoHash: `g${i}`, name: `Glasshour (2020) [${q} BluRay]`, imdbId: "tt4400003" }),
+    );
+
+    // Concurrently, so the in-flight map is what does the collapsing rather than the cache.
+    const settled = await Promise.all(rows.map((r) => lookupMeta(r)));
+
+    expect(mockMeta).toHaveBeenCalledTimes(1);
+    expect(settled.every((m) => m?.title === "Glasshour")).toBe(true);
+    // And once more after everything has settled, now served by the cache.
+    await lookupMeta(row({ infoHash: "g3", name: "Glasshour (2020) [480p BluRay]", imdbId: "tt4400003" }));
+    expect(mockMeta).toHaveBeenCalledTimes(1);
+  });
+
+  it("searches, matches and fetches when no id is supplied", async () => {
+    mockSearch.mockResolvedValue([hit("tt4400004", "Winterlark", "2017")]);
+    mockMeta.mockResolvedValue(meta("tt4400004", "Winterlark"));
+
+    const r = row({ infoHash: "s1", name: "Winterlark.2017.1080p.BluRay.x264-GRP", source: "tpb-movies" });
+    await expect(lookupMeta(r)).resolves.toEqual(meta("tt4400004", "Winterlark"));
+
+    expect(mockSearch).toHaveBeenCalledWith("movie", "Winterlark", expect.anything());
+    expect(mockMeta).toHaveBeenCalledWith("movie", "tt4400004", expect.anything());
+  });
+
+  it("negatively caches an unmatched row", async () => {
+    // The catalog answers with a different film, so pickBestHit abstains.
+    mockSearch.mockResolvedValue([hit("tt4400005", "Something Else Entirely", "1994")]);
+
+    const r = row({ infoHash: "n1", name: "Duskmarch.2016.1080p.WEB-DL", source: "tpb-movies" });
+    await expect(lookupMeta(r)).resolves.toBeNull();
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+
+    await expect(lookupMeta(r)).resolves.toBeNull();
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockMeta).not.toHaveBeenCalled();
+    // And the miss is visible synchronously, so the hook shows no spinner on a revisit.
+    expect(peekMeta(r)).toBeNull();
+  });
+
+  it("never touches the network for a games row", async () => {
+    const r = row({ infoHash: "fg1", name: "Ravenmoor Deluxe Edition v1.2", source: "fitgirl" });
+    await expect(lookupMeta(r)).resolves.toBeNull();
+    expect(peekMeta(r)).toBeNull();
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockMeta).not.toHaveBeenCalled();
+  });
+
+  it("never touches the network for a name with no searchable title", async () => {
+    const r = row({
+      infoHash: "cjk1",
+      name: "【喵萌奶茶屋】★07月新番★[花織同學][04][1080p][繁體]",
+      source: "nyaa",
+    });
+    await expect(lookupMeta(r)).resolves.toBeNull();
+    expect(peekMeta(r)).toBeNull();
+    expect(mockSearch).not.toHaveBeenCalled();
+  });
+
+  it("returns null on abort and leaves the cache untouched", async () => {
+    mockSearch.mockResolvedValue([hit("tt4400006", "Stormglass", "2015")]);
+    mockMeta.mockResolvedValue(meta("tt4400006", "Stormglass"));
+
+    const ctrl = new AbortController();
+    const r = row({ infoHash: "ab1", name: "Stormglass.2015.1080p.BluRay", source: "tpb-movies" });
+    const pending = lookupMeta(r, { signal: ctrl.signal });
+    ctrl.abort();
+    await expect(pending).resolves.toBeNull();
+
+    // Nothing was written, so the next visit is free to try again rather than being told "no
+    // metadata" for the rest of the TTL.
+    expect(peekMeta(r)).toBeUndefined();
+    await expect(lookupMeta(r)).resolves.toEqual(meta("tt4400006", "Stormglass"));
+    expect(peekMeta(r)).toEqual(meta("tt4400006", "Stormglass"));
+  });
+
+  it("survives a provider that rejects", async () => {
+    // The real searchCatalog never rejects — it swallows everything and returns []. This pins the
+    // belt-and-braces catch in lookupMeta: if that contract is ever broken, the render path still
+    // gets null rather than an unhandled rejection, and nothing is recorded for a failure that
+    // never produced an answer.
+    mockSearch.mockRejectedValue(new Error("boom"));
+    const r = row({ infoHash: "br1", name: "Ashenvale.2022.1080p.WEB-DL", source: "tpb-movies" });
+    await expect(lookupMeta(r)).resolves.toBeNull();
+    expect(peekMeta(r)).toBeUndefined();
+  });
+});
+
+describe("shared requests", () => {
+  it("keeps a request alive for the callers that still want it", async () => {
+    // The Task 5 shape: a detail view and a pane both mounted on one row, then the detail closes.
+    let settle: (m: Meta | null) => void = () => {};
+    mockMeta.mockReturnValue(
+      new Promise<Meta | null>((res) => {
+        settle = res;
+      }),
+    );
+    const found = meta("tt4400008", "Palewind");
+    const r = row({ infoHash: "sh1", name: "Palewind (2020) [1080p]", imdbId: "tt4400008" });
+
+    const leaving = new AbortController();
+    const staying = new AbortController();
+    const first = lookupMeta(r, { signal: leaving.signal });
+    const second = lookupMeta(r, { signal: staying.signal });
+
+    leaving.abort();
+    await expect(first).resolves.toBeNull();
+
+    // One caller walking away must not cancel the request, answer null for the other, or stop the
+    // answer reaching the cache — the joiner has no way to notice and retry.
+    settle(found);
+    await expect(second).resolves.toEqual(found);
+    expect(peekMeta(r)).toEqual(found);
+    expect(mockMeta).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the request once the last caller has gone", async () => {
+    mockMeta.mockReturnValue(new Promise<Meta | null>(() => {}));
+    const r = row({ infoHash: "sh2", name: "Duskvane (2020) [1080p]", imdbId: "tt4400009" });
+
+    const a = new AbortController();
+    const b = new AbortController();
+    const first = lookupMeta(r, { signal: a.signal });
+    const second = lookupMeta(r, { signal: b.signal });
+
+    a.abort();
+    b.abort();
+    await expect(Promise.all([first, second])).resolves.toEqual([null, null]);
+
+    const passed = mockMeta.mock.calls[0]?.[2]?.signal;
+    expect(passed?.aborted).toBe(true);
+  });
+
+  it("starts a fresh request rather than joining a cancelled one", async () => {
+    mockMeta.mockReturnValueOnce(new Promise<Meta | null>(() => {}));
+    const found = meta("tt4400010", "Marrowfen");
+    const r = row({ infoHash: "sh3", name: "Marrowfen (2020) [1080p]", imdbId: "tt4400010" });
+
+    const gone = new AbortController();
+    const abandoned = lookupMeta(r, { signal: gone.signal });
+    gone.abort();
+    await expect(abandoned).resolves.toBeNull();
+
+    // The dead flight is still in the map at this point; joining it would relay its null forever.
+    mockMeta.mockResolvedValue(found);
+    await expect(lookupMeta(r)).resolves.toEqual(found);
+    expect(mockMeta).toHaveBeenCalledTimes(2);
+  });
+
+  it("answers a caller that gave up before it asked, without touching the cache", async () => {
+    const found = meta("tt4400011", "Thornhollow");
+    mockMeta.mockResolvedValue(found);
+    const r = row({ infoHash: "sh4", name: "Thornhollow (2020) [1080p]", imdbId: "tt4400011" });
+    await lookupMeta(r);
+    expect(peekMeta(r)).toEqual(found);
+
+    // Even with the answer sitting in the cache, an abandoned caller is told nothing.
+    const dead = AbortSignal.abort();
+    await expect(lookupMeta(r, { signal: dead })).resolves.toBeNull();
+
+    const untouched = row({ infoHash: "sh5", name: "Ravenglass (2020) [1080p]", imdbId: "tt4400012" });
+    mockMeta.mockClear();
+    await expect(lookupMeta(untouched, { signal: dead })).resolves.toBeNull();
+    expect(mockMeta).not.toHaveBeenCalled();
+  });
+});
+
+describe("negative caching", () => {
+  it("forgets a miss long before it forgets a hit", async () => {
+    mockSearch.mockResolvedValue([]);
+    const missed = row({ infoHash: "tt1", name: "Fernmoor.2016.1080p.WEB-DL", source: "tpb-movies" });
+    const found = meta("tt4400013", "Larkspur");
+    mockMeta.mockResolvedValue(found);
+    const hitRow = row({ infoHash: "tt2", name: "Larkspur (2018) [1080p]", imdbId: "tt4400013" });
+
+    await lookupMeta(missed);
+    await lookupMeta(hitRow);
+    expect(peekMeta(missed)).toBeNull();
+    expect(peekMeta(hitRow)).toEqual(found);
+
+    // Five minutes on: a dead network at launch must not have killed metadata for the session, so
+    // the miss is retried while the answer we actually got is still good.
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 5 * 60 * 1000);
+    try {
+      expect(peekMeta(missed)).toBeUndefined();
+      expect(peekMeta(hitRow)).toEqual(found);
+
+      await lookupMeta(missed);
+      expect(mockSearch).toHaveBeenCalledTimes(2);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+});
+
+describe("peekMeta", () => {
+  it("reports an unresolved row as unknown, not as a miss", () => {
+    expect(peekMeta(row({ infoHash: "pk1", name: "Hollowmere (2019) 1080p" }))).toBeUndefined();
+  });
+
+  it("serves a resolved row synchronously", async () => {
+    const found = meta("tt4400007", "Brightwater");
+    mockMeta.mockResolvedValue(found);
+    const r = row({ infoHash: "pk2", name: "Brightwater (2018) [1080p]", imdbId: "tt4400007" });
+    await lookupMeta(r);
+    expect(peekMeta(r)).toEqual(found);
+  });
+});

--- a/src/meta/lookup.ts
+++ b/src/meta/lookup.ts
@@ -1,0 +1,305 @@
+import { SOURCES } from "../sources/registry";
+import { fetchMeta, searchCatalog } from "./cinemeta";
+import { normalizeTitle, pickBestHit } from "./match";
+import { parseRelease } from "./release";
+import type { ParsedRelease } from "./release";
+import type { SourceGroup, TorrentResult } from "../sources/types";
+import type { Meta, MetaKind } from "./types";
+
+// The orchestrator between a torrent row and Cinemeta: decide whether a row is worth a lookup at
+// all, turn it into a stable cache key, and make sure the same title is only ever fetched once.
+//
+// Shape is deliberately identical to sources/cache.ts — a module-level Map, a TTL constant, a key
+// helper, no eviction and no persistence. A process-lifetime map is right here for the same reason
+// it is right there: torlink is a short-lived terminal session, the working set is the handful of
+// rows the user actually scrolled past, and a Meta is a few hundred bytes.
+//
+// Everything fails soft. This is reached from a React render path, so a dead provider or a hostile
+// payload must degrade to "no metadata", never to an exception that unmounts the TUI.
+
+// Metadata is far more stable than a search result set (which uses 5 minutes): a film's plot and
+// poster do not change inside a session, so an answer we did get is worth keeping for most of one.
+const TTL_MS = 30 * 60 * 1000;
+
+// "No metadata" gets a much shorter life, because at this layer it is ambiguous. cinemeta.ts
+// collapses a dead network, a 502 and a title Cinemeta genuinely does not carry into the same
+// []/null, so a session started while DNS or a VPN is still settling would otherwise record a hard
+// "nothing here" for every row the user scrolled past and keep serving it for half an hour after
+// the network came back. Two minutes still absorbs the case this cache exists for — scrolling up
+// and down a result page takes seconds, and no row is re-queried during it — while capping a
+// transient outage at one stale pass instead of a dead session.
+const NEGATIVE_TTL_MS = 2 * 60 * 1000;
+
+// Matches cinemeta's own per-request budget. It exists here too because the lookup can chain two
+// requests (search, then meta) and the *pair* needs a ceiling, not just each half.
+const TIMEOUT_MS = 6000;
+
+interface Entry {
+  at: number;
+  meta: Meta | null;
+}
+
+const cache = new Map<string, Entry>();
+
+/**
+ * One request that more than one caller may be waiting on.
+ *
+ * The request owns its own AbortController rather than borrowing the first caller's signal, and
+ * `refs` counts the callers still interested. Only the last one to walk away cancels it: a caller
+ * losing interest is not the same event as a cancelled request, and conflating the two let one
+ * caller's abort hand every other caller a null they would then never retry.
+ */
+interface Flight {
+  readonly promise: Promise<Meta | null>;
+  readonly ctrl: AbortController;
+  /** The composite actually passed to the provider: `ctrl` plus the timeout. */
+  readonly signal: AbortSignal;
+  refs: number;
+}
+
+// A second map so a fast scroll that lands on the same title twice — four YTS quality rows of one
+// film, or a re-select after a re-sort — issues one request instead of one per landing.
+const inflight = new Map<string, Flight>();
+
+// Cinemeta is keyed by IMDb primary titles, which are Latin script. A release name that reduces to
+// CJK, Cyrillic or a bare episode number carries nothing to search with, so querying it spends a
+// request per row for a guaranteed miss. Nyaa's Chinese fansub names hit this on every single row:
+// "【喵萌奶茶屋】★07月新番★[花織同學][04][1080p][繁體]" parses to a long, non-empty, entirely
+// unsearchable title, which a plain length check waves straight through.
+//
+// Two Latin letters is the floor because real titles do get that short ("Up", "It", "Her"). The
+// all-digit escape hatch keeps "300", "1917" and "2012" queryable while still rejecting the bare
+// "04" that a fully-bracketed fansub name leaves behind. Mixed titles pass on their Latin half,
+// which is the right call: "Attack on Titan 進撃の巨人" is searchable.
+const LATIN_LETTER = /\p{Script=Latin}/gu;
+const ALL_DIGITS = /^\d{3,4}$/;
+
+export function isSearchableTitle(title: string): boolean {
+  if (typeof title !== "string") return false;
+  const t = title.trim();
+  if (t === "") return false;
+  if (ALL_DIGITS.test(t)) return true;
+  return (t.match(LATIN_LETTER) ?? []).length >= 2;
+}
+
+function groupsFor(id: TorrentResult["source"]): readonly SourceGroup[] | undefined {
+  // Deliberately not getSource(): it falls back to DEFAULT_SOURCE for an unknown id, and that
+  // default is FitGirl — Games-only — so a source id we do not recognise would silently classify
+  // as "never query" instead of falling through to the release name.
+  return SOURCES.find((s) => s.id === id)?.groups;
+}
+
+/**
+ * The source's own category, when it is unambiguous enough to overrule the release name. A YTS row
+ * is a film even when its name carries something the parser reads as a season marker, and a
+ * FitGirl row is a game no matter what the repack is called — which is what keeps games entirely
+ * off the network. Anime is best-effort "series"; Cinemeta files most of it there.
+ *
+ * `every` rather than an index read: it states "only this group" directly and needs no length
+ * check to satisfy noUncheckedIndexedAccess. Hence the emptiness guard, since every([]) is true.
+ */
+function kindFromGroups(groups: readonly SourceGroup[] | undefined, fallback: MetaKind): MetaKind | null {
+  // No groups, or a source that feeds several (BitTorrented is Movies + TV): the name is all the
+  // evidence there is.
+  if (groups === undefined || groups.length === 0) return fallback;
+  if (groups.every((g) => g === "Games")) return null;
+  if (groups.every((g) => g === "Movies")) return "movie";
+  if (groups.every((g) => g === "TV" || g === "Anime")) return "series";
+  return fallback;
+}
+
+/** Which Cinemeta catalog a row belongs in, or null when it must never be queried. */
+export function metaKindFor(r: TorrentResult): MetaKind | null {
+  return plan(r).kind;
+}
+
+interface Plan {
+  readonly kind: MetaKind | null;
+  readonly parsed: ParsedRelease;
+  readonly key: string;
+}
+
+/**
+ * Everything derivable from a row without touching the network, computed once. parseRelease is
+ * pure and cheap but not free, and metaKindFor, metaCacheKey and lookupMeta all want its output.
+ */
+function plan(r: TorrentResult): Plan {
+  const parsed = parseRelease(r.name);
+  const kind = kindFromGroups(groupsFor(r.source), parsed.kind);
+  return { kind, parsed, key: cacheKey(r, kind ?? parsed.kind, parsed) };
+}
+
+/**
+ * The key two rows share when they would produce the same metadata.
+ *
+ * With an id it is the id plus the episode coordinates, because Cinemeta answers a series id with
+ * the whole show and we narrow it to one episode: EZTV hands us the *series* id on every row, so
+ * without the coordinates S05E14 and S05E15 would collide on one entry and the second row would be
+ * served the first one's episode title. Movies carry no coordinates, so YTS's four quality rows of
+ * one film still collapse onto a single entry. `kind` is in the key too: the same IMDb id can arrive
+ * from both a movies feed and a TV feed misclassifying it, and those need different Cinemeta URLs
+ * (`/meta/movie/…` vs `/meta/series/…`). Cinemeta answers HTTP 200 with the "unknown id" stub for a
+ * wrong-type lookup rather than 404ing, so without `kind` here one feed's stub would poison the
+ * other's entry for the whole negative TTL.
+ *
+ * Without an id it is the normalized title plus everything that could distinguish two works with
+ * it, which is what collapses the same film arriving from TPB, 1337x and BitTorrented.
+ */
+function cacheKey(r: TorrentResult, kind: MetaKind, parsed: ParsedRelease): string {
+  const season = parsed.season ?? "";
+  const episode = parsed.episode ?? "";
+  if (r.imdbId !== undefined) return `imdb:${kind}:${r.imdbId}:${season}:${episode}`;
+  return `guess:${kind}:${normalizeTitle(parsed.title)}:${parsed.year ?? ""}:${season}:${episode}`;
+}
+
+export function metaCacheKey(r: TorrentResult): string {
+  return plan(r).key;
+}
+
+function read(key: string): Meta | null | undefined {
+  const hit = cache.get(key);
+  if (hit === undefined) return undefined;
+  // A miss is far less trustworthy than a hit, so it is remembered for far less time.
+  const ttl = hit.meta === null ? NEGATIVE_TTL_MS : TTL_MS;
+  return Date.now() - hit.at < ttl ? hit.meta : undefined;
+}
+
+/**
+ * Synchronous cache read: `undefined` means "not known yet, ask the network", `null` means "there
+ * is no metadata for this row" and a Meta is the answer. The hook calls this first so revisiting a
+ * row it already resolved renders instantly instead of flashing a spinner.
+ *
+ * A row that can never be queried — a game, or a name with no searchable title — answers null
+ * rather than undefined: the answer is already final, and making the caller wait on a request that
+ * will not happen would show that same spinner forever.
+ */
+export function peekMeta(r: TorrentResult): Meta | null | undefined {
+  const p = plan(r);
+  if (p.kind === null) return null;
+  if (r.imdbId === undefined && !isSearchableTitle(p.parsed.title)) return null;
+  return read(p.key);
+}
+
+/**
+ * Commit a result, unless the request that produced it was cancelled.
+ *
+ * This guard is load-bearing. searchCatalog and fetchMeta return []/null for an aborted request
+ * exactly as they do for a dead provider, so an abort is indistinguishable from a genuine miss at
+ * this point — and caching it would pin "no metadata" on the row for the full TTL just because the
+ * user scrolled past it before the answer arrived.
+ */
+function commit(key: string, meta: Meta | null, signal: AbortSignal): Meta | null {
+  if (signal.aborted) return null;
+  cache.set(key, { at: Date.now(), meta });
+  return meta;
+}
+
+async function resolve(r: TorrentResult, p: Plan, kind: MetaKind, signal: AbortSignal): Promise<Meta | null> {
+  // Only meaningful for a series, and fetchMeta wants both halves or neither.
+  const episodeOpts =
+    kind === "series" && p.parsed.season !== undefined && p.parsed.episode !== undefined
+      ? { season: p.parsed.season, episode: p.parsed.episode }
+      : {};
+
+  // Fast path: the source already told us what this is, so skip the guessing round trip entirely.
+  if (r.imdbId !== undefined) {
+    return commit(p.key, await fetchMeta(kind, r.imdbId, { signal, ...episodeOpts }), signal);
+  }
+
+  const hits = await searchCatalog(kind, p.parsed.title, { signal });
+  const best = pickBestHit(p.parsed, hits);
+  // A confident abstention is worth remembering: scrolling repeatedly past an unmatched row should
+  // cost nothing after the first pass.
+  if (best === null) return commit(p.key, null, signal);
+  return commit(p.key, await fetchMeta(kind, best.imdbId, { signal, ...episodeOpts }), signal);
+}
+
+/** Begin a request nobody is waiting on yet, and register it so the next caller can join it. */
+function start(r: TorrentResult, p: Plan, kind: MetaKind): Flight {
+  const ctrl = new AbortController();
+  // The request's own deadline plus its own cancel handle. No caller signal is folded in here:
+  // cancellation is driven by the refcount below, so the request outlives any single caller.
+  const signal = AbortSignal.any([ctrl.signal, AbortSignal.timeout(TIMEOUT_MS)]);
+  const flight: Flight = {
+    ctrl,
+    signal,
+    refs: 0,
+    // resolve() only calls functions that already swallow their own failures, but this is a render
+    // path: one unforeseen throw here would surface as an unhandled rejection in the TUI.
+    promise: resolve(r, p, kind, signal).catch((): Meta | null => null),
+  };
+  inflight.set(p.key, flight);
+  // Retire the entry once it settles — but only if it is still the current one, so a replacement
+  // started after a cancellation is never evicted by its predecessor.
+  void flight.promise.finally(() => {
+    if (inflight.get(p.key) === flight) inflight.delete(p.key);
+  });
+  return flight;
+}
+
+/**
+ * Wait on a shared request as one of possibly several callers.
+ *
+ * A caller gets its own answer the moment its own signal aborts, without disturbing anyone else's.
+ * The request itself is only cancelled when the count of interested callers reaches zero, which is
+ * what keeps the two `useResultMeta` instances Task 5 mounts on one row from poisoning each other:
+ * closing the detail view must not tell the still-open pane there is no metadata.
+ */
+async function join(flight: Flight, signal: AbortSignal | undefined): Promise<Meta | null> {
+  flight.refs += 1;
+  // Detaches the abort listener below; a caller's signal can easily outlive this join.
+  const detach = new AbortController();
+  let released = false;
+  const release = (): void => {
+    if (released) return;
+    released = true;
+    detach.abort();
+    flight.refs -= 1;
+    if (flight.refs <= 0) flight.ctrl.abort();
+  };
+
+  try {
+    if (signal === undefined) return await flight.promise;
+    const cancelled = new Promise<null>((settle) => {
+      // Released from inside the listener rather than from the finally below, so the last caller's
+      // abort reaches the provider synchronously — before any in-flight answer can be committed.
+      signal.addEventListener(
+        "abort",
+        () => {
+          release();
+          settle(null);
+        },
+        { once: true, signal: detach.signal },
+      );
+    });
+    return await Promise.race([flight.promise, cancelled]);
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Metadata for one row, or null when there is none to be had. Never throws and never rejects.
+ */
+export async function lookupMeta(
+  r: TorrentResult,
+  opts: { signal?: AbortSignal } = {},
+): Promise<Meta | null> {
+  const p = plan(r);
+  const kind = p.kind;
+  if (kind === null) return null;
+  if (r.imdbId === undefined && !isSearchableTitle(p.parsed.title)) return null;
+  // A caller that has already given up gets nothing and starts nothing — including on the cache
+  // path, where answering an abandoned request would be pointless work either way.
+  if (opts.signal?.aborted === true) return null;
+
+  const cached = read(p.key);
+  if (cached !== undefined) return cached;
+
+  const existing = inflight.get(p.key);
+  // A flight whose own signal has already fired — the last caller left, or the deadline passed —
+  // will never commit anything, so joining it would just relay its null. Start over instead.
+  const flight =
+    existing !== undefined && !existing.signal.aborted ? existing : start(r, p, kind);
+  return join(flight, opts.signal);
+}

--- a/src/meta/match.test.ts
+++ b/src/meta/match.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { normalizeTitle, pickBestHit, scoreHit } from "./match";
+import { parseRelease, type ParsedRelease } from "./release";
+import type { CatalogHit } from "./types";
+
+const hit = (name: string, releaseInfo?: string, imdbId = "tt0000001"): CatalogHit => ({
+  imdbId,
+  name,
+  kind: "movie",
+  ...(releaseInfo !== undefined ? { releaseInfo } : {}),
+});
+
+const release = (title: string, year?: number): ParsedRelease => ({
+  title,
+  kind: "movie",
+  ...(year !== undefined ? { year } : {}),
+});
+
+const MATRIX = hit("The Matrix", "1999", "tt0133093");
+const RESURRECTIONS = hit("The Matrix Resurrections", "2021", "tt10838180");
+const RELOADED = hit("The Matrix Reloaded", "2003", "tt0234215");
+
+describe("normalizeTitle", () => {
+  it("lowercases, drops punctuation and collapses whitespace", () => {
+    expect(normalizeTitle("The Lord of the Rings: The Two Towers")).toBe("lord of rings two towers");
+    expect(normalizeTitle("Spider-Man   -  No Way Home!")).toBe("spider man no way home");
+    expect(normalizeTitle("WALL·E")).toBe("wall e");
+  });
+
+  it("folds accents so a catalog spelling and a scene spelling meet", () => {
+    expect(normalizeTitle("Amélie")).toBe(normalizeTitle("Amelie"));
+    expect(normalizeTitle("Léon: The Professional")).toBe("leon professional");
+  });
+
+  it("drops articles wherever they appear, since providers disagree about them", () => {
+    expect(normalizeTitle("The Office")).toBe("office");
+    expect(normalizeTitle("Office, The")).toBe("office");
+    expect(normalizeTitle("A Quiet Place")).toBe("quiet place");
+  });
+
+  it("keeps digits, which are often the whole title", () => {
+    expect(normalizeTitle("2012")).toBe("2012");
+    expect(normalizeTitle("Blade Runner 2049")).toBe("blade runner 2049");
+  });
+
+  it("returns an empty string for input with nothing to compare", () => {
+    expect(normalizeTitle("")).toBe("");
+    expect(normalizeTitle("---")).toBe("");
+    expect(normalizeTitle("The")).toBe("");
+  });
+});
+
+describe("scoreHit", () => {
+  it("scores an exact title with an agreeing year highest", () => {
+    // exact 100 + prefix 60 + tokens 30 + year 40
+    expect(scoreHit(release("The Matrix", 1999), MATRIX)).toBe(230);
+  });
+
+  it("allows a year to be one out, because catalogs and releases date films differently", () => {
+    expect(scoreHit(release("The Matrix", 2000), MATRIX)).toBe(230);
+    expect(scoreHit(release("The Matrix", 1998), MATRIX)).toBe(230);
+  });
+
+  it("penalises a contradicted year", () => {
+    // exact 100 + prefix 60 + tokens 30 − year 40
+    expect(scoreHit(release("The Matrix", 1997), MATRIX)).toBe(150);
+  });
+
+  it("scores a prefix match without an exact match", () => {
+    // prefix 60 + tokens 30, no year on either side
+    expect(scoreHit(release("The Matrix"), RESURRECTIONS)).toBe(90);
+  });
+
+  it("does not treat a longer word as a prefix match", () => {
+    expect(scoreHit(release("Matrix"), hit("Matrixxx"))).toBe(0);
+  });
+
+  it("scores token containment when word order or padding differs", () => {
+    // tokens 30 only: "the professional" is not a prefix of "leon professional"
+    expect(scoreHit(release("The Professional"), hit("Léon: The Professional"))).toBe(30);
+  });
+
+  it("scores nothing when either side normalizes away", () => {
+    expect(scoreHit(release(""), MATRIX)).toBe(0);
+    expect(scoreHit(release("The Matrix"), hit(""))).toBe(0);
+  });
+
+  it("ignores a year the hit does not carry", () => {
+    expect(scoreHit(release("The Matrix", 1999), hit("The Matrix"))).toBe(190);
+  });
+
+  it("reads the leading year of a series release span", () => {
+    const bb = { imdbId: "tt0903747", name: "Breaking Bad", releaseInfo: "2008–2013", kind: "series" } as const;
+    const parsed: ParsedRelease = { title: "Breaking Bad", kind: "series", year: 2008, season: 5, episode: 14 };
+    expect(scoreHit(parsed, bb)).toBe(230);
+    // The span's later years are not the leading year, so they contradict.
+    expect(scoreHit({ ...parsed, year: 2013 }, bb)).toBe(150);
+    expect(scoreHit({ ...parsed, year: 2008 }, { ...bb, releaseInfo: "2016–" })).toBe(150);
+  });
+});
+
+describe("pickBestHit", () => {
+  it("uses the year to separate a film from its sequels", () => {
+    expect(pickBestHit(release("The Matrix", 1999), [RESURRECTIONS, RELOADED, MATRIX])?.imdbId).toBe(
+      "tt0133093",
+    );
+    expect(pickBestHit(release("The Matrix Resurrections", 2021), [MATRIX, RESURRECTIONS])?.imdbId).toBe(
+      "tt10838180",
+    );
+  });
+
+  it("lets an exact title outrank a sequel whose year happens to agree", () => {
+    // "The Matrix" + 2021 is 150 on the original (exact, wrong year) against 130 on Resurrections
+    // (prefix, right year). The title is the stronger claim: a release that meant the sequel would
+    // have carried the sequel's name.
+    expect(pickBestHit(release("The Matrix", 2021), [MATRIX, RESURRECTIONS])?.imdbId).toBe("tt0133093");
+  });
+
+  it("prefers the exact title when no year is available at all", () => {
+    expect(pickBestHit(release("The Matrix"), [RESURRECTIONS, MATRIX])?.imdbId).toBe("tt0133093");
+  });
+
+  it("returns null for an empty hit list", () => {
+    expect(pickBestHit(release("The Matrix", 1999), [])).toBeNull();
+  });
+
+  it("returns null for a plausible-but-wrong title rather than showing the wrong poster", () => {
+    // prefix 60 + tokens 30 − year 40 = 50, just under the threshold: the year says this is a
+    // different film, and a wrong poster is worse than no poster.
+    expect(scoreHit(release("The Matrix", 1999), RESURRECTIONS)).toBe(50);
+    expect(pickBestHit(release("The Matrix", 1999), [RESURRECTIONS])).toBeNull();
+  });
+
+  it("returns null when nothing shares enough words", () => {
+    expect(pickBestHit(release("Arrival", 2016), [hit("Arrested Development", "2003")])).toBeNull();
+    expect(pickBestHit(release("Dune", 2021), [hit("Dune: Part Two", "2024")])).toBeNull();
+  });
+
+  it("accepts a hit that clears the threshold exactly", () => {
+    // tokens 30 + year 40 = 70; token containment plus an agreeing year is enough on its own.
+    expect(scoreHit(release("The Professional", 1994), hit("Léon: The Professional", "1994"))).toBe(70);
+    expect(pickBestHit(release("The Professional", 1994), [hit("Léon: The Professional", "1994")])).not.toBeNull();
+  });
+
+  it("rejects a hit one point short of the threshold", () => {
+    // A bare prefix match with no other evidence is 60 and is kept; take the tokens away and the
+    // same hit falls to 0. There is no partial credit between them by design.
+    expect(scoreHit(release("The Matrix"), RELOADED)).toBe(90);
+    expect(scoreHit(release("Matrix Revolutions"), RELOADED)).toBe(0);
+    expect(pickBestHit(release("Matrix Revolutions"), [RELOADED])).toBeNull();
+  });
+
+  it("keeps the earlier hit when two score the same", () => {
+    const a = hit("The Matrix", "1999", "tt0133093");
+    const b = hit("The Matrix", "1999", "tt9999999");
+    expect(pickBestHit(release("The Matrix", 1999), [a, b])?.imdbId).toBe("tt0133093");
+  });
+
+  it("matches a real release name end to end", () => {
+    const parsed = parseRelease("The.Matrix.1999.1080p.BluRay.x264-GROUP");
+    expect(pickBestHit(parsed, [RESURRECTIONS, MATRIX, RELOADED])?.imdbId).toBe("tt0133093");
+  });
+
+  it("declines a release name that parsed to junk", () => {
+    const parsed = parseRelease("1080p x264");
+    expect(pickBestHit(parsed, [MATRIX])).toBeNull();
+  });
+});

--- a/src/meta/match.ts
+++ b/src/meta/match.ts
@@ -1,0 +1,100 @@
+import type { ParsedRelease } from "./release";
+import type { CatalogHit } from "./types";
+
+// A provider's search endpoint answers a fuzzy query with a ranked-by-popularity list, and
+// popularity is not relevance: querying "The Matrix" returns the sequels and the documentaries
+// too. This module decides which hit — if any — the release name actually meant.
+//
+// The bias is deliberate and one-sided: showing the wrong film's poster and plot next to a
+// torrent is worse than showing nothing, because the user cannot tell it is wrong. Every rule
+// here is therefore built to abstain rather than guess.
+
+// Articles carry no identity and providers disagree about them ("The Office" vs "Office, The"),
+// so they are dropped rather than compared.
+const ARTICLES: ReadonlySet<string> = new Set(["the", "a", "an"]);
+
+// Below this, we show nothing. This is the single quality knob in the feature: the point scale
+// below is arranged so that a title-prefix match with a contradicted year (60 + 30 − 40 = 50)
+// lands under it, while the same prefix match with no year claim at all (60 + 30) clears it.
+const THRESHOLD = 60;
+
+const EXACT_TITLE = 100;
+const PREFIX_TITLE = 60;
+const ALL_TOKENS = 30;
+const YEAR_AGREES = 40;
+const YEAR_CONTRADICTS = -40;
+
+// A release name and a catalog name for the same work differ in punctuation, case and accents far
+// more often than in words. Fold all three away so the comparison is about the words.
+const DIACRITICS = /[\u0300-\u036f]/g;
+const NON_ALPHANUMERIC = /[^\p{L}\p{N}]+/gu;
+
+export function normalizeTitle(s: string): string {
+  if (typeof s !== "string") return "";
+  const folded = s.toLowerCase().normalize("NFKD").replace(DIACRITICS, "");
+  return folded
+    .replace(NON_ALPHANUMERIC, " ")
+    .split(" ")
+    .filter((t) => t !== "" && !ARTICLES.has(t))
+    .join(" ");
+}
+
+/**
+ * The first four-digit run of `releaseInfo`. A movie sends "1999"; a series sends a span,
+ * "2008–2013" or open-ended "2016–", and its first year is the one a release name would carry.
+ */
+function leadingYear(releaseInfo: string | undefined): number | undefined {
+  if (releaseInfo === undefined) return undefined;
+  const m = releaseInfo.match(/\d{4}/);
+  if (m === null) return undefined;
+  const n = Number.parseInt(m[0], 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Additive score for one candidate. Higher is a better match; the caller decides what is good
+ * enough. Total by construction — an unparseable title scores 0, it does not throw.
+ */
+export function scoreHit(parsed: ParsedRelease, hit: CatalogHit): number {
+  const want = normalizeTitle(parsed.title);
+  const got = normalizeTitle(hit.name);
+  if (want === "" || got === "") return 0;
+
+  let score = 0;
+  if (want === got) score += EXACT_TITLE;
+  // Prefix on a word boundary, not on characters: "matrix" must not claim "matrixxx", but it
+  // should still recognise "matrix reloaded" as a near miss worth scoring.
+  if (got === want || got.startsWith(`${want} `)) score += PREFIX_TITLE;
+
+  const gotTokens = new Set(got.split(" "));
+  const wantTokens = want.split(" ");
+  // Rewards a reordered or padded title ("Léon: The Professional" vs "The Professional") that the
+  // prefix rule cannot see.
+  if (wantTokens.every((t) => gotTokens.has(t))) score += ALL_TOKENS;
+
+  const hitYear = leadingYear(hit.releaseInfo);
+  if (parsed.year !== undefined && hitYear !== undefined) {
+    // ±1 because release names disagree with catalogs about festival, limited and regional
+    // release dates all the time. A wider window would stop separating a film from its remake.
+    score += Math.abs(parsed.year - hitYear) <= 1 ? YEAR_AGREES : YEAR_CONTRADICTS;
+  }
+
+  return score;
+}
+
+/**
+ * The best-scoring hit, or null when nothing is convincing enough. Ties keep the earlier hit:
+ * providers return their list popularity-first, which is the right tiebreak for equal evidence.
+ */
+export function pickBestHit(parsed: ParsedRelease, hits: readonly CatalogHit[]): CatalogHit | null {
+  let best: CatalogHit | null = null;
+  let bestScore = 0;
+  for (const hit of hits) {
+    const score = scoreHit(parsed, hit);
+    if (score > bestScore) {
+      bestScore = score;
+      best = hit;
+    }
+  }
+  return bestScore >= THRESHOLD ? best : null;
+}

--- a/src/meta/release.test.ts
+++ b/src/meta/release.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRelease,
+  normalizeSeparators,
+  findEpisodeMarker,
+  findYear,
+  firstJunkIndex,
+} from "./release";
+import type { ParsedRelease } from "./release";
+
+type Row = readonly [name: string, expected: Partial<ParsedRelease>];
+
+// Every row below the first three is a real name sampled from a live source adapter.
+const TABLE: readonly Row[] = [
+  [
+    "The.Matrix.1999.1080p.BluRay.x264-GROUP",
+    { title: "The Matrix", year: 1999, kind: "movie", group: "GROUP" },
+  ],
+  ["Show.S01E05.720p.WEB", { title: "Show", season: 1, episode: 5, kind: "series" }],
+  [
+    "[SubsPlease] Show - 01 (1080p) [ABCD1234].mkv",
+    { title: "Show", episode: 1, kind: "series", group: "SubsPlease" },
+  ],
+  ["The.Odyssey.2026.1080p.TELESYNC.HEVC.AAC2.0-SPLiCE", { title: "The Odyssey", year: 2026 }],
+  ["Disclosure Day (2026) [1080p] [WEBRip] [5.1]", { title: "Disclosure Day", year: 2026 }],
+  [
+    "Marvel Studios Iron Man 2008 1080p MA WEB-DL DDP5 1 H 264-SARVO",
+    { title: "Marvel Studios Iron Man", year: 2008 },
+  ],
+  [
+    "Rick and Morty S09E10 Field of Dreams 1080p AMZN WEB-DL DDP5 1 H 264-FLUX",
+    { title: "Rick and Morty", season: 9, episode: 10 },
+  ],
+  [
+    "House of the Dragon S03E07 1080p WEB H264-CAKES",
+    { title: "House of the Dragon", season: 3, episode: 7 },
+  ],
+  [
+    "Spider-Man: Brand New Day 2026.1080p.HQ Pre.Multi.AAC 2.0.x264",
+    { title: "Spider-Man: Brand New Day", year: 2026 },
+  ],
+  [
+    "Avatar.The.Legend.of.Aang.The.Last.Airbender.2026.1080p.PMNTP.WEBRip.AAC2.0.H264-[LEAK].mp4",
+    { title: "Avatar The Legend of Aang The Last Airbender", year: 2026 },
+  ],
+  ["Oppenheimer (2023) [1080p bluray]", { title: "Oppenheimer", year: 2023 }],
+  ["Breaking Bad S05E14 1080p WEB-DL", { title: "Breaking Bad", season: 5, episode: 14 }],
+  ["Frieren - 28 [1080p]", { title: "Frieren", episode: 28, kind: "series" }],
+  [
+    "Tensei Shitara Slime Datta Ken S4 - 17 [1080p]",
+    { title: "Tensei Shitara Slime Datta Ken", season: 4, episode: 17 },
+  ],
+  ["Hell Mode S2 - 06v2 [1080p]", { title: "Hell Mode", season: 2, episode: 6 }],
+  [
+    "[Erai-raws] Jujutsu Kaisen S2 - 23 [1080p]",
+    { title: "Jujutsu Kaisen", season: 2, episode: 23, group: "Erai-raws" },
+  ],
+  ["[WZF]Bleach_-_100[X264-AAC][784x576][Sub_Esp][MP4]", { title: "Bleach", episode: 100 }],
+  [
+    "Zillow Gone Wild S03E14 Enchanted Forest 480p WEB-DL x264-RMTeam EZTV",
+    { title: "Zillow Gone Wild", season: 3, episode: 14 },
+  ],
+  [
+    "Elden Ring: Shadow of the Erdtree Edition",
+    { title: "Elden Ring: Shadow of the Erdtree Edition", kind: "movie" },
+  ],
+];
+
+describe("parseRelease", () => {
+  for (const [name, expected] of TABLE) {
+    it(`parses ${name}`, () => {
+      expect(parseRelease(name)).toMatchObject(expected);
+    });
+  }
+
+  // A bare hyphenated title has the same shape as a scene "-GROUP" suffix. Trackers really do
+  // post names this minimal, and mistaking "Man" for a group would send "Spider" to the lookup.
+  // ("Mad-Max" is deliberately not in this list: "max" is source vocabulary, so it would pass on
+  // the junk guard alone and prove nothing about the corroboration rule.)
+  for (const bare of ["Spider-Man", "Ant-Man", "X-Men", "Kill-Bill"]) {
+    it(`keeps the hyphenated title ${bare} intact and extracts no group`, () => {
+      const parsed = parseRelease(bare);
+      expect(parsed.title).toBe(bare);
+      expect(parsed.group).toBeUndefined();
+    });
+  }
+
+  it("still takes a trailing group when scene context corroborates it", () => {
+    expect(parseRelease("Ant-Man.2015.1080p.BluRay.x264-GROUP")).toMatchObject({
+      title: "Ant-Man",
+      year: 2015,
+      group: "GROUP",
+    });
+  });
+
+  it("survives full-width brackets and CJK without throwing", () => {
+    const parsed = parseRelease("【喵萌奶茶屋】★07月新番★[花織同學][04][1080p][繁體]");
+    expect(typeof parsed.title).toBe("string");
+  });
+
+  it("parses a bare parenthesised year", () => {
+    expect(parseRelease("Old School (2003)")).toMatchObject({ title: "Old School", year: 2003 });
+  });
+
+  for (const degenerate of ["", ".", "[]", "2012"]) {
+    it(`returns a string title for the degenerate input ${JSON.stringify(degenerate)}`, () => {
+      const parsed = parseRelease(degenerate);
+      expect(typeof parsed.title).toBe("string");
+      expect(parsed.title === "" || degenerate.includes(parsed.title)).toBe(true);
+    });
+  }
+
+  it("never throws and always yields a string title over a junk corpus", () => {
+    const alphabet = ["", ".", "-", "_", "[", "]", "(", ")", "S01E01", "1080p", "2020", "x", "喵"];
+    for (let i = 0; i < 3000; i++) {
+      let name = "";
+      // Deterministic pseudo-random walk: a seeded corpus keeps failures reproducible.
+      let seed = i * 2654435761;
+      for (let j = 0; j < 8; j++) {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+        name += alphabet[seed % alphabet.length];
+      }
+      const parsed = parseRelease(name);
+      expect(typeof parsed.title).toBe("string");
+      expect(parsed.kind === "movie" || parsed.kind === "series").toBe(true);
+    }
+  });
+});
+
+describe("normalizeSeparators", () => {
+  it("always turns underscores into spaces", () => {
+    expect(normalizeSeparators("Some_Show_Name")).toBe("Some Show Name");
+  });
+
+  it("turns dots into spaces when dots outnumber spaces", () => {
+    expect(normalizeSeparators("The.Matrix.1999.1080p")).toBe("The Matrix 1999 1080p");
+  });
+
+  it("keeps dots when spaces already dominate, so decimals survive", () => {
+    expect(normalizeSeparators("Some Long Show Name AAC 2.0")).toBe("Some Long Show Name AAC 2.0");
+  });
+});
+
+describe("findEpisodeMarker", () => {
+  it("finds SxxExx", () => {
+    expect(findEpisodeMarker("Breaking Bad S05E14 1080p")).toMatchObject({ season: 5, episode: 14 });
+  });
+
+  it("finds the 1x02 form", () => {
+    expect(findEpisodeMarker("Some Show 3x07 720p")).toMatchObject({ season: 3, episode: 7 });
+  });
+
+  it("finds a bare season", () => {
+    expect(findEpisodeMarker("Hell Mode S2")).toMatchObject({ season: 2 });
+  });
+
+  it("returns null when there is no marker at all", () => {
+    expect(findEpisodeMarker("The Matrix 1999 1080p BluRay")).toBeNull();
+  });
+});
+
+describe("findYear", () => {
+  it("prefers a parenthesised year", () => {
+    expect(findYear("Old School (2003)")).toMatchObject({ year: 2003 });
+  });
+
+  it("takes a standalone year followed by junk", () => {
+    expect(findYear("The Matrix 1999 1080p BluRay")).toMatchObject({ year: 1999 });
+  });
+
+  it("refuses a year that is the only remaining token", () => {
+    expect(findYear("2012")).toBeNull();
+  });
+});
+
+describe("firstJunkIndex", () => {
+  it("reports the first junk token position", () => {
+    expect(firstJunkIndex(["The", "Matrix", "1080p", "BluRay"])).toBe(2);
+  });
+
+  it("reports -1 when nothing is junk", () => {
+    expect(firstJunkIndex(["Elden", "Ring"])).toBe(-1);
+  });
+});

--- a/src/meta/release.ts
+++ b/src/meta/release.ts
@@ -1,0 +1,296 @@
+// Release names are the only metadata a tracker reliably gives us, and every scene/fansub group
+// spells them differently. This module reduces one to a searchable title plus whatever season,
+// episode and year fell out on the way. It is deliberately import-free and total: it runs on
+// every visible row during a search, so it must never throw and never reach the network.
+// Sanitizing the result for a terminal is the caller's job at the render boundary.
+
+export type ReleaseKind = "movie" | "series";
+
+export interface ParsedRelease {
+  readonly title: string;
+  readonly kind: ReleaseKind;
+  readonly year?: number;
+  readonly season?: number;
+  readonly episode?: number;
+  /** Release group / fansub tag. Informational only — never part of the search title. */
+  readonly group?: string;
+}
+
+const CONTAINER_EXT = /\.(mkv|mp4|avi|ts|m2ts|iso|rar|mov|webm)$/i;
+
+// A leading tag is a group; every other bracket is a candidate for removal. Full-width brackets
+// are here because nyaa carries Chinese fansub names that use them.
+const BRACKET_ANY = /[[(【]([^[\])】]*)[\])】]/g;
+const BRACKET_LEADING = /^\s*[[(【]([^[\])】]*)[\])】]/;
+
+const YEAR_ONLY = /^(19\d{2}|20\d{2})$/;
+const YEAR_PAREN = /\((19\d{2}|20\d{2})\)/;
+const YEAR_ANY = /\b(19\d{2}|20\d{2})\b/g;
+
+// Fansub CRC stamps, e.g. "[ABCD1234]" — pure noise, but they look like a title to a naive split.
+const CRC32 = /^[0-9A-F]{8}$/;
+
+const RESOLUTION = /^\d{3,4}p$/i;
+const DIMENSIONS = /^\d{3,4}x\d{3,4}$/;
+
+// One frozen vocabulary rather than a regex alternation: membership is O(1) and the list stays
+// readable when the next streaming-service tag has to be added.
+const JUNK: ReadonlySet<string> = new Set([
+  // quality
+  "4k", "uhd", "8k", "hd", "sd", "hdr", "hdr10", "dv", "sdr",
+  // source
+  "bluray", "blu-ray", "bdrip", "bdremux", "brrip", "remux", "webrip", "web-dl", "webdl", "web",
+  "hdtv", "pdtv", "dvdrip", "dvdscr", "dvd", "hdrip", "cam", "camrip", "ts", "telesync", "tc",
+  "telecine", "hdcam", "screener", "scr", "r5", "vodrip", "amzn", "nf", "hulu", "dsnp", "atvp",
+  "ma", "max", "hmax", "pmntp", "itunes",
+  // codec
+  "x264", "x265", "h264", "h265", "h.264", "h.265", "hevc", "avc", "xvid", "divx", "av1", "vp9",
+  "10bit", "8bit", "10-bit", "hi10p",
+  // audio
+  "aac", "ac3", "eac3", "dts", "truehd", "ddp", "dd", "atmos", "flac", "mp3", "opus", "dual-audio",
+  "5.1", "7.1", "2.0", "aac2.0", "ddp5.1", "dd5.1",
+  // misc
+  "multi", "multi-audio", "multi-subs", "subbed", "dubbed", "sub", "subs", "vostfr", "vf",
+  "french", "truefrench", "ita", "eng", "esp", "repack", "proper", "extended", "uncut", "unrated",
+  "remastered", "imax", "limited", "internal", "complete", "batch", "leak", "hq", "pre",
+]);
+
+// Trim only leading/trailing non-alphanumerics: interior punctuation is significant ("web-dl",
+// "aac2.0", "h.264"). Unicode classes keep CJK titles intact instead of erasing them to "".
+const EDGE_PUNCTUATION = /^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu;
+
+function isJunk(token: string): boolean {
+  const t = token.toLowerCase().replace(EDGE_PUNCTUATION, "");
+  if (t === "") return false;
+  return JUNK.has(t) || RESOLUTION.test(t) || DIMENSIONS.test(t);
+}
+
+/** True when every dash/underscore/space-separated part of a bracket body is junk. */
+function isJunkOnly(inner: string): boolean {
+  if (isJunk(inner)) return true;
+  const parts = inner.split(/[\s_-]+/).filter((p) => p !== "");
+  return parts.length > 0 && parts.every(isJunk);
+}
+
+interface Token {
+  readonly text: string;
+  readonly index: number;
+}
+
+function tokenize(s: string): readonly Token[] {
+  const out: Token[] = [];
+  for (const m of s.matchAll(/\S+/g)) {
+    if (m.index !== undefined) out.push({ text: m[0], index: m.index });
+  }
+  return out;
+}
+
+/**
+ * `_` is never anything but a separator. `.` is ambiguous — it separates scene names but also
+ * carries decimals ("AAC 2.0") — so only convert it when dots are pulling their weight as the
+ * dominant separator. Ties go to dots: a name with as many dots as spaces is a scene name whose
+ * title happens to contain spaces, and leaving the dots in would fuse title and junk tokens.
+ */
+export function normalizeSeparators(s: string): string {
+  const underscored = s.replace(/_/g, " ");
+  const dots = (underscored.match(/\./g) ?? []).length;
+  const spaces = (underscored.match(/ /g) ?? []).length;
+  return dots > 0 && dots >= spaces ? underscored.replace(/\./g, " ") : underscored;
+}
+
+const EP_SxxExx = /S(\d{1,2})[ ._-]?E(\d{1,3})/i;
+const EP_NxNN = /\b(\d{1,2})x(\d{2})\b/i;
+const EP_SEASON_WORD = /\bSeason[ ._-]?(\d{1,2})(?:[ ._-]?Episode[ ._-]?(\d{1,3}))?/i;
+// SubsPlease / Erai-raws style "Show - 01", optionally version-stamped ("- 06v2").
+const EP_DASH = /[ ._-]-[ ._-](\d{1,4})(?:v\d)?\b/;
+const EP_BARE_SEASON = /\bS(\d{1,2})\b/i;
+
+function toInt(s: string | undefined): number | undefined {
+  if (s === undefined) return undefined;
+  const n = Number.parseInt(s, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * First marker wins, strongest form first. The bare "- 01" form is last-resort and only trusted
+ * past the first third of the name, because a hyphen that early is far more likely to be part of
+ * the title ("Spider-Man - the ...") than an episode number.
+ */
+export function findEpisodeMarker(
+  s: string,
+): { index: number; season?: number; episode?: number } | null {
+  const sxxexx = s.match(EP_SxxExx);
+  if (sxxexx?.index !== undefined) {
+    return { index: sxxexx.index, season: toInt(sxxexx[1]), episode: toInt(sxxexx[2]) };
+  }
+
+  const nxnn = s.match(EP_NxNN);
+  if (nxnn?.index !== undefined) {
+    return { index: nxnn.index, season: toInt(nxnn[1]), episode: toInt(nxnn[2]) };
+  }
+
+  const worded = s.match(EP_SEASON_WORD);
+  if (worded?.index !== undefined) {
+    return { index: worded.index, season: toInt(worded[1]), episode: toInt(worded[2]) };
+  }
+
+  const dash = s.match(EP_DASH);
+  if (dash?.index !== undefined && dash.index >= s.length / 3) {
+    // The dash form carries no season, but fansubs park one just before it ("… S4 - 17"), so
+    // backfill from the text we are about to discard and cut at whichever marker comes first.
+    const before = s.slice(0, dash.index);
+    const season = before.match(EP_BARE_SEASON);
+    if (season?.index !== undefined) {
+      return { index: season.index, season: toInt(season[1]), episode: toInt(dash[1]) };
+    }
+    return { index: dash.index, episode: toInt(dash[1]) };
+  }
+
+  const bare = s.match(EP_BARE_SEASON);
+  if (bare?.index !== undefined) return { index: bare.index, season: toInt(bare[1]) };
+
+  return null;
+}
+
+/**
+ * A parenthesised year is an explicit claim and always wins. A naked four-digit run is not — it
+ * could be part of the title ("2012", "Blade Runner 2049") — so it only counts when junk follows
+ * it, which is the shape of a real scene name, and never when it is all we have left.
+ */
+export function findYear(s: string): { index: number; year: number } | null {
+  const paren = s.match(YEAR_PAREN);
+  if (paren?.index !== undefined) {
+    const year = toInt(paren[1]);
+    if (year !== undefined) return { index: paren.index, year };
+  }
+
+  if (YEAR_ONLY.test(s.trim())) return null;
+
+  const matches = [...s.matchAll(YEAR_ANY)];
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    if (m?.index === undefined) continue;
+    const year = toInt(m[1]);
+    if (year === undefined) continue;
+    const trailing = tokenize(s.slice(m.index + m[0].length));
+    if (trailing.some((t) => isJunk(t.text))) return { index: m.index, year };
+  }
+  return null;
+}
+
+/** Index of the first junk token, or -1. Token index, not character offset. */
+export function firstJunkIndex(tokens: readonly string[]): number {
+  for (let i = 0; i < tokens.length; i++) {
+    const t = tokens[i];
+    if (t !== undefined && isJunk(t)) return i;
+  }
+  return -1;
+}
+
+function stripLeadingGroup(s: string): { text: string; group?: string } {
+  const lead = s.match(BRACKET_LEADING);
+  const inner = lead?.[1]?.trim();
+  if (lead === null || lead === undefined || inner === undefined || inner === "") return { text: s };
+  // A leading "[1080p]" or "(2023)" is metadata, not a group — leave it for the generic pass.
+  if (YEAR_ONLY.test(inner) || isJunkOnly(inner) || CRC32.test(inner)) return { text: s };
+  return { text: s.slice(lead[0].length), group: inner };
+}
+
+function stripJunkBrackets(s: string): string {
+  return s.replace(BRACKET_ANY, (whole: string, inner: string) => {
+    const v = inner.trim();
+    if (YEAR_ONLY.test(v)) return whole; // the year is the one bracket body worth keeping
+    if (v === "" || isJunkOnly(v) || CRC32.test(v)) return " ";
+    return whole;
+  });
+}
+
+// Scene names end in "-GROUP" with no space before the dash — but so does an ordinary hyphenated
+// title ("Spider-Man", "X-Men"), and so does "WEB-DL". Shape alone cannot tell them apart.
+const TRAILING_GROUP = /-([A-Za-z][A-Za-z0-9]+)$/;
+
+/**
+ * A trailing "-GROUP" is only believable when the rest of the name reads like a scene release:
+ * some junk token, a year, or an episode marker ahead of it. Without that corroboration the
+ * hyphen belongs to the title, and taking it would search for "Spider" instead of "Spider-Man".
+ * Rejecting a vocabulary candidate ("WEB-DL") stays as a second, independent guard.
+ */
+function stripTrailingGroup(s: string): { text: string; group?: string } {
+  const m = s.match(TRAILING_GROUP);
+  const candidate = m?.[1];
+  if (m?.index === undefined || candidate === undefined) return { text: s };
+  const lastToken = s.slice(s.lastIndexOf(" ") + 1);
+  if (isJunk(lastToken) || isJunk(candidate)) return { text: s };
+
+  const before = s.slice(0, m.index);
+  const corroborated =
+    firstJunkIndex(tokenize(before).map((t) => t.text)) >= 0 ||
+    findYear(before) !== null ||
+    findEpisodeMarker(before) !== null;
+  if (!corroborated) return { text: s };
+
+  return { text: s.slice(0, m.index), group: candidate };
+}
+
+const TRAILING_EZTV = /[\s._-]*EZTV$/i;
+const TRAILING_PUNCTUATION = /[-:–,]+$/;
+
+function tidy(s: string): string {
+  let t = s.replace(/\s+/g, " ").trim();
+  // EZTV staples its own name onto every row it publishes; it is never part of the title.
+  t = t.replace(TRAILING_EZTV, "").trim();
+  let previous = "";
+  while (t !== previous) {
+    previous = t;
+    t = t.replace(TRAILING_PUNCTUATION, "").trim();
+  }
+  return t;
+}
+
+/**
+ * Reduce a torrent release name to something worth querying a metadata provider with. Total by
+ * construction: unparseable input yields an empty title rather than an exception, and the caller
+ * decides whether an empty or junk-looking title is worth a lookup.
+ */
+export function parseRelease(name: string): ParsedRelease {
+  if (typeof name !== "string" || name === "") return { title: "", kind: "movie" };
+
+  const withoutExt = name.replace(CONTAINER_EXT, "");
+
+  const lead = stripLeadingGroup(withoutExt);
+  const debracketed = stripJunkBrackets(lead.text).replace(/\s+/g, " ").trim();
+
+  // Separators are normalized before the group strip: the corroboration check reads the name as
+  // tokens, and a dotted scene name is a single token until the dots become spaces.
+  const normalized = normalizeSeparators(debracketed).replace(/\s+/g, " ").trim();
+  const trailing = stripTrailingGroup(normalized);
+  const s = trailing.text.trim();
+
+  const marker = findEpisodeMarker(s);
+  const year = findYear(s);
+  const tokens = tokenize(s);
+  const junkToken = firstJunkIndex(tokens.map((t) => t.text));
+
+  const cuts: number[] = [];
+  if (marker !== null) cuts.push(marker.index);
+  if (year !== null) cuts.push(year.index);
+  if (junkToken >= 0) {
+    const t = tokens[junkToken];
+    if (t !== undefined) cuts.push(t.index);
+  }
+  const cut = cuts.length > 0 ? Math.min(...cuts) : s.length;
+
+  const title = tidy(s.slice(0, cut));
+  const season = marker?.season;
+  const episode = marker?.episode;
+  const group = lead.group ?? trailing.group;
+
+  return {
+    title,
+    kind: season !== undefined || episode !== undefined ? "series" : "movie",
+    ...(year !== null ? { year: year.year } : {}),
+    ...(season !== undefined ? { season } : {}),
+    ...(episode !== undefined ? { episode } : {}),
+    ...(group !== undefined ? { group } : {}),
+  };
+}

--- a/src/meta/types.ts
+++ b/src/meta/types.ts
@@ -1,0 +1,41 @@
+// The shape of the metadata torlink shows beside a search result, independent of which provider
+// produced it. Everything here has already crossed the trust boundary: strings are cleaned, lists
+// are capped and the IMDb id is validated, so a render path can print any of it verbatim.
+// Fields are readonly because these values are cached and shared across rows — a consumer that
+// mutated one would silently poison every other row holding the same object.
+
+export type MetaKind = "movie" | "series";
+
+export interface EpisodeMeta {
+  readonly season: number;
+  readonly number: number;
+  readonly title?: string;
+  readonly overview?: string;
+}
+
+export interface Meta {
+  readonly imdbId: string;
+  readonly kind: MetaKind;
+  readonly title: string;
+  /** `releaseInfo` verbatim: a movie's "1999", a series' "2008–2013" or open-ended "2016–". */
+  readonly year?: string;
+  /** IMDb rating as sent, e.g. "8.7" — kept a string so a missing value is absent, not 0. */
+  readonly rating?: string;
+  readonly runtime?: string;
+  readonly genres: readonly string[];
+  readonly cast: readonly string[];
+  /** Cinemeta sends `null` here for series, so this is routinely empty. */
+  readonly director: readonly string[];
+  readonly plot?: string;
+  /** https only, host-allowlisted at the mapping boundary. */
+  readonly posterUrl?: string;
+  readonly episode?: EpisodeMeta;
+}
+
+/** One row of a provider's search catalog — just enough to match against a parsed release name. */
+export interface CatalogHit {
+  readonly imdbId: string;
+  readonly name: string;
+  readonly releaseInfo?: string;
+  readonly kind: MetaKind;
+}

--- a/src/sources/eztv.test.ts
+++ b/src/sources/eztv.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toResult } from "./eztv";
 
-const mockFetch = vi.fn();
+// Hoisted above the vi.mock factory below, which runs before this file's own top-level
+// statements: toResult is imported statically, so ./eztv -- and with it the mocked
+// ../util/net -- loads at import time rather than inside a test.
+const mockFetch = vi.hoisted(() => vi.fn());
 
 vi.mock("../util/net", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../util/net")>();
@@ -124,5 +128,42 @@ describe("eztv search", () => {
 
     // Only the catalogue request, never the ten index pages again.
     expect(mockFetch.mock.calls.length - afterFirst).toBe(1);
+  });
+});
+
+// Field names and value shapes are verbatim from an EZTV get-torrents response.
+const API_ROW = {
+  title: "Show.Name.S01E02.1080p.WEB.h264-GROUP",
+  filename: "Show.Name.S01E02.1080p.WEB.h264-GROUP.mkv",
+  imdb_id: "399664",
+  hash: "8C4ADBF9EBDC4C6D1D0F1B0F0E0D0C0B0A090807",
+  magnet_url: "magnet:?xt=urn:btih:8c4adbf9ebdc4c6d1d0f1b0f0e0d0c0b0a090807",
+  seeds: 88,
+  peers: 5,
+  size_bytes: "734003200",
+  date_released_unix: 1600000000,
+} as const;
+
+describe("toResult", () => {
+  it("zero-pads EZTV's bare numeric series id into an IMDb id", () => {
+    expect(toResult({ ...API_ROW })).toMatchObject({
+      infoHash: "8c4adbf9ebdc4c6d1d0f1b0f0e0d0c0b0a090807",
+      source: "eztv",
+      imdbId: "tt0399664",
+    });
+  });
+
+  it("leaves the id absent when EZTV's value is empty or already prefixed", () => {
+    expect(toResult({ ...API_ROW, imdb_id: "" })?.imdbId).toBeUndefined();
+    expect(toResult({ ...API_ROW, imdb_id: "tt0399664" })?.imdbId).toBeUndefined();
+  });
+
+  it("leaves the id absent when EZTV omits the field entirely", () => {
+    const { imdb_id: _imdbId, ...withoutImdb } = API_ROW;
+    expect(toResult(withoutImdb)?.imdbId).toBeUndefined();
+  });
+
+  it("still drops rows with no usable hash or magnet", () => {
+    expect(toResult({ ...API_ROW, hash: "", magnet_url: "" })).toBeNull();
   });
 });

--- a/src/sources/eztv.ts
+++ b/src/sources/eztv.ts
@@ -1,5 +1,5 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
-import { imdbFromNumeric } from "../meta/cinemeta";
+import { imdbFromNumeric } from "../meta/imdbId";
 import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, TorrentResult } from "./types";
 
@@ -82,7 +82,8 @@ function matches(t: EztvTorrent, tokens: string[]): boolean {
   return tokens.every((token) => name.includes(token));
 }
 
-function toResult(t: EztvTorrent): TorrentResult | null {
+/** Exported for tests: the mapping is where every EZTV quirk is absorbed. */
+export function toResult(t: EztvTorrent): TorrentResult | null {
   const hash = (t.hash ?? "").toLowerCase();
   const name = t.title || t.filename || hash;
   const magnet = t.magnet_url || (hash ? buildMagnet(hash, name) : "");

--- a/src/sources/eztv.ts
+++ b/src/sources/eztv.ts
@@ -1,4 +1,5 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
+import { imdbFromNumeric } from "../meta/cinemeta";
 import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, TorrentResult } from "./types";
 
@@ -95,6 +96,9 @@ function toResult(t: EztvTorrent): TorrentResult | null {
     source: "eztv",
     magnet,
     added: t.date_released_unix,
+    // EZTV publishes the *series* id, bare digits and unpadded ("399664"), so it needs both the
+    // tt-prefix and the same result-side validation every other remote id gets.
+    imdbId: imdbFromNumeric(t.imdb_id),
   };
 }
 

--- a/src/sources/piratebay.test.ts
+++ b/src/sources/piratebay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { tpbMovies } from "./piratebay";
+import { toResult, tpbMovies } from "./piratebay";
 import { fetchResilient } from "../util/net";
 
 vi.mock("../util/net", async (importOriginal) => {
@@ -71,5 +71,47 @@ describe("apibay sentinel retry", () => {
     await tpbMovies.search("");
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(askedUrl(0)).toContain("/precompiled/");
+  });
+});
+
+// Field names and value shapes are verbatim from an apibay q.php response.
+const ROW = {
+  id: "10944926",
+  name: "The Matrix 1999 1080p BluRay x264",
+  info_hash: "8C4ADBF9EBDC4C6D1D0F1B0F0E0D0C0B0A090807",
+  seeders: "412",
+  leechers: "17",
+  num_files: "3",
+  size: "2147483648",
+  added: "1600000000",
+  category: "207",
+  imdb: "tt0133093",
+} as const;
+
+describe("toResult", () => {
+  it("carries the IMDb id apibay supplies", () => {
+    expect(toResult({ ...ROW }, "tpb-movies")).toMatchObject({
+      infoHash: "8c4adbf9ebdc4c6d1d0f1b0f0e0d0c0b0a090807",
+      source: "tpb-movies",
+      imdbId: "tt0133093",
+    });
+  });
+
+  it('rejects the "0" apibay sends for a row with no id', () => {
+    // Not a sentinel check: normalizeImdbId refuses it on shape, the same way it refuses any other
+    // remote string that is not tt + 7-10 digits.
+    expect(toResult({ ...ROW, imdb: "0" }, "tpb-movies")?.imdbId).toBeUndefined();
+    expect(toResult({ ...ROW, imdb: "" }, "tpb-movies")?.imdbId).toBeUndefined();
+    expect(toResult({ ...ROW, imdb: "tt0133093/../admin" }, "tpb-tv")?.imdbId).toBeUndefined();
+  });
+
+  it("leaves the id absent when apibay omits the field entirely", () => {
+    const { imdb: _imdb, ...withoutImdb } = ROW;
+    expect(toResult(withoutImdb, "tpb-tv")?.imdbId).toBeUndefined();
+  });
+
+  it("still drops the rows it always dropped", () => {
+    expect(toResult({ ...ROW, info_hash: "0".repeat(40) }, "tpb-movies")).toBeNull();
+    expect(toResult({ ...ROW, id: "0" }, "tpb-movies")).toBeNull();
   });
 });

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -1,5 +1,5 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
-import { normalizeImdbId } from "../meta/cinemeta";
+import { normalizeImdbId } from "../meta/imdbId";
 import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 

--- a/src/sources/piratebay.ts
+++ b/src/sources/piratebay.ts
@@ -1,4 +1,5 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
+import { normalizeImdbId } from "../meta/cinemeta";
 import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, SourceId, TorrentResult } from "./types";
 
@@ -20,11 +21,13 @@ interface ApibayItem {
   size?: string;
   added?: string;
   category?: string;
+  imdb?: string;
 }
 
 const ZERO_HASH = "0000000000000000000000000000000000000000";
 
-function toResult(it: ApibayItem, source: SourceId): TorrentResult | null {
+/** Exported for tests: the mapping is where every apibay quirk is absorbed. */
+export function toResult(it: ApibayItem, source: SourceId): TorrentResult | null {
   const infoHash = (it.info_hash ?? "").toLowerCase();
   if (!infoHash || infoHash === ZERO_HASH || it.id === "0") return null;
   const name = it.name || "Unknown";
@@ -39,6 +42,9 @@ function toResult(it: ApibayItem, source: SourceId): TorrentResult | null {
     source,
     magnet: buildMagnet(infoHash, name),
     added: Number(it.added) || undefined,
+    // apibay carries the id on both category feeds, and sends the string "0" on rows that have
+    // none. normalizeImdbId rejects that on shape alone, so no separate sentinel check is needed.
+    imdbId: normalizeImdbId(it.imdb),
   };
 }
 

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -22,6 +22,12 @@ export interface TorrentResult {
   source: SourceId;
   magnet: string;
   added?: number;
+  /**
+   * IMDb id (`tt` + 7-10 digits) when the source's API hands one over. Lets the
+   * metadata lookup skip title guessing. Never trusted verbatim: it is remote
+   * text interpolated into a URL path, so producers validate the shape first.
+   */
+  imdbId?: string;
 }
 
 export interface SearchOptions {

--- a/src/sources/yts.test.ts
+++ b/src/sources/yts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { toResult } from "./yts";
+
+// Field names and value shapes are verbatim from a YTS list_movies.json response.
+const MOVIE = {
+  title_long: "The Matrix (1999)",
+  title: "The Matrix",
+  imdb_code: "tt0133093",
+  date_uploaded_unix: 1600000000,
+} as const;
+
+const TORRENT = {
+  hash: "8C4ADBF9EBDC4C6D1D0F1B0F0E0D0C0B0A090807",
+  quality: "1080p",
+  type: "bluray",
+  size_bytes: 2147483648,
+  seeds: 412,
+  peers: 17,
+} as const;
+
+describe("toResult", () => {
+  it("carries the IMDb id YTS supplies", () => {
+    expect(toResult({ ...MOVIE }, { ...TORRENT })).toMatchObject({
+      infoHash: "8c4adbf9ebdc4c6d1d0f1b0f0e0d0c0b0a090807",
+      source: "yts",
+      imdbId: "tt0133093",
+    });
+  });
+
+  it("leaves the id absent when YTS's value doesn't look like an IMDb id", () => {
+    expect(toResult({ ...MOVIE, imdb_code: "133093" }, { ...TORRENT })?.imdbId).toBeUndefined();
+    expect(toResult({ ...MOVIE, imdb_code: "" }, { ...TORRENT })?.imdbId).toBeUndefined();
+  });
+
+  it("leaves the id absent when YTS omits the field entirely", () => {
+    const { imdb_code: _imdbCode, ...withoutImdb } = MOVIE;
+    expect(toResult(withoutImdb, { ...TORRENT })?.imdbId).toBeUndefined();
+  });
+
+  it("still drops rows with no usable hash", () => {
+    expect(toResult({ ...MOVIE }, { ...TORRENT, hash: undefined })).toBeNull();
+  });
+});

--- a/src/sources/yts.ts
+++ b/src/sources/yts.ts
@@ -1,5 +1,5 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
-import { normalizeImdbId } from "../meta/cinemeta";
+import { normalizeImdbId } from "../meta/imdbId";
 import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, TorrentResult } from "./types";
 
@@ -43,6 +43,28 @@ async function fetchMovies(params: URLSearchParams, opts: SearchOptions): Promis
   throw lastError instanceof Error ? lastError : new HttpError(0, "YTS unreachable");
 }
 
+/** Exported for tests: the mapping is where every YTS quirk is absorbed. */
+export function toResult(movie: YtsMovie, t: YtsTorrent): TorrentResult | null {
+  if (!t.hash) return null;
+  const infoHash = t.hash.toLowerCase();
+  const base = movie.title_long || movie.title || "Unknown";
+  const tag = [t.quality, t.type].filter(Boolean).join(" ");
+  const name = tag ? `${base} [${tag}]` : base;
+  return {
+    infoHash,
+    name,
+    sizeBytes: t.size_bytes ?? 0,
+    seeders: t.seeds ?? 0,
+    leechers: t.peers ?? 0,
+    source: "yts",
+    magnet: buildMagnet(infoHash, name),
+    added: movie.date_uploaded_unix,
+    // One id per film, shared by its quality rows: validated here, at the trust boundary, not at
+    // the point of use.
+    imdbId: normalizeImdbId(movie.imdb_code),
+  };
+}
+
 async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
   const q = query.trim();
   const params = new URLSearchParams({ limit: "50" });
@@ -52,26 +74,9 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
   const json = await fetchMovies(params, opts);
   const out: TorrentResult[] = [];
   for (const movie of json.data?.movies ?? []) {
-    const base = movie.title_long || movie.title || "Unknown";
-    // One id per film, shared by its quality rows: hoisted so the metadata cache collapses all
-    // four of them onto one entry. Validated here, at the trust boundary, not at the point of use.
-    const imdbId = normalizeImdbId(movie.imdb_code);
     for (const t of movie.torrents ?? []) {
-      if (!t.hash) continue;
-      const infoHash = t.hash.toLowerCase();
-      const tag = [t.quality, t.type].filter(Boolean).join(" ");
-      const name = tag ? `${base} [${tag}]` : base;
-      out.push({
-        infoHash,
-        name,
-        sizeBytes: t.size_bytes ?? 0,
-        seeders: t.seeds ?? 0,
-        leechers: t.peers ?? 0,
-        source: "yts",
-        magnet: buildMagnet(infoHash, name),
-        added: movie.date_uploaded_unix,
-        imdbId,
-      });
+      const r = toResult(movie, t);
+      if (r) out.push(r);
     }
   }
   return out;

--- a/src/sources/yts.ts
+++ b/src/sources/yts.ts
@@ -1,4 +1,5 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
+import { normalizeImdbId } from "../meta/cinemeta";
 import { buildMagnet } from "./magnet";
 import type { SearchOptions, Source, TorrentResult } from "./types";
 
@@ -15,6 +16,7 @@ interface YtsTorrent {
 interface YtsMovie {
   title_long?: string;
   title?: string;
+  imdb_code?: string;
   date_uploaded_unix?: number;
   torrents?: YtsTorrent[];
 }
@@ -51,6 +53,9 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
   const out: TorrentResult[] = [];
   for (const movie of json.data?.movies ?? []) {
     const base = movie.title_long || movie.title || "Unknown";
+    // One id per film, shared by its quality rows: hoisted so the metadata cache collapses all
+    // four of them onto one entry. Validated here, at the trust boundary, not at the point of use.
+    const imdbId = normalizeImdbId(movie.imdb_code);
     for (const t of movie.torrents ?? []) {
       if (!t.hash) continue;
       const infoHash = t.hash.toLowerCase();
@@ -65,6 +70,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
         source: "yts",
         magnet: buildMagnet(infoHash, name),
         added: movie.date_uploaded_unix,
+        imdbId,
       });
     }
   }

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SOURCES } from "../../sources/registry";
-import { StoreContext } from "../store";
+import { StoreContext, type Store } from "../store";
 import {
   KEY,
   makeTestStore,
@@ -10,12 +10,21 @@ import {
 } from "../testHarness";
 import { Results } from "./Results";
 import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
+import type { MetaState } from "../hooks/useResultMeta";
+import type { Meta } from "../../meta/types";
 import type { TorrentResult } from "../../sources/types";
 
 const searchState = vi.hoisted(() => ({ current: null as unknown }));
 
 vi.mock("../hooks/useConcurrentSearch", () => ({
   useConcurrentSearch: () => searchState.current,
+}));
+
+const IDLE_META: MetaState = { loading: false, meta: null };
+const metaState = vi.hoisted(() => ({ current: null as unknown }));
+
+vi.mock("../hooks/useResultMeta", () => ({
+  useResultMeta: () => metaState.current,
 }));
 
 const t = (infoHash: string, name: string): TorrentResult => ({
@@ -55,16 +64,33 @@ afterEach(() => {
   ui = null;
 });
 
-async function mount(results: TorrentResult[] = LIST): Promise<RenderedUI> {
+async function mount(
+  results: TorrentResult[] = LIST,
+  storeOverrides: Partial<Store> = {},
+  meta: MetaState = IDLE_META,
+): Promise<RenderedUI> {
   searchState.current = settled(results);
+  metaState.current = meta;
   ui = renderUI(
-    <StoreContext.Provider value={makeTestStore({ query: "linux iso" })}>
+    <StoreContext.Provider value={makeTestStore({ query: "linux iso", ...storeOverrides })}>
       <Results />
     </StoreContext.Provider>,
   );
   const u = ui;
   await vi.waitFor(() => expect(u.frame()).toContain(`Results (${results.length})`));
   return u;
+}
+
+// The detail panel's height comes from listRows, same as the list view. The default test
+// listRows (14) leaves ~5 content rows after the search bar and panel chrome — enough for the
+// pre-existing rows but not for five more metadata rows on top, so detail-view tests ask for a
+// tall enough panel to actually see what they're asserting on instead of silently clipping it.
+async function openDetail(u: RenderedUI): Promise<void> {
+  u.press(KEY.enter);
+  // "Magnet" is an unconditional detail-view row (present regardless of metadata state), so
+  // waiting on it — rather than the result's own name, which the list view already shows —
+  // actually proves the mode switch happened instead of matching the still-open list frame.
+  await vi.waitFor(() => expect(u.frame()).toContain("Magnet"));
 }
 
 const lines = (u: RenderedUI): string[] => u.frame().split("\n");
@@ -183,5 +209,174 @@ describe("Results filter UI", () => {
     u.press(KEY.enter);
     await vi.waitFor(() => expect(u.frame()).not.toContain("Filter"));
     expect(u.frame()).toContain("Results (8)");
+  });
+});
+
+const MOVIE_META: Meta = {
+  imdbId: "tt0111161",
+  kind: "movie",
+  title: "The Shawshank Redemption",
+  year: "1994",
+  rating: "9.3",
+  runtime: "142 min",
+  genres: ["Drama"],
+  cast: ["Tim Robbins", "Morgan Freeman"],
+  director: ["Frank Darabont"],
+  plot: "A banker convicted of murdering his wife forms a friendship over a number of years.",
+};
+
+// Cinemeta sends null director for series; an empty array is the routine shape here, not an
+// edge case, which is exactly why the "no Director row" guard below matters.
+const SERIES_META: Meta = {
+  imdbId: "tt0944947",
+  kind: "series",
+  title: "Game of Thrones",
+  year: "2011–2019",
+  rating: "9.2",
+  genres: ["Drama", "Fantasy"],
+  cast: ["Emilia Clarke", "Kit Harington"],
+  director: [],
+  plot: "Nine noble families fight for control of the mythical land of Westeros.",
+};
+
+// Tall enough that the detail panel's fixed height (derived from listRows) never clips a row
+// these tests assert on — the default test listRows only fits the pre-existing rows.
+const TALL_DETAIL_STORE = { listRows: 40 };
+
+describe("Results detail metadata", () => {
+  it("renders rating, genres, director, cast and plot when metadata is present", async () => {
+    const u = await mount(LIST, TALL_DETAIL_STORE, { loading: false, meta: MOVIE_META });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("Rating");
+    expect(frame).toContain("9.3 / 10");
+    expect(frame).toContain("Genres");
+    expect(frame).toContain("Drama");
+    expect(frame).toContain("Director");
+    expect(frame).toContain("Frank Darabont");
+    expect(frame).toContain("Cast");
+    expect(frame).toContain("Tim Robbins, Morgan Freeman");
+    expect(frame).toContain("Plot");
+    expect(frame).toContain("A banker convicted of murdering his wife");
+
+    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+  });
+
+  it("renders none of the metadata rows when meta is null", async () => {
+    const u = await mount(LIST, TALL_DETAIL_STORE, IDLE_META);
+    await openDetail(u);
+
+    // The existing rows still render exactly as before...
+    expect(u.frame()).toContain("Magnet");
+    // ...but nothing new appears: no error row, no placeholder, no partial label.
+    expect(u.frame()).not.toContain("Rating");
+    expect(u.frame()).not.toContain("Genres");
+    expect(u.frame()).not.toContain("Director");
+    expect(u.frame()).not.toContain("Cast");
+    expect(u.frame()).not.toContain("Plot");
+
+    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+  });
+
+  it("omits the Director row for a series with no director", async () => {
+    const u = await mount(LIST, TALL_DETAIL_STORE, { loading: false, meta: SERIES_META });
+    await openDetail(u);
+
+    const frame = u.frame();
+    // Metadata that does exist still renders...
+    expect(frame).toContain("Cast");
+    expect(frame).toContain("Emilia Clarke");
+    // ...but an empty director list produces no row at all, not a blank one.
+    expect(frame).not.toContain("Director");
+
+    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+  });
+});
+
+// The maximum shape Meta's own caps allow: 6 genres, 12 cast, 3 directors, an 800-char plot.
+// Exercises the metadata layout budget at its worst case, not just a comfortable one.
+const MAX_META: Meta = {
+  imdbId: "tt0111161",
+  kind: "movie",
+  title: "The Shawshank Redemption",
+  year: "1994",
+  rating: "9.3",
+  runtime: "142 min",
+  genres: ["Drama", "Crime", "Prison", "Redemption", "Friendship", "Hope"],
+  cast: [
+    "Tim Robbins",
+    "Morgan Freeman",
+    "Bob Gunton",
+    "William Sadler",
+    "Clancy Brown",
+    "Gil Bellows",
+    "Mark Rolston",
+    "James Whitmore",
+    "Jeffrey DeMunn",
+    "Larry Brandenburg",
+    "Neil Giuntoli",
+    "Brian Libby",
+  ],
+  director: ["Frank Darabont", "Second Director", "Third Director"],
+  plot: "A".repeat(800),
+};
+
+describe("Results detail metadata at a realistic terminal height", () => {
+  // App.tsx's own listRows formula gives 17 for a standard 24-row terminal — the height that
+  // matters for real usage, as opposed to TALL_DETAIL_STORE's 40, which exists purely to pin the
+  // full, unclipped rendering path above. At this height the detail panel's inner content area
+  // (Panel's height minus its own bottom border) is exactly 11 rows, and the six torrent-fact
+  // rows below already use all 11 once Files and Added both apply — leaving no room for any
+  // metadata row at all, which the first test asserts holds up even under MAX_META.
+  const REALISTIC_STORE = { listRows: 17 };
+
+  it("keeps every torrent fact and the action hint intact, even with MAX_META and no room to spare", async () => {
+    const withFiles = [{ ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: 3 }];
+    const u = await mount(withFiles, REALISTIC_STORE, { loading: false, meta: MAX_META });
+    await openDetail(u);
+
+    const frame = u.frame();
+    // The row order and content that existed before this feature must survive completely
+    // unchanged: nothing dropped from the top, nothing fused, nothing renamed.
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Size");
+    expect(frame).toContain("Health");
+    expect(frame).toContain("Files");
+    expect(frame).toContain("Added");
+    expect(frame).toContain("Hash");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(frame).toContain("esc back");
+
+    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+  });
+
+  it("sheds metadata rows from the bottom of the block with no gap in the middle", async () => {
+    // No numFiles on this result, so the facts block is one row shorter than the test above —
+    // just enough budget for Rating alone. Genres needs two lines and does not fit, and once one
+    // present row fails, every row below it (director, cast, plot) is dropped too — even though
+    // Director's own three names would easily fit in what Genres left behind. Showing Director
+    // there would be a hole in the middle of the block, which is exactly the failure mode this
+    // pins against.
+    const u = await mount([t("a1", "ubuntu 24.04 desktop amd64 iso")], REALISTIC_STORE, {
+      loading: false,
+      meta: MAX_META,
+    });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("Rating");
+    expect(frame).toContain("9.3 / 10");
+    expect(frame).not.toContain("Genres");
+    expect(frame).not.toContain("Director");
+    expect(frame).not.toContain("Cast");
+    expect(frame).not.toContain("Plot");
+    // The facts and hint rows are unaffected by how much metadata budget is left.
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(frame).toContain("esc back");
+
+    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
   });
 });

--- a/src/ui/components/Results.test.tsx
+++ b/src/ui/components/Results.test.tsx
@@ -9,6 +9,7 @@ import {
   type RenderedUI,
 } from "../testHarness";
 import { Results } from "./Results";
+import { displayWidth } from "../textWidth";
 import type { ConcurrentSearchState } from "../hooks/useConcurrentSearch";
 import type { MetaState } from "../hooks/useResultMeta";
 import type { Meta } from "../../meta/types";
@@ -96,6 +97,20 @@ async function openDetail(u: RenderedUI): Promise<void> {
 const lines = (u: RenderedUI): string[] => u.frame().split("\n");
 const lineIndex = (u: RenderedUI, needle: string): number =>
   lines(u).findIndex((l) => l.includes(needle));
+// A plain `.toContain("esc back")` still passes when the hint row is fused with stray content
+// from an overflowing row above it (`esc back田`, `esc backLibby`) — the exact corruption this
+// feature has produced before. This instead requires "esc back" to be followed by nothing but
+// padding and the panel's own right border, which only a clean, unfused hint row satisfies.
+const hintRowIntact = (u: RenderedUI): boolean =>
+  lines(u).some((l) => /esc back\s*│$/.test(l));
+// `.length` undercounts a CJK/emoji line (one JS unit, two terminal columns) by roughly half, so
+// it stays "within budget" even when the real rendered line is corrupted or overflowing — the
+// exact blind spot that let a display-width bug through review with every existing test green.
+// This uses the component's own `displayWidth`, not a second implementation that could quietly
+// drift from it and give false confidence again.
+const widthFits = (u: RenderedUI): void => {
+  for (const l of lines(u)) expect(displayWidth(l)).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+};
 // The TextField cursor renders as SGR inverse; nothing else in this view does.
 const editing = (u: RenderedUI): boolean => u.rawFrame().includes(`${KEY.esc}[7m`);
 
@@ -260,7 +275,7 @@ describe("Results detail metadata", () => {
     expect(frame).toContain("Plot");
     expect(frame).toContain("A banker convicted of murdering his wife");
 
-    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+    widthFits(u);
   });
 
   it("renders none of the metadata rows when meta is null", async () => {
@@ -276,7 +291,7 @@ describe("Results detail metadata", () => {
     expect(u.frame()).not.toContain("Cast");
     expect(u.frame()).not.toContain("Plot");
 
-    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+    widthFits(u);
   });
 
   it("omits the Director row for a series with no director", async () => {
@@ -290,7 +305,7 @@ describe("Results detail metadata", () => {
     // ...but an empty director list produces no row at all, not a blank one.
     expect(frame).not.toContain("Director");
 
-    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+    widthFits(u);
   });
 });
 
@@ -347,36 +362,235 @@ describe("Results detail metadata at a realistic terminal height", () => {
     expect(frame).toContain("Hash");
     expect(frame).toContain("Magnet");
     expect(frame).toContain("d Download");
-    expect(frame).toContain("esc back");
+    expect(hintRowIntact(u)).toBe(true);
 
-    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+    widthFits(u);
   });
 
-  it("sheds metadata rows from the bottom of the block with no gap in the middle", async () => {
-    // No numFiles on this result, so the facts block is one row shorter than the test above —
-    // just enough budget for Rating alone. Genres needs two lines and does not fit, and once one
-    // present row fails, every row below it (director, cast, plot) is dropped too — even though
-    // Director's own three names would easily fit in what Genres left behind. Showing Director
-    // there would be a hole in the middle of the block, which is exactly the failure mode this
-    // pins against.
-    const u = await mount([t("a1", "ubuntu 24.04 desktop amd64 iso")], REALISTIC_STORE, {
-      loading: false,
-      meta: MAX_META,
-    });
+  it("drops genres, director and cast as one unit once genres fails to fit, while rating and plot survive on either side of the gap", async () => {
+    // No numFiles or Added on this result, so the facts block is two rows shorter than the test
+    // above — budget 2 rather than 0. Rating (1 line) is admitted first, leaving 1. Genres needs 2
+    // lines for MAX_META's six genres and does not fit, which cuts off every row after it in that
+    // all-or-nothing group — including Director, whose own three names *would* fit in the 1 line
+    // Genres left behind (1 <= 1) if admitted independently. Showing Director there anyway is
+    // exactly the bug a prior, unreviewed version of this fix had: it admitted each of
+    // genres/director/cast independently instead of sharing one cutoff, so Director rendered while
+    // Genres, ranked above it, did not — a row missing from the middle of that group. Plot is a
+    // deliberate exception to the cutoff (see planMetaRows' doc comment) and still claims the 1
+    // line Genres left unclaimed, so the real, intended result has a gap — Genres/Director/Cast
+    // all missing — between Rating and Plot, not "no gap at all".
+    const minimal = { ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: undefined, added: undefined };
+    const u = await mount([minimal], REALISTIC_STORE, { loading: false, meta: MAX_META });
     await openDetail(u);
 
     const frame = u.frame();
+    // The title row is the loudest signature of this class of corruption — it's the first thing
+    // Yoga's shrink math squeezes away when the panel overflows.
+    expect(frame).toContain("ubuntu 24.04 desktop");
     expect(frame).toContain("Rating");
     expect(frame).toContain("9.3 / 10");
     expect(frame).not.toContain("Genres");
     expect(frame).not.toContain("Director");
     expect(frame).not.toContain("Cast");
-    expect(frame).not.toContain("Plot");
+    expect(frame).toContain("Plot");
     // The facts and hint rows are unaffected by how much metadata budget is left.
     expect(frame).toContain("Magnet");
     expect(frame).toContain("d Download");
-    expect(frame).toContain("esc back");
+    expect(hintRowIntact(u)).toBe(true);
 
-    for (const l of lines(u)) expect(l.length).toBeLessThanOrEqual(TEST_CONTENT_WIDTH);
+    widthFits(u);
+  });
+
+  it("hard-breaks a single unbreakable token so it cannot undercount its way past the budget", async () => {
+    // No spaces at all — nothing for the greedy word-wrapper to break on except its hard
+    // per-character fallback. Without that fallback this "word" is undercounted as one line when
+    // it actually needs many, which is exactly what let a single unbroken run of text blow through
+    // a budget that looked, on paper, like it had room to spare (the original Critical bug, and
+    // the plot's 800-char stress case is unbroken text for the same reason). A tight budget is
+    // required to make the miscount visible: at a generous budget the same miscount just leaves
+    // unused slack, so this reuses REALISTIC_STORE with a fact row dropped rather than
+    // TALL_DETAIL_STORE.
+    const unbreakable = "X".repeat(600);
+    const meta: Meta = { ...MAX_META, genres: [], cast: [], director: [unbreakable] };
+    const minimal = { ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: undefined, added: undefined };
+    const u = await mount([minimal], REALISTIC_STORE, { loading: false, meta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
+  });
+});
+
+// Nyaa (one of torlink's own sources) is an anime index, and Cinemeta routinely returns CJK cast
+// and plot text for Japanese/Korean/Chinese titles — this is a routine path, not an edge case.
+// Each CJK character is one JS string unit but two terminal columns, which a length-based layout
+// budget silently undercounts by half; these pin the fix at the reviewer's own repro shapes.
+describe("Results detail metadata with CJK text", () => {
+  const REALISTIC_STORE = { listRows: 17 };
+
+  const CJK_CAST = [
+    "田中誠",
+    "鈴木一郎",
+    "佐藤健二",
+    "高橋美咲",
+    "伊藤大輔",
+    "渡辺直樹",
+    "山本花子",
+    "中村和也",
+    "小林優子",
+    "加藤誠一",
+    "吉田真央",
+    "山田太郎",
+  ];
+
+  const cjkCastMeta: Meta = { ...MAX_META, cast: CJK_CAST, genres: ["Drama"], director: [] };
+  // Genres/director cleared and plot dropped so Cast is the only thing competing for budget —
+  // needed for the "admitted and rendered" tests below, where the point is to actually exercise
+  // the wide-char measurement on a multi-line wrapped value, not just an admit/reject decision.
+  const cjkCastOnlyMeta: Meta = { ...MAX_META, cast: CJK_CAST, genres: [], director: [], plot: undefined };
+  const cjkPlotMeta: Meta = {
+    ...MAX_META,
+    cast: [],
+    genres: [],
+    director: [],
+    plot: "本作は刑務所を舞台にした友情と希望の物語である。".repeat(20),
+  };
+
+  it("renders a CJK cast without corruption at listRows=17, budget 2 (reviewer's exact repro)", async () => {
+    // No numFiles or Added — the same budget-2 shape as the mutant-killing test above. Budget 2
+    // cannot admit a 3-line CJK cast list regardless of how it's measured (Rating alone already
+    // takes 1), so this specifically pins "still renders cleanly when correctly rejected" — it is
+    // not the test that exercises the wide-char table on admitted content; see the two tests below
+    // for that.
+    const minimal = { ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: undefined, added: undefined };
+    const u = await mount([minimal], REALISTIC_STORE, { loading: false, meta: cjkCastMeta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Size");
+    expect(frame).toContain("Health");
+    expect(frame).toContain("Hash");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
+  });
+
+  it("admits and renders a CJK cast at listRows=20 with just enough budget to fit it", async () => {
+    // Minimal facts (no numFiles/Added) plus an otherwise-empty meta gives budget 5 at
+    // listRows=20: Rating (1) + the CJK cast's real 3-line wrap = 4, with 1 line to spare — tight
+    // enough that a wrong (undercounted) line-count prediction changes the outcome, unlike a
+    // generous budget where the same miscount just wastes slack invisibly.
+    const minimal = { ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: undefined, added: undefined };
+    const u = await mount([minimal], { listRows: 20 }, { loading: false, meta: cjkCastOnlyMeta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Size");
+    expect(frame).toContain("Health");
+    expect(frame).toContain("Hash");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("Cast");
+    for (const name of CJK_CAST) expect(frame).toContain(name);
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
+  });
+
+  it("renders a CJK plot without corruption at listRows=20", async () => {
+    const withFiles = [{ ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: 3 }];
+    const u = await mount(withFiles, { listRows: 20 }, { loading: false, meta: cjkPlotMeta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Size");
+    expect(frame).toContain("Health");
+    expect(frame).toContain("Files");
+    expect(frame).toContain("Added");
+    expect(frame).toContain("Hash");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
+  });
+
+  it("renders a full CJK cast list unclipped at a tall terminal", async () => {
+    const u = await mount(LIST, TALL_DETAIL_STORE, { loading: false, meta: cjkCastMeta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Cast");
+    // All twelve names present somewhere in the wrapped, multi-line Cast value.
+    for (const name of CJK_CAST) expect(frame).toContain(name);
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
+  });
+});
+
+// Astral code points (emoji outside the BMP, CJK Extension B+ ideographs) get no free ride from
+// `.length` the way a BMP character never did either — `for...of` yields one code point per
+// surrogate pair, so an unlisted astral range undercounts exactly like an unlisted BMP one. A
+// prior version of this file's width table left every astral range out on the theory that
+// `.length` already "handled" them, which reproduced the original Critical bug on emoji plots.
+describe("Results detail metadata with astral and BMP emoji", () => {
+  const clapperMeta: Meta = {
+    imdbId: "tt3", kind: "movie", title: "t", rating: "8.0",
+    genres: [], cast: [], director: [], plot: "🎬".repeat(200),
+  };
+  const starMeta: Meta = {
+    imdbId: "tt4", kind: "movie", title: "t", rating: "8.0",
+    genres: [], cast: [], director: [], plot: "⭐".repeat(200),
+  };
+
+  it("renders an astral emoji (clapper board) plot without corruption at listRows=20", async () => {
+    const withFiles = [{ ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: 3 }];
+    const u = await mount(withFiles, { listRows: 20 }, { loading: false, meta: clapperMeta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Size");
+    expect(frame).toContain("Health");
+    expect(frame).toContain("Files");
+    expect(frame).toContain("Added");
+    expect(frame).toContain("Hash");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
+  });
+
+  it("renders a BMP emoji (star) plot without corruption at listRows=20", async () => {
+    const withFiles = [{ ...t("a1", "ubuntu 24.04 desktop amd64 iso"), numFiles: 3 }];
+    const u = await mount(withFiles, { listRows: 20 }, { loading: false, meta: starMeta });
+    await openDetail(u);
+
+    const frame = u.frame();
+    expect(frame).toContain("ubuntu 24.04 desktop");
+    expect(frame).toContain("Size");
+    expect(frame).toContain("Health");
+    expect(frame).toContain("Files");
+    expect(frame).toContain("Added");
+    expect(frame).toContain("Hash");
+    expect(frame).toContain("Magnet");
+    expect(frame).toContain("d Download");
+    expect(hintRowIntact(u)).toBe(true);
+
+    widthFits(u);
   });
 });

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -7,12 +7,14 @@ import { TextField } from "./TextField";
 import { Panel } from "./Panel";
 import { Rule } from "./Rule";
 import { useConcurrentSearch } from "../hooks/useConcurrentSearch";
+import { useResultMeta } from "../hooks/useResultMeta";
 import { getSource, SOURCES } from "../../sources/registry";
 import { stickCursor, wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
 import { filterResults } from "../filter";
 import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
+import type { Meta } from "../../meta/types";
 import type { Source, TorrentResult } from "../../sources/types";
 
 type Mode = "list" | "search" | "detail" | "filter";
@@ -30,9 +32,152 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   );
 }
 
-function Detail({ r, width }: { r: TorrentResult; width: number }) {
+// Greedy word wrap, used only to learn — and pin — exactly how many terminal rows a value will
+// occupy before Ink ever lays it out. The detail panel has a fixed height (Panel's `height` prop,
+// clipped with `overflow: hidden`), and handing Ink's own `wrap="wrap"` more text than that
+// budget allows does not clip cleanly: Yoga's flexbox shrink squeezes whichever rows land on the
+// losing side of its shrink math, dropping or fusing rows anywhere in the block, including ones
+// above the actual overflow. Every metadata row rendered below is only rendered once it is known
+// to fit, which means knowing its line count first.
+//
+// A word longer than `width` (a Cinemeta plot has no guaranteed word length cap) is hard-broken
+// into `width`-sized chunks rather than left to overflow its own line — Ink's real wrap does the
+// same, and undercounting here is exactly what let a single unbroken run of text blow through a
+// budget that looked, on paper, like it had room to spare.
+function wordWrapLines(text: string, width: number): string[] {
+  if (width <= 0) return [text];
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+  const lines: string[] = [];
+  let line = "";
+  for (const word of words) {
+    let rest = word;
+    while (rest.length > width) {
+      if (line !== "") {
+        lines.push(line);
+        line = "";
+      }
+      lines.push(rest.slice(0, width));
+      rest = rest.slice(width);
+    }
+    if (line === "") line = rest;
+    else if (line.length + 1 + rest.length <= width) line += ` ${rest}`;
+    else {
+      lines.push(line);
+      line = rest;
+    }
+  }
+  if (line !== "") lines.push(line);
+  return lines;
+}
+
+interface MetaPlan {
+  readonly rating: string | null;
+  readonly genres: string | null;
+  readonly director: string | null;
+  readonly cast: string | null;
+  readonly plot: string | null;
+}
+
+const NO_META_PLAN: MetaPlan = { rating: null, genres: null, director: null, cast: null, plot: null };
+
+/**
+ * Decides which of the five metadata rows fit in `budget` terminal rows, in priority order —
+ * rating, genres, director, cast, plot — so a tight panel sheds value from the bottom of the
+ * metadata block outward and never touches the torrent facts above it or the action hint below.
+ *
+ * The moment one *present* row among rating/genres/director/cast fails to fit, every one of that
+ * group considered afterward is dropped too, even ones that would individually have fit on their
+ * own — otherwise a wide-but-short row (say, three-name Director) could land after a taller one it
+ * just displaced (six-genre Genres), which reads as a row missing from the middle of the block
+ * rather than a clean cut at the bottom. A field that is simply absent from this title's metadata
+ * (no director credited, most series) is not a fit failure and never triggers that cutoff — only a
+ * row that exists but does not fit does.
+ *
+ * Genres/director/cast are all-or-nothing: a cast list cut off mid-name reads as a bug, not a
+ * feature, so each is only admitted if every one of its wrapped lines fits. Plot is exempt from
+ * that cutoff and always evaluated last — it is the one row allowed to show less than it has, so
+ * it takes whatever budget the rows above it left unspent (whether they filled it or gave up on
+ * it) and ellipsizes its last visible line when the full text still does not fit. Sitting at the
+ * very bottom of the block, plot has nothing below it to expose as a hole.
+ */
+function planMetaRows(meta: Meta | null, valueWidth: number, budget: number): MetaPlan {
+  if (meta === null) return NO_META_PLAN;
+  let remaining = budget;
+  // Set the first time a present row does not fit. Every row considered afterward — regardless
+  // of whether it would individually fit in what is left — is dropped, which is what keeps
+  // degradation a clean prefix cut instead of a hole partway through the block.
+  let cutoff = false;
+
+  const admit = (rows: number): boolean => {
+    if (cutoff || rows > remaining) {
+      cutoff = true;
+      return false;
+    }
+    remaining -= rows;
+    return true;
+  };
+
+  const rating = meta.rating && admit(1) ? `${meta.rating} / 10` : null;
+
+  const admitJoined = (values: readonly string[]): string | null => {
+    if (values.length === 0) return null; // absent, not a fit failure — does not trip the cutoff
+    const lines = wordWrapLines(values.join(", "), valueWidth);
+    return admit(lines.length) ? lines.join("\n") : null;
+  };
+
+  const genres = admitJoined(meta.genres);
+  const director = admitJoined(meta.director);
+  const cast = admitJoined(meta.cast);
+
+  // Not gated on `cutoff`: plot is exempt from the all-or-nothing rule above (it is the one row
+  // allowed to show a partial answer) and always sits last in the block, so it is free to absorb
+  // whatever budget a higher row's cutoff left unspent — that is still degrading from the bottom,
+  // not opening a hole, because nothing below plot exists to expose one.
+  let plot: string | null = null;
+  if (meta.plot && remaining > 0) {
+    const lines = wordWrapLines(meta.plot, valueWidth);
+    if (lines.length <= remaining) {
+      plot = lines.join("\n");
+    } else {
+      const kept = lines.slice(0, remaining);
+      const lastIndex = kept.length - 1;
+      const last = kept[lastIndex];
+      // `truncate()` only marks a line as cut when the line itself overruns `valueWidth`, but a
+      // hard-wrapped chunk is already sized to fit exactly — it never trips that check even
+      // though real text still follows it. The ellipsis has to be forced on here instead, or a
+      // capped plot reads as the *whole* plot rather than a fragment of one.
+      if (last !== undefined) {
+        kept[lastIndex] = `${last.slice(0, Math.max(0, valueWidth - 1))}…`;
+      }
+      plot = kept.join("\n");
+    }
+  }
+
+  return { rating, genres, director, cast, plot };
+}
+
+function Detail({ r, width, panelHeight }: { r: TorrentResult; width: number; panelHeight: number }) {
   const ss = sourceStyle(r.source);
   const date = formatRelative(r.added);
+  // No debounce: Enter is an explicit commit (unlike the list cursor sweeping past rows), and
+  // the cache behind this hook usually resolves the same title's earlier lookup instantly.
+  const { meta } = useResultMeta(r, true, 0);
+
+  // Same column math DetailRow itself uses (a fixed 9-wide label plus whatever remains), kept
+  // here too because planMetaRows needs it to know a value's wrapped line count before render.
+  const valueWidth = Math.max(1, width - 9);
+  // The four unconditional facts rows plus whichever of Files/Added this result actually has.
+  const factsRows = 4 + (r.numFiles ? 1 : 0) + (date ? 1 : 0);
+  // Fixed chrome that is never negotiable: title, rule, the blank line above the facts block,
+  // the blank line above the hint row, and the hint row itself.
+  const CHROME_ROWS = 5;
+  // Panel renders its own bottom border inside `panelHeight` (its top border is the separate
+  // title-bar row above it), so one row of that budget is never available to Detail's content.
+  const innerRows = Math.max(0, panelHeight - 1);
+  const metaBudget = Math.max(0, innerRows - CHROME_ROWS - factsRows);
+  const plan = planMetaRows(meta, valueWidth, metaBudget);
+
   const health =
     r.seeders || r.leechers ? (
       <Text>
@@ -91,6 +236,24 @@ function Detail({ r, width }: { r: TorrentResult; width: number }) {
             </Text>
           }
         />
+        {plan.rating !== null ? (
+          <DetailRow label="Rating" value={<Text dimColor>{plan.rating}</Text>} />
+        ) : null}
+        {plan.genres !== null ? (
+          <DetailRow label="Genres" value={<Text dimColor>{plan.genres}</Text>} />
+        ) : null}
+        {/* Cinemeta sends no director for most series — an empty row here would be a label with
+            nothing after it, so absence of data means absence of the row (planMetaRows never
+            admits an empty list in the first place). */}
+        {plan.director !== null ? (
+          <DetailRow label="Director" value={<Text dimColor>{plan.director}</Text>} />
+        ) : null}
+        {plan.cast !== null ? (
+          <DetailRow label="Cast" value={<Text dimColor>{plan.cast}</Text>} />
+        ) : null}
+        {plan.plot !== null ? (
+          <DetailRow label="Plot" value={<Text dimColor wrap="wrap">{plan.plot}</Text>} />
+        ) : null}
       </Box>
       <Box marginTop={1}>
         <Text color={COLOR.accent} bold>
@@ -407,7 +570,7 @@ export function Results() {
           height={panelOuter}
         >
           {mode === "detail" && detail ? (
-            <Detail r={detail} width={Math.max(10, contentWidth - 4)} />
+            <Detail r={detail} width={Math.max(10, contentWidth - 4)} panelHeight={panelOuter} />
           ) : (
             <>
               <Box>{status()}</Box>

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -12,10 +12,10 @@ import { getSource, SOURCES } from "../../sources/registry";
 import { stickCursor, wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
 import { filterResults } from "../filter";
-import { ellipsizeToWidth, LABEL_W, wordWrapLines } from "../textWidth";
+import { planMetaRows } from "../metaPlan";
+import { LABEL_W } from "../textWidth";
 import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
-import type { Meta } from "../../meta/types";
 import type { Source, TorrentResult } from "../../sources/types";
 
 type Mode = "list" | "search" | "detail" | "filter";
@@ -31,92 +31,6 @@ function DetailRow({ label, value }: { label: string; value: ReactNode }) {
       <Box flexGrow={1} minWidth={0}>{value}</Box>
     </Box>
   );
-}
-
-interface MetaPlan {
-  readonly rating: string | null;
-  readonly genres: string | null;
-  readonly director: string | null;
-  readonly cast: string | null;
-  readonly plot: string | null;
-}
-
-const NO_META_PLAN: MetaPlan = { rating: null, genres: null, director: null, cast: null, plot: null };
-
-/**
- * Decides which of the five metadata rows fit in `budget` terminal rows, in priority order —
- * rating, genres, director, cast, plot — so a tight panel sheds value from the metadata block
- * outward and never touches the torrent facts above it or the action hint below.
- *
- * Rating/genres/director/cast share one cutoff: the moment a *present* row among them fails to
- * fit, every one of them considered afterward is dropped too, even ones that would individually
- * have fit on their own — otherwise a wide-but-short row (say, three-name Director) could land
- * after a taller one it just displaced (six-genre Genres), which reads as a row missing from the
- * middle of that group rather than a clean cut at its end. A field that is simply absent from this
- * title's metadata (no director credited, most series) is not a fit failure and never triggers
- * that cutoff — only a row that exists but does not fit does. Among themselves, genres/director/
- * cast are also all-or-nothing: a cast list cut off mid-name reads as a bug, not a feature, so
- * each is only admitted if every one of its wrapped lines fits.
- *
- * Plot is deliberately exempt from that cutoff and always evaluated last, spending whatever
- * budget the rows above it left unclaimed — whether they used it in full or gave up on it early —
- * and ellipsizing its last visible line when the full text still does not fit. This is the one
- * place a real gap can appear: rating can end up directly above plot with genres, director and
- * cast all missing between them. That is an accepted tradeoff, not an oversight — capping the
- * plot, rather than truncating whichever all-or-nothing row happens to sit at the budget boundary,
- * is the chosen primary lever for a tight panel, and plot is the only row built to show less than
- * it has.
- */
-function planMetaRows(meta: Meta | null, valueWidth: number, budget: number): MetaPlan {
-  if (meta === null) return NO_META_PLAN;
-  let remaining = budget;
-  // Set the first time a present row does not fit. Every row considered afterward — regardless
-  // of whether it would individually fit in what is left — is dropped, which is what keeps
-  // degradation a clean prefix cut instead of a hole partway through the block.
-  let cutoff = false;
-
-  const admit = (rows: number): boolean => {
-    if (cutoff || rows > remaining) {
-      cutoff = true;
-      return false;
-    }
-    remaining -= rows;
-    return true;
-  };
-
-  const rating = meta.rating && admit(1) ? `${meta.rating} / 10` : null;
-
-  const admitJoined = (values: readonly string[]): string | null => {
-    if (values.length === 0) return null; // absent, not a fit failure — does not trip the cutoff
-    const lines = wordWrapLines(values.join(", "), valueWidth);
-    return admit(lines.length) ? lines.join("\n") : null;
-  };
-
-  const genres = admitJoined(meta.genres);
-  const director = admitJoined(meta.director);
-  const cast = admitJoined(meta.cast);
-
-  // Not gated on `cutoff` — see the doc comment above for why plot is the deliberate exception.
-  let plot: string | null = null;
-  if (meta.plot && remaining > 0) {
-    const lines = wordWrapLines(meta.plot, valueWidth);
-    if (lines.length <= remaining) {
-      plot = lines.join("\n");
-    } else {
-      const kept = lines.slice(0, remaining);
-      const lastIndex = kept.length - 1;
-      const last = kept[lastIndex];
-      // A hard-wrapped chunk is already sized to fit exactly, so it never looks "cut" on its own
-      // even though real text still follows it — the ellipsis has to be forced on here, or a
-      // capped plot reads as the whole plot rather than a fragment of one.
-      if (last !== undefined) {
-        kept[lastIndex] = ellipsizeToWidth(last, valueWidth);
-      }
-      plot = kept.join("\n");
-    }
-  }
-
-  return { rating, genres, director, cast, plot };
 }
 
 function Detail({ r, width, panelHeight }: { r: TorrentResult; width: number; panelHeight: number }) {

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -12,6 +12,7 @@ import { getSource, SOURCES } from "../../sources/registry";
 import { stickCursor, wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
 import { filterResults } from "../filter";
+import { ellipsizeToWidth, LABEL_W, wordWrapLines } from "../textWidth";
 import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
 import type { Meta } from "../../meta/types";
@@ -24,51 +25,12 @@ const PLACEHOLDER = "Search or paste a magnet link…";
 function DetailRow({ label, value }: { label: string; value: ReactNode }) {
   return (
     <Box>
-      <Box width={9} flexShrink={0}>
+      <Box width={LABEL_W} flexShrink={0}>
         <Text dimColor>{label}</Text>
       </Box>
       <Box flexGrow={1} minWidth={0}>{value}</Box>
     </Box>
   );
-}
-
-// Greedy word wrap, used only to learn — and pin — exactly how many terminal rows a value will
-// occupy before Ink ever lays it out. The detail panel has a fixed height (Panel's `height` prop,
-// clipped with `overflow: hidden`), and handing Ink's own `wrap="wrap"` more text than that
-// budget allows does not clip cleanly: Yoga's flexbox shrink squeezes whichever rows land on the
-// losing side of its shrink math, dropping or fusing rows anywhere in the block, including ones
-// above the actual overflow. Every metadata row rendered below is only rendered once it is known
-// to fit, which means knowing its line count first.
-//
-// A word longer than `width` (a Cinemeta plot has no guaranteed word length cap) is hard-broken
-// into `width`-sized chunks rather than left to overflow its own line — Ink's real wrap does the
-// same, and undercounting here is exactly what let a single unbroken run of text blow through a
-// budget that looked, on paper, like it had room to spare.
-function wordWrapLines(text: string, width: number): string[] {
-  if (width <= 0) return [text];
-  const words = text.split(/\s+/).filter(Boolean);
-  if (words.length === 0) return [];
-  const lines: string[] = [];
-  let line = "";
-  for (const word of words) {
-    let rest = word;
-    while (rest.length > width) {
-      if (line !== "") {
-        lines.push(line);
-        line = "";
-      }
-      lines.push(rest.slice(0, width));
-      rest = rest.slice(width);
-    }
-    if (line === "") line = rest;
-    else if (line.length + 1 + rest.length <= width) line += ` ${rest}`;
-    else {
-      lines.push(line);
-      line = rest;
-    }
-  }
-  if (line !== "") lines.push(line);
-  return lines;
 }
 
 interface MetaPlan {
@@ -83,23 +45,27 @@ const NO_META_PLAN: MetaPlan = { rating: null, genres: null, director: null, cas
 
 /**
  * Decides which of the five metadata rows fit in `budget` terminal rows, in priority order —
- * rating, genres, director, cast, plot — so a tight panel sheds value from the bottom of the
- * metadata block outward and never touches the torrent facts above it or the action hint below.
+ * rating, genres, director, cast, plot — so a tight panel sheds value from the metadata block
+ * outward and never touches the torrent facts above it or the action hint below.
  *
- * The moment one *present* row among rating/genres/director/cast fails to fit, every one of that
- * group considered afterward is dropped too, even ones that would individually have fit on their
- * own — otherwise a wide-but-short row (say, three-name Director) could land after a taller one it
- * just displaced (six-genre Genres), which reads as a row missing from the middle of the block
- * rather than a clean cut at the bottom. A field that is simply absent from this title's metadata
- * (no director credited, most series) is not a fit failure and never triggers that cutoff — only a
- * row that exists but does not fit does.
+ * Rating/genres/director/cast share one cutoff: the moment a *present* row among them fails to
+ * fit, every one of them considered afterward is dropped too, even ones that would individually
+ * have fit on their own — otherwise a wide-but-short row (say, three-name Director) could land
+ * after a taller one it just displaced (six-genre Genres), which reads as a row missing from the
+ * middle of that group rather than a clean cut at its end. A field that is simply absent from this
+ * title's metadata (no director credited, most series) is not a fit failure and never triggers
+ * that cutoff — only a row that exists but does not fit does. Among themselves, genres/director/
+ * cast are also all-or-nothing: a cast list cut off mid-name reads as a bug, not a feature, so
+ * each is only admitted if every one of its wrapped lines fits.
  *
- * Genres/director/cast are all-or-nothing: a cast list cut off mid-name reads as a bug, not a
- * feature, so each is only admitted if every one of its wrapped lines fits. Plot is exempt from
- * that cutoff and always evaluated last — it is the one row allowed to show less than it has, so
- * it takes whatever budget the rows above it left unspent (whether they filled it or gave up on
- * it) and ellipsizes its last visible line when the full text still does not fit. Sitting at the
- * very bottom of the block, plot has nothing below it to expose as a hole.
+ * Plot is deliberately exempt from that cutoff and always evaluated last, spending whatever
+ * budget the rows above it left unclaimed — whether they used it in full or gave up on it early —
+ * and ellipsizing its last visible line when the full text still does not fit. This is the one
+ * place a real gap can appear: rating can end up directly above plot with genres, director and
+ * cast all missing between them. That is an accepted tradeoff, not an oversight — capping the
+ * plot, rather than truncating whichever all-or-nothing row happens to sit at the budget boundary,
+ * is the chosen primary lever for a tight panel, and plot is the only row built to show less than
+ * it has.
  */
 function planMetaRows(meta: Meta | null, valueWidth: number, budget: number): MetaPlan {
   if (meta === null) return NO_META_PLAN;
@@ -130,10 +96,7 @@ function planMetaRows(meta: Meta | null, valueWidth: number, budget: number): Me
   const director = admitJoined(meta.director);
   const cast = admitJoined(meta.cast);
 
-  // Not gated on `cutoff`: plot is exempt from the all-or-nothing rule above (it is the one row
-  // allowed to show a partial answer) and always sits last in the block, so it is free to absorb
-  // whatever budget a higher row's cutoff left unspent — that is still degrading from the bottom,
-  // not opening a hole, because nothing below plot exists to expose one.
+  // Not gated on `cutoff` — see the doc comment above for why plot is the deliberate exception.
   let plot: string | null = null;
   if (meta.plot && remaining > 0) {
     const lines = wordWrapLines(meta.plot, valueWidth);
@@ -143,12 +106,11 @@ function planMetaRows(meta: Meta | null, valueWidth: number, budget: number): Me
       const kept = lines.slice(0, remaining);
       const lastIndex = kept.length - 1;
       const last = kept[lastIndex];
-      // `truncate()` only marks a line as cut when the line itself overruns `valueWidth`, but a
-      // hard-wrapped chunk is already sized to fit exactly — it never trips that check even
-      // though real text still follows it. The ellipsis has to be forced on here instead, or a
-      // capped plot reads as the *whole* plot rather than a fragment of one.
+      // A hard-wrapped chunk is already sized to fit exactly, so it never looks "cut" on its own
+      // even though real text still follows it — the ellipsis has to be forced on here, or a
+      // capped plot reads as the whole plot rather than a fragment of one.
       if (last !== undefined) {
-        kept[lastIndex] = `${last.slice(0, Math.max(0, valueWidth - 1))}…`;
+        kept[lastIndex] = ellipsizeToWidth(last, valueWidth);
       }
       plot = kept.join("\n");
     }
@@ -164,9 +126,9 @@ function Detail({ r, width, panelHeight }: { r: TorrentResult; width: number; pa
   // the cache behind this hook usually resolves the same title's earlier lookup instantly.
   const { meta } = useResultMeta(r, true, 0);
 
-  // Same column math DetailRow itself uses (a fixed 9-wide label plus whatever remains), kept
-  // here too because planMetaRows needs it to know a value's wrapped line count before render.
-  const valueWidth = Math.max(1, width - 9);
+  // Same column math DetailRow itself uses (LABEL_W plus whatever remains), needed here because
+  // planMetaRows must know a value's wrapped line count before render.
+  const valueWidth = Math.max(1, width - LABEL_W);
   // The four unconditional facts rows plus whichever of Files/Added this result actually has.
   const factsRows = 4 + (r.numFiles ? 1 : 0) + (date ? 1 : 0);
   // Fixed chrome that is never negotiable: title, rule, the blank line above the facts block,

--- a/src/ui/dedupe.test.ts
+++ b/src/ui/dedupe.test.ts
@@ -69,13 +69,16 @@ describe("dedupeResults", () => {
     expect(new Set(tr).size).toBe(tr.length);
   });
 
-  it("backfills numFiles and added only where the winner has none", () => {
+  it("backfills numFiles, added and imdbId only where the winner has none", () => {
     const out = dedupeResults([
       row({ source: "yts", seeders: 90, added: 1_700_000_000 }),
-      row({ source: "eztv", seeders: 3, numFiles: 7, added: 1_600_000_000 }),
+      row({ source: "eztv", seeders: 3, numFiles: 7, added: 1_600_000_000, imdbId: "tt0133093" }),
     ]);
     expect(out[0]!.numFiles).toBe(7);
     expect(out[0]!.added).toBe(1_700_000_000);
+    // The healthiest row is routinely one from a source that carries no id at all, so the
+    // winner losing the loser's imdbId is the common case, not the corner.
+    expect(out[0]!.imdbId).toBe("tt0133093");
   });
 
   it("keeps the first row when seeders tie", () => {

--- a/src/ui/dedupe.ts
+++ b/src/ui/dedupe.ts
@@ -11,8 +11,10 @@ import type { TorrentResult } from "../sources/types";
 //     defaults, so keeping the higher-seeder row alone can trade a working
 //     announce list for a generic one. Same loss #146 fixed for a .torrent
 //     file's own trackers.
-//   - numFiles and added, but only where the winner has none. A field the
-//     winner never reported is a gap, not a decision.
+//   - numFiles, added and imdbId, but only where the winner has none. A field
+//     the winner never reported is a gap, not a decision — and an imdbId is
+//     worth more than a blank column, since losing it sends the metadata
+//     lookup back to guessing a title from the release name.
 //
 // Everything else stays the winner's, including its magnet URI byte for byte.
 function merge(a: TorrentResult, b: TorrentResult): TorrentResult {
@@ -22,6 +24,7 @@ function merge(a: TorrentResult, b: TorrentResult): TorrentResult {
     magnet: mergeMagnetTrackers(win.magnet, [lost.magnet]),
     numFiles: win.numFiles ?? lost.numFiles,
     added: win.added ?? lost.added,
+    imdbId: win.imdbId ?? lost.imdbId,
   };
 }
 

--- a/src/ui/hooks/useResultMeta.test.tsx
+++ b/src/ui/hooks/useResultMeta.test.tsx
@@ -58,7 +58,14 @@ function Probe({
   return <Text>{loading ? "LOADING" : (found?.title ?? "NONE")}</Text>;
 }
 
-/** Let Ink flush a render and any timer shorter than `ms`. */
+/**
+ * Let Ink flush a render and any timer shorter than `ms`.
+ *
+ * Only for the waits that are *purely negative* — "nothing happened", "it did not ask again" —
+ * and for the debounces, which are wall-clock facts by construction. Anything positive waits on
+ * the fact itself with `vi.waitFor`, because a fixed sleep is a guess about how long a loaded
+ * machine takes to settle a promise, and a wrong guess is a test that fails for no reason.
+ */
 function tick(ms = 0): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));
 }
@@ -88,16 +95,21 @@ describe("useResultMeta", () => {
 
     const ui = renderUI(<Probe first={ALPHA} debounceMs={0} />);
     try {
-      await tick(5);
-      expect(mockLookup).toHaveBeenCalledTimes(1);
+      // The lookup is fired from a timer inside the effect, so it cannot have happened by the
+      // time render() returns — this waits on a fact the mount frame does not already show.
+      await vi.waitFor(() => expect(mockLookup).toHaveBeenCalledTimes(1));
       expect(mockLookup.mock.calls[0]?.[0]).toBe(ALPHA);
 
       swap?.(BRAVO);
-      await tick(5);
-      expect(ui.frame()).toContain("Bravo");
+      // Alpha is still pending, so the frame reads LOADING until Bravo's own lookup settles.
+      await vi.waitFor(() => expect(ui.frame()).toContain("Bravo"));
 
       // Alpha's request finally comes back, long after the user moved on.
       slow.settle(meta("Alpha"));
+      // Purely negative, with no positive fact to pin it: the point is that the late resolution
+      // changes nothing, so a waitFor would pass on its first attempt and prove nothing. A real
+      // sleep instead — the same precedent as MetaPane's unfocused-keys test — giving the
+      // resolution every chance to land in the state Bravo is rendering.
       await tick(5);
       expect(ui.frame()).toContain("Bravo");
       expect(ui.frame()).not.toContain("Alpha");
@@ -110,13 +122,14 @@ describe("useResultMeta", () => {
     mockLookup.mockReturnValue(deferred().promise);
     const ui = renderUI(<Probe first={ALPHA} debounceMs={0} />);
     try {
-      await tick(5);
+      await vi.waitFor(() => expect(mockLookup).toHaveBeenCalledTimes(1));
       const signal = mockLookup.mock.calls[0]?.[1]?.signal;
       expect(signal?.aborted).toBe(false);
 
       swap?.(BRAVO);
-      await tick(5);
-      expect(signal?.aborted).toBe(true);
+      // The abort comes from the effect cleanup, which React runs on the render the swap
+      // schedules rather than synchronously inside it — so this still has something to wait for.
+      await vi.waitFor(() => expect(signal?.aborted).toBe(true));
     } finally {
       ui.unmount();
     }
@@ -128,6 +141,9 @@ describe("useResultMeta", () => {
     // A debounce long enough that anything reaching the network would still be waiting.
     const ui = renderUI(<Probe first={ALPHA} debounceMs={5000} />);
     try {
+      // A cache hit is served synchronously inside the effect, so there is no intermediate state
+      // to wait on and every assertion below is a negative. A real sleep instead: it gives a hook
+      // that wrongly armed the timer or the request the chance to show it.
       await tick(5);
       expect(ui.frame()).toContain("Charlie");
       expect(ui.frame()).not.toContain("LOADING");
@@ -143,6 +159,9 @@ describe("useResultMeta", () => {
     mockPeek.mockReturnValue(null);
     const ui = renderUI(<Probe first={ALPHA} debounceMs={5000} />);
     try {
+      // "NONE" is what the mount frame already shows, so waiting for it would resolve on the
+      // first attempt and prove nothing. A real sleep, as in the cached-hit test above: a hook
+      // that treated the cached null as unanswered would replace it with LOADING in that window.
       await tick(5);
       expect(ui.frame()).toContain("NONE");
       expect(mockLookup).not.toHaveBeenCalled();
@@ -157,6 +176,9 @@ describe("useResultMeta", () => {
     expect(mockLookup).not.toHaveBeenCalled();
 
     ui.unmount();
+    // Both waits are negative, and both are wall-clock by construction: the second has to outlive
+    // the 60 ms the cancelled timer would have fired at. A sleep can only ever overshoot on a
+    // loaded machine, which is the harmless direction for "still not called".
     await tick(120);
     expect(mockLookup).not.toHaveBeenCalled();
   });
@@ -164,10 +186,13 @@ describe("useResultMeta", () => {
   it("waits out the debounce before asking, then asks once", async () => {
     const ui = renderUI(<Probe first={ALPHA} debounceMs={40} />);
     try {
+      // The one wait in this file that a loaded machine can overshoot into failing: 5 ms is a
+      // fraction of the 40 ms debounce, but only the clock says so. There is nothing else to
+      // wait on — "has not asked yet" is exactly a negative — and fake timers would take the
+      // debounce out of the test entirely.
       await tick(5);
       expect(mockLookup).not.toHaveBeenCalled();
-      await tick(80);
-      expect(mockLookup).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(mockLookup).toHaveBeenCalledTimes(1));
     } finally {
       ui.unmount();
     }
@@ -176,24 +201,28 @@ describe("useResultMeta", () => {
   it("keys on the infoHash, so a re-sorted list does not retrigger", async () => {
     const ui = renderUI(<Probe first={ALPHA} debounceMs={0} />);
     try {
-      await tick(5);
-      expect(mockLookup).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(mockLookup).toHaveBeenCalledTimes(1));
 
       // What a streaming re-sort produces: an equal row with a fresh object identity.
       swap?.({ ...ALPHA });
+      // Negative — "it did not ask again" — so a real sleep, long enough that a retrigger would
+      // have run its zero-length debounce and bumped the count this line reads.
       await tick(5);
       expect(mockLookup).toHaveBeenCalledTimes(1);
 
       // And the counter is not simply stuck — a genuinely different row does retrigger.
       swap?.(BRAVO);
-      await tick(5);
-      expect(mockLookup).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => expect(mockLookup).toHaveBeenCalledTimes(2));
     } finally {
       ui.unmount();
     }
   });
 
   it("asks for nothing while disabled or with no row", async () => {
+    // Both shapes take the effect's early return, which sets IDLE synchronously — the same state,
+    // and the same "NONE" frame, the probe already renders on mount. Nothing here is asynchronous
+    // and every assertion is a negative, so a waitFor could only pass on its first attempt. Real
+    // sleeps instead: a hook that wrongly asked has a whole debounce-free window to prove it.
     const off = renderUI(<Probe first={ALPHA} debounceMs={0} enabled={false} />);
     await tick(5);
     expect(off.frame()).toContain("NONE");

--- a/src/ui/hooks/useResultMeta.test.tsx
+++ b/src/ui/hooks/useResultMeta.test.tsx
@@ -1,0 +1,209 @@
+import { Text } from "ink";
+import { useEffect, useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { lookupMeta, peekMeta } from "../../meta/lookup";
+import { renderUI } from "../testHarness";
+import { useResultMeta } from "./useResultMeta";
+import type { ReactElement } from "react";
+import type { Meta } from "../../meta/types";
+import type { TorrentResult } from "../../sources/types";
+
+// The orchestrator is mocked so these tests are about the hook's own contract — which row it asks
+// for, when it asks, and whose answer it is allowed to render.
+vi.mock("../../meta/lookup", () => ({ peekMeta: vi.fn(), lookupMeta: vi.fn() }));
+
+const mockPeek = vi.mocked(peekMeta);
+const mockLookup = vi.mocked(lookupMeta);
+
+function row(infoHash: string, name: string): TorrentResult {
+  return {
+    infoHash,
+    name,
+    sizeBytes: 2.1e9,
+    seeders: 40,
+    leechers: 6,
+    source: "yts",
+    magnet: `magnet:?xt=urn:btih:${infoHash}`,
+  };
+}
+
+function meta(title: string): Meta {
+  return { imdbId: "tt1234567", kind: "movie", title, genres: [], cast: [], director: [] };
+}
+
+const ALPHA = row("h-alpha", "Alpha (2019) [1080p]");
+const BRAVO = row("h-bravo", "Bravo (2020) [1080p]");
+
+// The probe exposes its row setter so a test can change the selection the way the results list
+// does, without needing a rerender handle the shared harness does not provide.
+let swap: ((r: TorrentResult | null) => void) | null = null;
+
+function Probe({
+  first,
+  debounceMs,
+  enabled = true,
+}: {
+  first: TorrentResult | null;
+  debounceMs: number;
+  enabled?: boolean;
+}): ReactElement {
+  const [r, setR] = useState<TorrentResult | null>(first);
+  useEffect(() => {
+    swap = setR;
+    return () => {
+      swap = null;
+    };
+  }, []);
+  const { loading, meta: found } = useResultMeta(r, enabled, debounceMs);
+  return <Text>{loading ? "LOADING" : (found?.title ?? "NONE")}</Text>;
+}
+
+/** Let Ink flush a render and any timer shorter than `ms`. */
+function tick(ms = 0): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+function deferred(): { promise: Promise<Meta | null>; settle: (m: Meta | null) => void } {
+  let settle: (m: Meta | null) => void = () => {};
+  const promise = new Promise<Meta | null>((res) => {
+    settle = res;
+  });
+  return { promise, settle };
+}
+
+beforeEach(() => {
+  swap = null;
+  mockPeek.mockReset();
+  mockLookup.mockReset();
+  mockPeek.mockReturnValue(undefined);
+  mockLookup.mockResolvedValue(null);
+});
+
+describe("useResultMeta", () => {
+  it("never renders one row's metadata against another row", async () => {
+    // The `alive` flag is the only thing enforcing this. Cache keys make the cache correct; they
+    // do nothing to stop a late resolution landing in the state a different row is rendering.
+    const slow = deferred();
+    mockLookup.mockReturnValueOnce(slow.promise).mockResolvedValue(meta("Bravo"));
+
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={0} />);
+    try {
+      await tick(5);
+      expect(mockLookup).toHaveBeenCalledTimes(1);
+      expect(mockLookup.mock.calls[0]?.[0]).toBe(ALPHA);
+
+      swap?.(BRAVO);
+      await tick(5);
+      expect(ui.frame()).toContain("Bravo");
+
+      // Alpha's request finally comes back, long after the user moved on.
+      slow.settle(meta("Alpha"));
+      await tick(5);
+      expect(ui.frame()).toContain("Bravo");
+      expect(ui.frame()).not.toContain("Alpha");
+    } finally {
+      ui.unmount();
+    }
+  });
+
+  it("aborts the in-flight lookup when the row changes", async () => {
+    mockLookup.mockReturnValue(deferred().promise);
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={0} />);
+    try {
+      await tick(5);
+      const signal = mockLookup.mock.calls[0]?.[1]?.signal;
+      expect(signal?.aborted).toBe(false);
+
+      swap?.(BRAVO);
+      await tick(5);
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      ui.unmount();
+    }
+  });
+
+  it("renders a cached row with no timer and no request", async () => {
+    mockPeek.mockReturnValue(meta("Charlie"));
+
+    // A debounce long enough that anything reaching the network would still be waiting.
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={5000} />);
+    try {
+      await tick(5);
+      expect(ui.frame()).toContain("Charlie");
+      expect(ui.frame()).not.toContain("LOADING");
+      expect(mockLookup).not.toHaveBeenCalled();
+    } finally {
+      ui.unmount();
+    }
+  });
+
+  it("renders a cached miss as a final answer, not as loading", async () => {
+    // peekMeta answers null for a row that can never be queried at all, so the spinner would
+    // otherwise never end.
+    mockPeek.mockReturnValue(null);
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={5000} />);
+    try {
+      await tick(5);
+      expect(ui.frame()).toContain("NONE");
+      expect(mockLookup).not.toHaveBeenCalled();
+    } finally {
+      ui.unmount();
+    }
+  });
+
+  it("issues no lookup when the row is left before the debounce elapses", async () => {
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={60} />);
+    await tick(5);
+    expect(mockLookup).not.toHaveBeenCalled();
+
+    ui.unmount();
+    await tick(120);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it("waits out the debounce before asking, then asks once", async () => {
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={40} />);
+    try {
+      await tick(5);
+      expect(mockLookup).not.toHaveBeenCalled();
+      await tick(80);
+      expect(mockLookup).toHaveBeenCalledTimes(1);
+    } finally {
+      ui.unmount();
+    }
+  });
+
+  it("keys on the infoHash, so a re-sorted list does not retrigger", async () => {
+    const ui = renderUI(<Probe first={ALPHA} debounceMs={0} />);
+    try {
+      await tick(5);
+      expect(mockLookup).toHaveBeenCalledTimes(1);
+
+      // What a streaming re-sort produces: an equal row with a fresh object identity.
+      swap?.({ ...ALPHA });
+      await tick(5);
+      expect(mockLookup).toHaveBeenCalledTimes(1);
+
+      // And the counter is not simply stuck — a genuinely different row does retrigger.
+      swap?.(BRAVO);
+      await tick(5);
+      expect(mockLookup).toHaveBeenCalledTimes(2);
+    } finally {
+      ui.unmount();
+    }
+  });
+
+  it("asks for nothing while disabled or with no row", async () => {
+    const off = renderUI(<Probe first={ALPHA} debounceMs={0} enabled={false} />);
+    await tick(5);
+    expect(off.frame()).toContain("NONE");
+    expect(mockPeek).not.toHaveBeenCalled();
+    expect(mockLookup).not.toHaveBeenCalled();
+    off.unmount();
+
+    const empty = renderUI(<Probe first={null} debounceMs={0} />);
+    await tick(5);
+    expect(mockLookup).not.toHaveBeenCalled();
+    empty.unmount();
+  });
+});

--- a/src/ui/hooks/useResultMeta.ts
+++ b/src/ui/hooks/useResultMeta.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from "react";
+import { lookupMeta, peekMeta } from "../../meta/lookup";
+import type { Meta } from "../../meta/types";
+import type { TorrentResult } from "../../sources/types";
+
+export interface MetaState {
+  loading: boolean;
+  meta: Meta | null;
+}
+
+// The user is scrolling a list; every row they pass through is a candidate lookup they did not
+// ask for. Waiting this long before firing means holding an arrow key down costs zero requests,
+// and a deliberate stop on a row still feels immediate.
+const DEBOUNCE_MS = 250;
+
+const IDLE: MetaState = { loading: false, meta: null };
+
+/**
+ * Metadata for the currently interesting row, fetched lazily and cancelled the moment it stops
+ * being interesting.
+ *
+ * `enabled` exists so a caller can keep the hook mounted (hooks cannot be called conditionally)
+ * while the pane that wants the data is closed.
+ */
+export function useResultMeta(
+  result: TorrentResult | null,
+  enabled: boolean,
+  debounceMs?: number,
+): MetaState {
+  const [state, setState] = useState<MetaState>(IDLE);
+
+  // The effect keys on the infoHash, not the row object, so the streaming re-sorts in Results
+  // cannot restart a lookup that is already in flight. It still needs the row itself to run the
+  // lookup, and reading it through a ref keeps that out of the dependency list — two objects with
+  // the same infoHash are the same torrent, so the latest one is always safe to use.
+  const latest = useRef(result);
+  latest.current = result;
+
+  const infoHash = result?.infoHash;
+
+  useEffect(() => {
+    const row = latest.current;
+    if (!enabled || row === null || row === undefined) {
+      setState(IDLE);
+      return;
+    }
+
+    // Synchronous cache read first: a row we already resolved (or already know we never will)
+    // renders its answer immediately instead of flashing a spinner on every revisit.
+    const cached = peekMeta(row);
+    if (cached !== undefined) {
+      setState({ loading: false, meta: cached });
+      return;
+    }
+
+    setState({ loading: true, meta: null });
+
+    let alive = true;
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => {
+      void lookupMeta(row, { signal: ctrl.signal })
+        .then((meta) => {
+          // The row changed under us while the request was in flight; its state belongs to
+          // whichever effect is current, not to this one.
+          if (alive) setState({ loading: false, meta });
+        })
+        .catch(() => {
+          // lookupMeta already swallows its own failures. Belt and braces: an unhandled rejection
+          // from a render path is a crashed TUI.
+          if (alive) setState(IDLE);
+        });
+    }, debounceMs ?? DEBOUNCE_MS);
+
+    return () => {
+      alive = false;
+      ctrl.abort();
+      clearTimeout(timer);
+    };
+  }, [infoHash, enabled, debounceMs]);
+
+  return state;
+}

--- a/src/ui/metaPlan.test.ts
+++ b/src/ui/metaPlan.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { NO_META_PLAN, planMetaRows } from "./metaPlan";
+import { displayWidth } from "./textWidth";
+import type { Meta } from "../meta/types";
+
+// The detail panel's row-budget arithmetic without a render: Results.test.tsx proves the panel
+// draws what it is given, and these prove what it is given. A wrapped credit that costs two rows
+// instead of one is a fused row in the panel, which is the hardest failure to read off a rendered
+// snapshot.
+const META: Meta = {
+  imdbId: "tt0111161",
+  kind: "movie",
+  title: "The Shawshank Redemption",
+  year: "1994",
+  rating: "9.3",
+  runtime: "142 min",
+  genres: ["Drama"],
+  cast: ["Neo"],
+  director: ["Frank Darabont"],
+  plot: "A banker convicted of murdering his wife forms a friendship over a number of years.",
+};
+
+const WIDTH = 30;
+const INFINITE = Number.POSITIVE_INFINITY;
+
+describe("planMetaRows", () => {
+  it("answers every field null when there is no metadata to plan", () => {
+    expect(planMetaRows(null, WIDTH, INFINITE)).toEqual(NO_META_PLAN);
+  });
+
+  it("builds every row when nothing is competing for rows", () => {
+    const plan = planMetaRows(META, WIDTH, INFINITE);
+    expect(plan.rating).toBe("9.3 / 10");
+    expect(plan.genres).toBe("Drama");
+    expect(plan.director).toBe("Frank Darabont");
+    expect(plan.cast).toBe("Neo");
+    // Wrapped to this width, so compare against the wrap-normalized text rather than the raw
+    // single-line source.
+    expect(plan.plot?.replace(/\n/g, " ")).toBe(META.plot);
+  });
+
+  it("answers an empty plan for a budget with no rows to give", () => {
+    expect(planMetaRows(META, WIDTH, 0)).toEqual(NO_META_PLAN);
+    expect(planMetaRows(META, WIDTH, -3)).toEqual(NO_META_PLAN);
+  });
+
+  it("spends the budget in priority order — rating, then genres, then director, then cast", () => {
+    // Each of these four rows costs exactly one line at this fixture and width.
+    expect(planMetaRows(META, WIDTH, 1)).toMatchObject({
+      rating: "9.3 / 10",
+      genres: null,
+      director: null,
+      cast: null,
+    });
+    expect(planMetaRows(META, WIDTH, 2)).toMatchObject({
+      rating: "9.3 / 10",
+      genres: "Drama",
+      director: null,
+      cast: null,
+    });
+    expect(planMetaRows(META, WIDTH, 3)).toMatchObject({
+      rating: "9.3 / 10",
+      genres: "Drama",
+      director: "Frank Darabont",
+      cast: null,
+    });
+  });
+
+  it("treats a field the result never carried as absent, not as a fit failure", () => {
+    const noRating: Meta = { ...META, rating: undefined };
+    const plan = planMetaRows(noRating, WIDTH, 3);
+    // Genres, director and cast all fit in the three rows a missing rating never claimed.
+    expect(plan).toMatchObject({ rating: null, genres: "Drama", director: "Frank Darabont", cast: "Neo" });
+  });
+
+  it("holds the cutoff once a present row does not fit, even for a shorter row right after it", () => {
+    // Two directors wrap to two lines at this width; the cast credit right after it would fit
+    // in the one row left over on its own, but the cutoff a two-row overflow triggers drops it
+    // too rather than leaving a hole where director should have been.
+    const wideDirector: Meta = { ...META, director: ["Christopher Alexander Nolan", "Peter Jackson"] };
+    const plan = planMetaRows(wideDirector, WIDTH, 3);
+    expect(plan.rating).toBe("9.3 / 10");
+    expect(plan.genres).toBe("Drama");
+    expect(plan.director).toBeNull();
+    expect(plan.cast).toBeNull();
+  });
+
+  it("still gives the plot the row a dropped credit left unclaimed", () => {
+    // Same fixture as the cutoff test above: director's failed attempt never spent the one row
+    // left after rating and genres, so plot — exempt from the cutoff — gets to spend it.
+    const wideDirector: Meta = { ...META, director: ["Christopher Alexander Nolan", "Peter Jackson"] };
+    const plan = planMetaRows(wideDirector, WIDTH, 3);
+    expect(plan.plot).not.toBeNull();
+    expect(displayWidth(plan.plot ?? "")).toBeLessThanOrEqual(WIDTH);
+  });
+
+  it("omits the plot row entirely when the rows above it spent everything", () => {
+    expect(planMetaRows(META, WIDTH, 4).plot).toBeNull();
+  });
+
+  it("ellipsizes the plot's last line rather than dropping it whole", () => {
+    const longPlot: Meta = {
+      ...META,
+      plot:
+        "A computer hacker learns from mysterious rebels about the true nature of his reality and " +
+        "his role in the war against its controllers, who farm humanity in a simulated world.",
+    };
+    const plan = planMetaRows(longPlot, WIDTH, 6);
+    expect(plan.plot).toContain("…");
+    for (const line of plan.plot?.split("\n") ?? []) {
+      expect(displayWidth(line)).toBeLessThanOrEqual(WIDTH);
+    }
+  });
+
+  it("never spends more rows than it was given", () => {
+    const rowsOf = (plan: ReturnType<typeof planMetaRows>): number =>
+      [plan.rating, plan.genres, plan.director, plan.cast, plan.plot]
+        .filter((v): v is string => v !== null)
+        .reduce((n, v) => n + v.split("\n").length, 0);
+    for (let budget = 0; budget <= 8; budget++) {
+      expect(rowsOf(planMetaRows(META, WIDTH, budget)), `budget ${budget}`).toBeLessThanOrEqual(budget);
+    }
+  });
+});

--- a/src/ui/metaPlan.ts
+++ b/src/ui/metaPlan.ts
@@ -1,0 +1,102 @@
+/**
+ * The detail panel's metadata rows: which of the five fields fit in a fixed row budget.
+ *
+ * A pure module the component and its tests both read from, mirroring paneCard.ts — the same
+ * budgeted-degradation problem, one level down. paneCard.ts plans the *pane's* card; this plans
+ * the *detail panel's* rows.
+ */
+
+import { ellipsizeToWidth, wordWrapLines } from "./textWidth";
+import type { Meta } from "../meta/types";
+
+export interface MetaPlan {
+  readonly rating: string | null;
+  readonly genres: string | null;
+  readonly director: string | null;
+  readonly cast: string | null;
+  readonly plot: string | null;
+}
+
+export const NO_META_PLAN: MetaPlan = {
+  rating: null,
+  genres: null,
+  director: null,
+  cast: null,
+  plot: null,
+};
+
+/**
+ * Decides which of the five metadata rows fit in `budget` terminal rows, in priority order —
+ * rating, genres, director, cast, plot — so a tight panel sheds value from the metadata block
+ * outward and never touches the torrent facts above it or the action hint below.
+ *
+ * Rating/genres/director/cast share one cutoff: the moment a *present* row among them fails to
+ * fit, every one of them considered afterward is dropped too, even ones that would individually
+ * have fit on their own — otherwise a wide-but-short row (say, three-name Director) could land
+ * after a taller one it just displaced (six-genre Genres), which reads as a row missing from the
+ * middle of that group rather than a clean cut at its end. A field that is simply absent from this
+ * title's metadata (no director credited, most series) is not a fit failure and never triggers
+ * that cutoff — only a row that exists but does not fit does. Among themselves, genres/director/
+ * cast are also all-or-nothing: a cast list cut off mid-name reads as a bug, not a feature, so
+ * each is only admitted if every one of its wrapped lines fits.
+ *
+ * Plot is deliberately exempt from that cutoff and always evaluated last, spending whatever
+ * budget the rows above it left unclaimed — whether they used it in full or gave up on it early —
+ * and ellipsizing its last visible line when the full text still does not fit. This is the one
+ * place a real gap can appear: rating can end up directly above plot with genres, director and
+ * cast all missing between them. That is an accepted tradeoff, not an oversight — capping the
+ * plot, rather than truncating whichever all-or-nothing row happens to sit at the budget boundary,
+ * is the chosen primary lever for a tight panel, and plot is the only row built to show less than
+ * it has.
+ */
+export function planMetaRows(meta: Meta | null, valueWidth: number, budget: number): MetaPlan {
+  if (meta === null) return NO_META_PLAN;
+  let remaining = budget;
+  // Set the first time a present row does not fit. Every row considered afterward — regardless
+  // of whether it would individually fit in what is left — is dropped, which is what keeps
+  // degradation a clean prefix cut instead of a hole partway through the block.
+  let cutoff = false;
+
+  const admit = (rows: number): boolean => {
+    if (cutoff || rows > remaining) {
+      cutoff = true;
+      return false;
+    }
+    remaining -= rows;
+    return true;
+  };
+
+  const rating = meta.rating && admit(1) ? `${meta.rating} / 10` : null;
+
+  const admitJoined = (values: readonly string[]): string | null => {
+    if (values.length === 0) return null; // absent, not a fit failure — does not trip the cutoff
+    const lines = wordWrapLines(values.join(", "), valueWidth);
+    return admit(lines.length) ? lines.join("\n") : null;
+  };
+
+  const genres = admitJoined(meta.genres);
+  const director = admitJoined(meta.director);
+  const cast = admitJoined(meta.cast);
+
+  // Not gated on `cutoff` — see the doc comment above for why plot is the deliberate exception.
+  let plot: string | null = null;
+  if (meta.plot && remaining > 0) {
+    const lines = wordWrapLines(meta.plot, valueWidth);
+    if (lines.length <= remaining) {
+      plot = lines.join("\n");
+    } else {
+      const kept = lines.slice(0, remaining);
+      const lastIndex = kept.length - 1;
+      const last = kept[lastIndex];
+      // A hard-wrapped chunk is already sized to fit exactly, so it never looks "cut" on its own
+      // even though real text still follows it — the ellipsis has to be forced on here, or a
+      // capped plot reads as the whole plot rather than a fragment of one.
+      if (last !== undefined) {
+        kept[lastIndex] = ellipsizeToWidth(last, valueWidth);
+      }
+      plot = kept.join("\n");
+    }
+  }
+
+  return { rating, genres, director, cast, plot };
+}

--- a/src/ui/textWidth.test.ts
+++ b/src/ui/textWidth.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { codePointWidth } from "./textWidth";
+
+// Astral code points (emoji outside the BMP, CJK Extension B+ ideographs) get no free ride from
+// `.length` the way a BMP character never did either — `for...of` yields one code point per
+// surrogate pair, so an unlisted astral range undercounts exactly like an unlisted BMP one. A
+// prior version of this file's width table left every astral range out on the theory that
+// `.length` already "handled" them, which reproduced the original Critical bug on emoji plots.
+describe("terminal column width", () => {
+  it("measures the full reviewer-named spread of wide and narrow code points correctly", () => {
+    // Wide: astral emoji/pictographs, BMP dingbat emoji scattered through U+231A..U+2B55, a rare
+    // astral CJK ideograph (Extension B), a Vertical Forms code point, plus one representative
+    // each of Hangul Jamo, CJK unified ideographs and Hangul syllables.
+    const wide = [
+      0x1f3ac, // 🎬 clapper board (astral emoji)
+      0x2b50, // ⭐ star (BMP emoji)
+      0x2705, // ✅ check mark button
+      0x2757, // ❗ heavy exclamation mark
+      0x2b1b, // ⬛ black large square
+      0x231a, // ⌚ watch
+      0x20000, // 𠀀 CJK unified ideographs extension B
+      0xfe10, // ︐ presentation form for vertical comma
+      0x4e00, // 一 CJK unified ideographs
+      0xac00, // 가 Hangul syllable
+    ];
+    // Narrow: this app's own border/pointer characters (the regression a too-broad wide range
+    // caused in an earlier draft of this table), halfwidth katakana, and a spread of non-CJK
+    // scripts that must never be measured as wide.
+    const narrow = [
+      0x2500, // ─ box drawings light horizontal (this app's own panel border)
+      0x2502, // │ box drawings light vertical
+      0x276f, // ❯ heavy right-pointing angle quotation mark ornament (list cursor)
+      0x61, // a
+      0xff71, // ｱ halfwidth katakana A
+      0xff61, // ｡ halfwidth ideographic full stop
+      0x439, // й Cyrillic
+      0x3b1, // α Greek
+      0xe9, // é Latin-1
+      0x5d0, // א Hebrew
+      0x627, // ا Arabic
+      0xe01, // ก Thai
+    ];
+    for (const cp of wide) {
+      expect(codePointWidth(String.fromCodePoint(cp)), `U+${cp.toString(16)} should be wide`).toBe(2);
+    }
+    for (const cp of narrow) {
+      expect(codePointWidth(String.fromCodePoint(cp)), `U+${cp.toString(16)} should be narrow`).toBe(1);
+    }
+  });
+});

--- a/src/ui/textWidth.ts
+++ b/src/ui/textWidth.ts
@@ -1,0 +1,199 @@
+// Terminal column accounting, shared by every view that has to know how much of a fixed-size
+// panel a string will actually occupy *before* Ink lays it out.
+//
+// This lives in its own module rather than inside the component that first needed it because two
+// views now depend on the same answers — the detail panel and the info pane beside the results
+// list — and a second copy of this table is a second thing to get wrong. Ink/Yoga clips an
+// overflowing panel by squeezing rows, not by cutting the offending line, so a miscount here shows
+// up as dropped and fused rows somewhere else entirely.
+
+// DetailRow's fixed label column width. Hoisted so Detail's own layout-budget math (which needs
+// to know exactly how many columns are left for a value) can never independently drift from what
+// DetailRow actually renders — two copies of this number is exactly the kind of silent mismatch
+// that reintroduces the panel-overflow bug behind an otherwise green test suite.
+export const LABEL_W = 9;
+
+// [start, end] (inclusive) code point ranges rendered at 2 terminal columns: East Asian
+// Wide/Fullwidth blocks, plus the specific BMP and astral emoji/symbol ranges terminals render
+// double-width.
+//
+// This has to cover the full 0–0x10FFFF space, astral planes included. There is no free ride for
+// an emoji or a CJK Extension B+ ideograph the way there was for `.length`, which counted 2
+// UTF-16 units per astral code point regardless of what the character actually was — `for...of`
+// (below, and throughout this file) yields one code point per surrogate pair, so an astral
+// character gets exactly the same "look it up or default to 1" treatment as a BMP one. A prior
+// version of this table left every astral range out entirely on the theory that `.length` already
+// handled them; that was the same 2x undercount as the bug this whole mechanism exists to
+// prevent, just relocated to emoji and rare CJK ideographs instead of common ones.
+//
+// Solid CJK/Hangul/fullwidth territory is merged into single generous spans — a handful of narrow
+// or unassigned code points inside one of those costs at most one wasted row. U+2000–U+2BFF is
+// the one region kept surgical rather than swept: it also holds Box Drawing (this app's own
+// panel borders — ─│╭╮╰╯ all live at U+2500+) and Geometric Shapes, both mostly narrow, so a wide
+// net here would double-count the UI's own chrome, not just waste a line.
+const WIDE_RANGES: readonly (readonly [number, number])[] = [
+  [0x1100, 0x115f], // Hangul Jamo
+  [0x231a, 0x231b], // watch, hourglass
+  [0x2329, 0x232a], // angle brackets
+  [0x23e9, 0x23ec], // fast-forward/rewind/next/last track
+  [0x23f0, 0x23f0], // alarm clock
+  [0x23f3, 0x23f3], // hourglass (flowing)
+  [0x25fd, 0x25fe], // small squares
+  [0x2614, 0x2615], // umbrella, hot beverage
+  [0x2648, 0x2653], // zodiac signs
+  [0x267f, 0x267f], // wheelchair symbol
+  [0x2693, 0x2693], // anchor
+  [0x26a1, 0x26a1], // high voltage
+  [0x26aa, 0x26ab], // circles
+  [0x26bd, 0x26be], // soccer ball, baseball
+  [0x26c4, 0x26c5], // snowman, sun behind cloud
+  [0x26ce, 0x26ce], // ophiuchus
+  [0x26d4, 0x26d4], // no entry
+  [0x26ea, 0x26ea], // church
+  [0x26f2, 0x26f3], // fountain, flag in hole
+  [0x26f5, 0x26f5], // sailboat
+  [0x26fa, 0x26fa], // tent
+  [0x26fd, 0x26fd], // fuel pump
+  [0x2705, 0x2705], // check mark button
+  [0x270a, 0x270b], // raised fist, raised hand
+  [0x2728, 0x2728], // sparkles
+  [0x274c, 0x274c], // cross mark
+  [0x274e, 0x274e], // negative squared cross mark
+  [0x2753, 0x2755], // question/exclamation marks
+  [0x2757, 0x2757], // heavy exclamation mark
+  [0x2795, 0x2797], // plus/minus/division
+  [0x27b0, 0x27b0], // curly loop
+  [0x27bf, 0x27bf], // double curly loop
+  [0x2b1b, 0x2b1c], // large squares
+  [0x2b50, 0x2b50], // star
+  [0x2b55, 0x2b55], // heavy large circle
+  [0x2e80, 0x9fff], // CJK radicals through CJK unified ideographs — Hiragana, Katakana, Hangul
+  // compatibility Jamo, Yijing hexagrams and everything else in this span included
+  [0xa000, 0xa4cf], // Yi syllables and radicals
+  [0xa960, 0xa97f], // Hangul Jamo Extended-A
+  [0xac00, 0xd7a3], // Hangul syllables
+  [0xd7b0, 0xd7ff], // Hangul Jamo Extended-B
+  [0xf900, 0xfaff], // CJK compatibility ideographs
+  [0xfe10, 0xfe19], // vertical forms
+  [0xfe30, 0xfe6b], // CJK compatibility forms, small form variants
+  [0xff00, 0xff60], // fullwidth forms (halfwidth katakana/Hangul at 0xff61+ excluded on purpose)
+  [0xffe0, 0xffe6], // fullwidth signs
+  [0x1f000, 0x1ffff], // mahjong/domino/cards, enclosed CJK, emoji, transport, chess, pictographs
+  [0x20000, 0x3fffd], // CJK unified ideographs extension B and every plane beyond it
+];
+
+function isWideCodePoint(cp: number): boolean {
+  for (const [start, end] of WIDE_RANGES) {
+    if (cp >= start && cp <= end) return true;
+  }
+  return false;
+}
+
+// A `for...of` over a string yields whole code points (surrogate pairs included), so this reads
+// one on-screen glyph at a time rather than one UTF-16 unit — the distinction that matters for a
+// CJK character (one unit, two columns) exactly as much as for an astral one (an emoji, a rare
+// CJK ideograph): both are a single code point handed to `isWideCodePoint`, no special-casing
+// either way. Exported so a test can measure a rendered frame by the identical column accounting
+// the components use to decide what fits, rather than trusting a second, potentially-diverging
+// implementation to agree with it.
+export function codePointWidth(ch: string): number {
+  const cp = ch.codePointAt(0);
+  return cp !== undefined && isWideCodePoint(cp) ? 2 : 1;
+}
+
+export function displayWidth(text: string): number {
+  let w = 0;
+  for (const ch of text) w += codePointWidth(ch);
+  return w;
+}
+
+// Breaks a single run of text with no whitespace into chunks that each fit within `width` display
+// columns, splitting only between code points, never inside one.
+function breakToWidth(text: string, width: number): string[] {
+  const chunks: string[] = [];
+  let chunk = "";
+  let col = 0;
+  for (const ch of text) {
+    const w = codePointWidth(ch);
+    if (col + w > width && chunk !== "") {
+      chunks.push(chunk);
+      chunk = "";
+      col = 0;
+    }
+    chunk += ch;
+    col += w;
+  }
+  if (chunk !== "") chunks.push(chunk);
+  return chunks;
+}
+
+// Trims to at most `width` display columns before the ellipsis, using the same column accounting
+// as wordWrapLines below. A plain `.slice()` counts UTF-16 units, which can land inside a CJK
+// character (one unit, two columns) or split a surrogate-pair emoji in half; this never does.
+// Every call site clamps its width with `Math.max(1, …)` before calling in, so there is no
+// `width <= 0` case to guard here, same reasoning as wordWrapLines below.
+export function ellipsizeToWidth(text: string, width: number): string {
+  if (width === 1) return "…";
+  let out = "";
+  let col = 0;
+  for (const ch of text) {
+    const w = codePointWidth(ch);
+    if (col + w > width - 1) break;
+    out += ch;
+    col += w;
+  }
+  return `${out}…`;
+}
+
+// Greedy word wrap, used only to learn — and pin — exactly how many terminal rows a value will
+// occupy before Ink ever lays it out. Both panels that use it have a fixed height (Panel's
+// `height` prop, clipped with `overflow: hidden`), and handing Ink's own `wrap="wrap"` more text
+// than that budget allows does not clip cleanly: Yoga's flexbox shrink squeezes whichever rows
+// land on the losing side of its shrink math, dropping or fusing rows anywhere in the block,
+// including ones above the actual overflow. Every metadata row is only rendered once it is known
+// to fit, which means knowing its line count first.
+//
+// Wraps by *display* column, not UTF-16 code unit: a CJK character is one JS string unit but two
+// terminal columns, and Nyaa (an anime index, one of torlink's own sources) plus Cinemeta's
+// Japanese/Korean/Chinese titles make CJK cast and plot text a routine path here, not an edge
+// case. A word wider than `width` (a Cinemeta plot has no guaranteed word-length cap, and neither
+// does a single-token cast credit) is hard-broken into `width`-wide chunks rather than left to
+// overflow its own line — Ink's real wrap does the same, and undercounting here is exactly what
+// let a single unbroken run of text blow through a budget that looked, on paper, like it had room
+// to spare.
+export function wordWrapLines(text: string, width: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return [];
+  const lines: string[] = [];
+  let line = "";
+  let lineWidth = 0;
+  for (const word of words) {
+    const wordWidth = displayWidth(word);
+    if (wordWidth > width) {
+      if (line !== "") {
+        lines.push(line);
+        line = "";
+        lineWidth = 0;
+      }
+      const chunks = breakToWidth(word, width);
+      const last = chunks.pop() ?? "";
+      for (const chunk of chunks) lines.push(chunk);
+      line = last;
+      lineWidth = displayWidth(last);
+      continue;
+    }
+    if (line === "") {
+      line = word;
+      lineWidth = wordWidth;
+    } else if (lineWidth + 1 + wordWidth <= width) {
+      line += ` ${word}`;
+      lineWidth += 1 + wordWidth;
+    } else {
+      lines.push(line);
+      line = word;
+      lineWidth = wordWidth;
+    }
+  }
+  if (line !== "") lines.push(line);
+  return lines;
+}


### PR DESCRIPTION
## What and why

A search row shows a release name and nothing else — `The.Odyssey.2026.1080p.TELESYNC.HEVC-SPLiCE`
tells you the encoder's initials but not whether you want the film. Scrolling twelve near-identical
names, the question you're actually asking is "which of these is the thing I meant", and today the
only way to answer it is to open each one.

<p align="center">
  <img src="https://raw.githubusercontent.com/TechNapoleon/torlink/pr-media/pr1-detail-view.png" alt="torlink's detail view for a release, showing size, health, magnet and — new here — rating, genres, director, cast and plot" width="900">
</p>

<p align="center"><sub>The Enter detail view. Everything from <b>Rating</b> down is what this PR adds.</sub></p>

This is the first of three PRs and it lands the machinery plus its first visible surface:

- **A release-name parser** that recovers a plain title from scene and fansub naming. Total by
  construction — it runs once per visible row, so it returns an empty title rather than throwing.
- **A keyless [Cinemeta](https://v3-cinemeta.strem.io) client.** IMDb-keyed, no account, no key to
  ship in a public binary. Every mapper is total and every request fails soft to `null` or `[]`,
  because it's called from a render path: a dead provider costs a poster, not the TUI.
- **A lookup cache** with a 30 minute TTL, a two minute negative TTL, and refcounted in-flight
  dedupe, so one film's four YTS quality rows and the same film from three trackers resolve to a
  single request.
- **IMDb-id fast paths** for YTS, EZTV and The Pirate Bay, which already carry the id and can skip
  title guessing entirely.
- **Metadata in the Enter detail view** — rating, genres, director, cast and plot — budgeted against
  the panel's real height, because handing Ink more rows than fit doesn't clip cleanly.

The matcher abstains rather than guesses: a search endpoint ranks by popularity, so "The Matrix"
comes back with its sequels attached, and a wrong poster is worse than no poster because the user
can't tell it's wrong.

**Two follow-up PRs build on this** — a live info pane beside the results list, then a native image
tier for terminals that can draw one. Each is independently useful; this one stands on its own.

`jpeg-js` is added as a dependency here because the poster decoder in PR 2 needs it and the lockfile
entry belongs with the first branch that carries it. Nothing in this PR decodes an image.

**Known follow-up, not in this PR:** series documents are fetched per episode, so browsing 20 EZTV
rows of the same show re-fetches that show's document 20 times. One Piece's is 1.35 MB. It needs its
own cache-shape decision and I didn't want to bury it here.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — *no new keys in this PR*
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — *no new Store fields in this PR*
- [x] OS-touching code works on Windows, macOS, and Linux — *nothing here touches the OS; no process spawning, no filesystem, no platform branches*
- [x] One concern, with a Conventional Commits title

53 test files, 469 tests, no network calls in any of them.
