### PR TITLE
fix: take node-datachannel's prebuilt binaries instead of its install script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -580,6 +580,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@node-datachannel/android-arm64": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/android-arm64/-/android-arm64-0.33.0.tgz",
+      "integrity": "sha512-3/Q8koe++/4X8jh5HvNH4/VTh+4XPHVAuBNZVsE9eI50tyOb9j21rxSfLJTZRK1KL16ELtD7okCMhLx7B/Lpgg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@node-datachannel/darwin-arm64": {
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@node-datachannel/darwin-arm64/-/darwin-arm64-0.33.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,6 +580,122 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@node-datachannel/darwin-arm64": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/darwin-arm64/-/darwin-arm64-0.33.1.tgz",
+      "integrity": "sha512-6reyGKzuYNzuJypm4KrpJVTpION39rZmLoqDNMiehTVuSZzV1yoYyLHCzJ9XNVpOViGdaUvAWXJTlHcoQOZtrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@node-datachannel/darwin-x64": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/darwin-x64/-/darwin-x64-0.33.1.tgz",
+      "integrity": "sha512-1zXH/E79bswwRfbUwilw9iPNCCI4GLul/xxsjx/H7jbPT9SeMgkHKcx7Emuw91NBeYYPvYSYwQ705h4FTVDxow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@node-datachannel/linux-arm64-gnu": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/linux-arm64-gnu/-/linux-arm64-gnu-0.33.1.tgz",
+      "integrity": "sha512-FriA+y9cKnr9shQaNz4AdqkaNb7yqBcj1U/OgAlLvJtY/mJLvRX7R3iic18aUA5BkMMK+wwqBI/0Al3brxdRAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@node-datachannel/linux-arm64-musl": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/linux-arm64-musl/-/linux-arm64-musl-0.33.1.tgz",
+      "integrity": "sha512-MGtNFlIZ5b9sRBDFD3xS3oAhmAxJyEDrrhuUUEtR4Z4boSGOIzg0IiE5YQalmG7XgpMe0cxigBBTJitDczYyNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@node-datachannel/linux-x64-gnu": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/linux-x64-gnu/-/linux-x64-gnu-0.33.1.tgz",
+      "integrity": "sha512-0mTxq+0fYatoQ/7y9uMLDSRbnb0/Vrrl1Fhsuys8PfB06ft3IA8+6/qdFgRriHbCNkCkB3mSvWEIjCVjXuPr1A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@node-datachannel/linux-x64-musl": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/linux-x64-musl/-/linux-x64-musl-0.33.1.tgz",
+      "integrity": "sha512-LSIdM/tpdwy8d+pN7Vj5Dd4kU3vtdh1PKzz8MYPEPKpv2If5gBydA9pvmGDldiyn07Ijj1TrIQhV+1ozGBm0dw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@node-datachannel/win32-arm64-msvc": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/win32-arm64-msvc/-/win32-arm64-msvc-0.33.1.tgz",
+      "integrity": "sha512-uERR6Zz3wqLnOhBe1YRFodFSD9c7N3aM2Upe/z7miR7F8sprLr00+SkrTXZ+RayW8BN+xDtZRKFYYROvuJy/ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@node-datachannel/win32-x64-msvc": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@node-datachannel/win32-x64-msvc/-/win32-x64-msvc-0.33.1.tgz",
+      "integrity": "sha512-i5c3t+hDz6oNcen8aQZetxtAfYnNeUEND67oJrnAL8qQFzaRv6wKO5Q7G1vpjzQUyC54xe6s4oD8uuVo2sKPzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL 2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
@@ -1739,26 +1855,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/bencode": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bencode/-/bencode-4.0.1.tgz",
@@ -1961,46 +2057,11 @@
         "utf-8-validate": "^6.0.4"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/block-iterator": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/block-iterator/-/block-iterator-1.1.2.tgz",
       "integrity": "sha512-yAHUP44v2K25xLPdrgVTgwtuQctlullzjczu9CoUZom5AP3g4p1R1+aWHjS1GHG9JtcSUVUnbEPiuXiW5YZ24w==",
       "license": "MIT"
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
     },
     "node_modules/bufferutil": {
       "version": "4.1.0",
@@ -2103,12 +2164,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/chrome-dgram": {
       "version": "3.0.6",
@@ -2399,30 +2454,6 @@
         }
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/default-gateway": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
@@ -2638,15 +2669,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2783,12 +2805,6 @@
         "node": ">=12.20.0"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs-native-extensions": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/fs-native-extensions/-/fs-native-extensions-1.5.0.tgz",
@@ -2860,12 +2876,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
-    },
     "node_modules/http-parser-js": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
@@ -2880,26 +2890,6 @@
       "engines": {
         "node": ">=14.18.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/immediate-chunk-store": {
       "version": "2.2.0",
@@ -2940,12 +2930,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ink": {
@@ -3630,18 +3614,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3650,12 +3622,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -3707,12 +3673,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
-    },
     "node_modules/napi-macros": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.2.2.tgz",
@@ -3729,29 +3689,27 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-datachannel": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.32.3.tgz",
-      "integrity": "sha512-Aok1ZhLsll472lRefgWYuWJ0070jh0ecHravTdRyZEmoESumebMEQV8Y+poBwSW2ZbEwAokAOGsK5Cu8pDDT2g==",
-      "hasInstallScript": true,
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/node-datachannel/-/node-datachannel-0.33.1.tgz",
+      "integrity": "sha512-9oryOvUx2WqOmMUQ+JHyCx9w9UPBLGQcZQNcSYDc1LZS/hFSAqDyIRt6b5H5Ue13Gpe/vTjU8y9UvCBrbwpbAQ==",
       "license": "MPL 2.0",
       "dependencies": {
-        "prebuild-install": "^7.1.3"
+        "detect-libc": "^2.0.4"
       },
       "engines": {
         "node": ">=18.20.0"
+      },
+      "optionalDependencies": {
+        "@node-datachannel/android-arm64": "0.33.1",
+        "@node-datachannel/darwin-arm64": "0.33.1",
+        "@node-datachannel/darwin-x64": "0.33.1",
+        "@node-datachannel/linux-arm64-gnu": "0.33.1",
+        "@node-datachannel/linux-arm64-musl": "0.33.1",
+        "@node-datachannel/linux-x64-gnu": "0.33.1",
+        "@node-datachannel/linux-x64-musl": "0.33.1",
+        "@node-datachannel/win32-arm64-msvc": "0.33.1",
+        "@node-datachannel/win32-x64-msvc": "0.33.1"
       }
     },
     "node_modules/node-domexception": {
@@ -4058,33 +4016,6 @@
         }
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -4173,21 +4104,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/rc4": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/rc4/-/rc4-0.1.5.tgz",
@@ -4226,6 +4142,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4477,18 +4394,6 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
-    "node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4522,51 +4427,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
     },
     "node_modules/slice-ansi": {
       "version": "9.0.0",
@@ -4694,6 +4554,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4763,15 +4624,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -4805,34 +4657,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/teex": {
@@ -5591,18 +5415,6 @@
         "fsevents": "~2.3.3"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-fest": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
@@ -5743,7 +5555,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/utp-native": {
       "version": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "webtorrent": "^2.4.1"
   },
   "overrides": {
+    "@node-datachannel/android-arm64": "0.33.0",
     "node-datachannel": "^0.33.1",
     "uint8-util": "2.2.6"
   },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "webtorrent": "^2.4.1"
   },
   "overrides": {
+    "node-datachannel": "^0.33.1",
     "uint8-util": "2.2.6"
   },
   "devDependencies": {

--- a/src/deps-pin.test.ts
+++ b/src/deps-pin.test.ts
@@ -51,6 +51,7 @@ describe("uint8-util quarantine pin", () => {
 // the platform package, which keeps scripts/ensure-webrtc.cjs working as the
 // compile-from-source fallback where no prebuilt exists.
 const PREBUILT_LINE = "^0.33.1";
+const ANDROID_PUBLISHED = "0.33.0";
 
 function atLeast(version: string, min: string): boolean {
   const a = version.split(".").map(Number);
@@ -88,5 +89,34 @@ describe("node-datachannel prebuilt binaries", () => {
   it("the native binding loads without any build step", async () => {
     const ndc = await import("node-datachannel");
     expect(typeof ndc.PeerConnection).toBe("function");
+  });
+
+  // 0.33.1 lists @node-datachannel/android-arm64@0.33.1 among its
+  // optionalDependencies and that version was never published -- 0.33.0 is the
+  // only one on the registry. npm then leaves the package out of the lockfile,
+  // and `npm ci` refuses the result outright: "Missing:
+  // @node-datachannel/android-arm64@ from lock file". So the override names the
+  // version that does exist. 0.33.1 only added a Windows ARM64 build, so the
+  // Android binary is the same one either way. Drop this once upstream
+  // publishes the missing package.
+  it("pins the platform package upstream declares but never published", () => {
+    const pkg = readJson("../package.json");
+    expect(pkg.overrides["@node-datachannel/android-arm64"]).toBe(ANDROID_PUBLISHED);
+    const lock = readJson("../package-lock.json");
+    expect(lock.packages["node_modules/@node-datachannel/android-arm64"].version).toBe(
+      ANDROID_PUBLISHED,
+    );
+  });
+
+  it("the lockfile carries every platform package the module declares", () => {
+    const declared = Object.keys(
+      readJson("../node_modules/node-datachannel/package.json").optionalDependencies ?? {},
+    );
+    const lock = readJson("../package-lock.json");
+    expect(declared.length).toBeGreaterThan(0);
+    for (const name of declared) {
+      expect(lock.packages[`node_modules/${name}`], `${name} missing from the lockfile`)
+        .toBeDefined();
+    }
   });
 });

--- a/src/deps-pin.test.ts
+++ b/src/deps-pin.test.ts
@@ -36,3 +36,57 @@ describe("uint8-util quarantine pin", () => {
     expect(() => asAny("fd568f2ceba6b2603e761e4b13e5308c8b0f8ae4")).not.toThrow();
   });
 });
+
+// Aug-2026 install breakage: node-datachannel 0.33.0 removed its `install`
+// script entirely (0.32.3 ran `prebuild-install -r napi || (npm install
+// --ignore-scripts --production=false && npm run _prebuild)`) and moved the
+// native binary into nine per-platform optionalDependencies. npm 12 blocks
+// install scripts that are not explicitly approved, so on 0.32.3 a fresh
+// install leaves node-datachannel without its binary and every import of it
+// throws "Cannot find module '../../../build/Release/node_datachannel.node'" —
+// the failure behind #166, #60, #81, #89, #135 and #20. Optional dependencies
+// need no script at all. webrtc-polyfill still asks for "^0.32.3", and a caret
+// on a 0.x version pins the minor, so only an override moves the tree onto the
+// prebuilt line. The 0.33 loader still checks a local build/ directory before
+// the platform package, which keeps scripts/ensure-webrtc.cjs working as the
+// compile-from-source fallback where no prebuilt exists.
+const PREBUILT_LINE = "^0.33.1";
+
+function atLeast(version: string, min: string): boolean {
+  const a = version.split(".").map(Number);
+  const b = min.split(".").map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((a[i] ?? 0) !== (b[i] ?? 0)) return (a[i] ?? 0) > (b[i] ?? 0);
+  }
+  return true;
+}
+
+describe("node-datachannel prebuilt binaries", () => {
+  it("package.json overrides the transitive range onto the prebuilt line", () => {
+    const pkg = readJson("../package.json");
+    expect(pkg.overrides["node-datachannel"]).toBe(PREBUILT_LINE);
+  });
+
+  it("the lockfile resolved a version that ships prebuilt binaries", () => {
+    const lock = readJson("../package-lock.json");
+    const resolved = lock.packages["node_modules/node-datachannel"].version;
+    expect(atLeast(resolved, "0.33.1")).toBe(true);
+  });
+
+  it("the installed copy carries no install script and declares platform packages", () => {
+    const installed = readJson("../node_modules/node-datachannel/package.json");
+    expect(installed.scripts?.install).toBeUndefined();
+    expect(Object.keys(installed.optionalDependencies ?? {})).toEqual(
+      expect.arrayContaining([
+        "@node-datachannel/linux-x64-gnu",
+        "@node-datachannel/darwin-arm64",
+        "@node-datachannel/win32-x64-msvc",
+      ]),
+    );
+  });
+
+  it("the native binding loads without any build step", async () => {
+    const ndc = await import("node-datachannel");
+    expect(typeof ndc.PeerConnection).toBe("function");
+  });
+});


### PR DESCRIPTION
## What and why

`npx torlnk` exits silently on a clean machine. `npm i -g torlnk` shows why (#166):

```
npm error command sh -c prebuild-install -r napi || (npm install --ignore-scripts --production=false && npm run _prebuild)
npm error prebuild-install warn install Request timed out
npm error prebuild WARN This package does not support N-API version undefined
npm error prebuild ERR! build TypeError: expected first argument to be an array
```

That line is `node-datachannel@0.32.3`'s `install` script, and it has two separate failure modes that are both live right now:

- **npm 12 never runs it.** Install scripts need explicit approval now, so a fresh `npm install` in this repo prints it under *"install scripts blocked because they are not covered by allowScripts"* and moves on:
  ```
  npm warn install-scripts   node-datachannel@0.32.3 (install: prebuild-install -r napi || (...))
  ```
- **When it does run, the fallback is broken.** `prebuild-install` times out, and the source build it falls back to dies on `N-API version undefined` before it compiles anything — that is the traceback in #166.

Either way `node_modules/node-datachannel` is left with no binary, and everything that touches WebRTC throws:

```
Error: Cannot find module '../../../build/Release/node_datachannel.node'
```

For a user that is `npx torlnk` returning to the prompt with no output. In this repo it is **five test suites failing on a clean checkout of `main`** — `queue`, `queue.safemode`, `daemon/runtime`, `daemon/serve`, `daemon/watch` — because they import webtorrent, which eagerly requires the native module.

### The fix

`node-datachannel@0.33.0` (2026-08-15) **removed the `install` script entirely** and moved the binary into nine per-platform `optionalDependencies`, which npm resolves as ordinary packages with no script at all:

```
@node-datachannel/{android-arm64, darwin-arm64, darwin-x64, linux-arm64-gnu,
 linux-arm64-musl, linux-x64-gnu, linux-x64-musl, win32-arm64-msvc, win32-x64-msvc}
```

`webrtc-polyfill@1.2.2` still asks for `node-datachannel: ^0.32.3`, and a caret on a `0.x` version pins the minor (`>=0.32.3 <0.33.0`), so that range can never reach 0.33 on its own. A single `overrides` entry moves the whole tree — the same mechanism package.json already uses to quarantine `uint8-util`.

Nothing else has to change:

- **The source-build fallback still works.** The 0.33 loader checks `build/node_datachannel.node` and `build/Release/node_datachannel.node` *before* the platform package, which is exactly where `scripts/ensure-webrtc.cjs`'s `cmake-js build` writes. 0.33.1 still ships `CMakeLists.txt` and `src/cpp`, so platforms with no prebuilt (armv7, FreeBSD) keep the existing path, and `ensure-webrtc.cjs` keeps its friendly warning if the toolchain is missing.
- **webrtc-polyfill's API surface is untouched.** Verified against the installed 1.2.2 — see below.
- **The tree gets smaller.** The lockfile loses 24 packages (the whole `prebuild-install` / `tar-fs` / `node-abi` download chain) and gains the platform packages, of which npm installs only the one matching the host.

### One upstream gap, pinned

CI caught this on the first run and it is worth spelling out: **0.33.1 declares a package that was never published.** Its `optionalDependencies` list `@node-datachannel/android-arm64@0.33.1`, and the registry only has `0.33.0`:

```
$ npm view @node-datachannel/android-arm64 versions
[ "0.33.0" ]
```

npm resolves around the gap and leaves the package out of the lockfile — and then `npm ci` rejects the lockfile npm itself wrote:

```
npm error `npm ci` can only install packages when your package.json and package-lock.json ... are in sync.
npm error Missing: @node-datachannel/android-arm64@ from lock file
```

(Node 22's npm tolerates it; Node 24's does not, which is why three of six CI jobs failed and three passed.)

So there is a second override, on that one package, naming the version that exists:

```json
"@node-datachannel/android-arm64": "0.33.0"
```

0.33.1 only added a Windows ARM64 build, so the Android binary is byte-identical to 0.33.0's — and pinning the package rather than the whole module keeps `win32-arm64-msvc`, which 0.33.0 does not carry at all. It comes out once upstream publishes the missing version, and `deps-pin.test.ts` says so.

The lockfile now holds all nine platform packages, which is the invariant `npm ci` actually checks, so the test checks it too — against whatever the installed module declares, so a future bump that adds a platform cannot quietly leave one out.

### Verification

Run on Windows 11, Node v24.19.0, npm 12.0.1, from a wiped `node_modules`.

Before (`main`):

```
npm warn install-scripts node-datachannel@0.32.3 (install: prebuild-install -r napi || ...)
$ node -e "require('node-datachannel')"
Error: Cannot find module '../../../build/Release/node_datachannel.node'
$ npm test
Test Files  5 failed | 40 passed (45)
     Tests  255 passed (255)
```

After:

```
$ npm install          # no blocked install script for node-datachannel
$ node -e "require('node-datachannel')"   # loads, 0.33.1, @node-datachannel/win32-x64-msvc
$ npm run typecheck    # clean
$ npm test
Test Files  45 passed (45)
     Tests  317 passed (317)
$ npm run build        # ok
```

The real WebRTC path, not just the import:

```js
const { RTCPeerConnection } = await import('webrtc-polyfill');   // 1.2.2, unchanged
const pc = new RTCPeerConnection();
pc.createDataChannel('t');
(await pc.createOffer()).sdp;   // -> "v=0 o=rtc 2..."
```

and a WebTorrent client boots and takes a magnet through to its `infoHash` event.

CI covers the other two platforms on this PR (ubuntu / macOS / windows x node 22, 24). I could not test Termux or Linux ARM myself, so I am not claiming those are fixed — but 0.33 is the first release to ship `android-arm64`, `linux-arm64-gnu` and `linux-arm64-musl` binaries, which is the missing piece in #24, #25, #106 and #52.

Related install reports: #166, #60, #81, #89, #135, #20.

### Test

`src/deps-pin.test.ts` already exists to keep a dependency decision from being undone silently, so the new block lives there next to the `uint8-util` pin. It asserts the override, the resolved lockfile version, that the installed copy carries no `install` script, and that the binding actually loads.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
