### PR TITLE
fix: keep an unreadable feed date out of the sort comparator

### DIFF
--- a/src/sources/nyaa.ts
+++ b/src/sources/nyaa.ts
@@ -1,7 +1,7 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
 import { buildMagnet } from "./magnet";
 import { unescapeEntities } from "./rss";
-import { parseSize } from "../util/format";
+import { parseSize, parseUnixSeconds } from "../util/format";
 import type { SearchOptions, Source, TorrentResult } from "./types";
 
 const BASE = "https://nyaa.si/";
@@ -35,7 +35,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
       leechers: Number.isFinite(leechers) ? leechers : 0,
       source: "nyaa",
       magnet: buildMagnet(infoHash, name),
-      added: dateStr ? new Date(dateStr).getTime() / 1000 : undefined,
+      added: parseUnixSeconds(dateStr),
     });
   }
   return out;

--- a/src/sources/subsplease.ts
+++ b/src/sources/subsplease.ts
@@ -1,5 +1,6 @@
 import { fetchResilient, HttpError, USER_AGENT } from "../util/net";
 import { parseMagnet } from "./magnet";
+import { parseUnixSeconds } from "../util/format";
 import type { SearchOptions, Source, TorrentResult } from "./types";
 
 const API = "https://subsplease.org/api/";
@@ -60,7 +61,7 @@ async function search(query: string, opts: SearchOptions = {}): Promise<TorrentR
       leechers: 0,
       source: "subsplease",
       magnet: parsed.magnet,
-      added: entry.release_date ? new Date(entry.release_date).getTime() / 1000 : undefined,
+      added: parseUnixSeconds(entry.release_date),
     });
   }
   return out;

--- a/src/util/format.test.ts
+++ b/src/util/format.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   formatBytes,
   parseSize,
+  parseUnixSeconds,
   formatBytesPerSec,
   formatCount,
   formatRelative,
@@ -116,5 +117,34 @@ describe("stripControl", () => {
     expect(stripControl(hash)).toBe(hash);
     expect(stripControl("a  b")).toBe("a  b");
     expect(stripControl("")).toBe("");
+  });
+});
+
+describe("parseUnixSeconds", () => {
+  it("parses the date shapes the feeds actually send", () => {
+    // nyaa.si RSS pubDate and the SubsPlease API release_date are both RFC 822.
+    expect(parseUnixSeconds("Thu, 27 Aug 2026 11:49:25 -0000")).toBe(
+      Date.UTC(2026, 7, 27, 11, 49, 25) / 1000,
+    );
+    expect(parseUnixSeconds("2026-08-27T11:49:25Z")).toBe(
+      Date.UTC(2026, 7, 27, 11, 49, 25) / 1000,
+    );
+  });
+
+  it("returns undefined rather than NaN for anything unreadable", () => {
+    for (const bad of [undefined, "", "   ", "not a date", "0000-13-45", "Thu, 32 Xxx"]) {
+      expect(parseUnixSeconds(bad)).toBeUndefined();
+    }
+  });
+
+  it("never yields a value that breaks a sort comparator", () => {
+    // NaN is a number, so `added ?? 0` would pass it through, and a comparator
+    // that returns NaN leaves Array.prototype.sort implementation-defined.
+    const added = ["Thu, 27 Aug 2026 11:49:25 -0000", "not a date", undefined].map(
+      parseUnixSeconds,
+    );
+    for (const a of added) expect(a === undefined || Number.isFinite(a)).toBe(true);
+    const cmp = (a?: number, b?: number): number => (b ?? 0) - (a ?? 0);
+    for (const a of added) for (const b of added) expect(Number.isNaN(cmp(a, b))).toBe(false);
   });
 });

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -28,6 +28,19 @@ export function parseSize(s: string): number {
   return Math.round(parseFloat(m[1]!) * (SIZE_UNITS[m[2]!.toUpperCase()] ?? 1));
 }
 
+// Feed timestamps arrive as free text: an RSS pubDate, a JSON release_date.
+// Date.parse returns NaN for anything it cannot read, and NaN is a number, so
+// the `added ?? 0` guards downstream never catch it — it flows straight into a
+// sort comparator, and a comparator that returns NaN makes Array.prototype.sort
+// implementation-defined for the whole array. Returning undefined keeps `added`
+// honest: absent, rather than zero or NaN. Same instinct as the Number.isFinite
+// guards nyaa.ts already applies to its seeders and leechers.
+export function parseUnixSeconds(value?: string): number | undefined {
+  if (!value) return undefined;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms / 1000 : undefined;
+}
+
 export function formatBytesPerSec(bytes?: number): string {
   if (bytes === undefined || !Number.isFinite(bytes) || bytes <= 0) return "";
   const units = ["B/s", "KB/s", "MB/s", "GB/s"];


### PR DESCRIPTION
## What and why

Two sources build `added` the same way:

```ts
// src/sources/nyaa.ts:38 and src/sources/subsplease.ts:63
added: dateStr ? new Date(dateStr).getTime() / 1000 : undefined,
```

`Date.parse` returns `NaN` for anything it cannot read, and **`NaN` is a `number`** — so a bad date produces a perfectly well-typed `added`, and it is invisible on screen because `formatRelative()` already guards with `Number.isFinite` and just renders the cell blank.

Where it does land is the comparators:

```ts
// src/ui/sort.ts:63
arr.sort((a, b) => mul * ((a.added ?? 0) - (b.added ?? 0)) || b.seeders - a.seeders);

// src/ui/hooks/useConcurrentSearch.ts:45 — the default "healthiest first" order
return (b.added ?? 0) - (a.added ?? 0);
```

`?? 0` reads like the guard, but it only replaces `undefined`. A `NaN` `added` makes the comparator return `NaN`, and a comparator that returns `NaN` puts `Array.prototype.sort` in implementation-defined territory for the **whole array**, not just the offending row. So one unreadable date can reorder the entire results list, and nothing on screen points at the cause — it just looks like a bad search.

The fix is the guard the codebase already uses everywhere else. The same `search()` in nyaa.ts writes:

```ts
seeders: Number.isFinite(seeders) ? seeders : 0,
leechers: Number.isFinite(leechers) ? leechers : 0,
```

and `parseUploadDate` in x1337.ts already ends with `Number.isNaN(secs) ? undefined : secs`. `added` in these two sources is the spot that was missed.

### The change

One helper next to `parseSize` in `src/util/format.ts`, so both sources parse feed dates the same way:

```ts
export function parseUnixSeconds(value?: string): number | undefined {
  if (!value) return undefined;
  const ms = new Date(value).getTime();
  return Number.isFinite(ms) ? ms / 1000 : undefined;
}
```

`undefined` rather than `0`, because "no date" is what the field already means when it is absent — `0` would claim 1970 and sort like it.

### How reachable is this, honestly

I checked the live feeds before writing this, and today they are clean:

| feed | items checked | unparseable dates |
| --- | --- | --- |
| `nyaa.si/?page=rss&q=one+piece` | 75 | 0 |
| `subsplease.org/api/?f=latest` | 20 | 0 |
| `subsplease.org/api/?f=search&s=one piece` | 30 | 0 |

Both send RFC 822 (`Thu, 27 Aug 2026 11:49:25 -0000`). So this is hardening against a feed changing or truncating a field, not a live incident report — I would rather say that than overstate it.

What makes it worth three lines anyway: the failure mode is silent and total. There is no error, no log line, no blank row to point at — just a result list in the wrong order, on a field the user explicitly asked to sort by.

### Test

`parseUnixSeconds` is a pure function, so it is tested in `src/util/format.test.ts` alongside `parseSize`: the two date shapes the feeds actually send, the unreadable inputs, and an explicit check that nothing it returns can make a `(b ?? 0) - (a ?? 0)` comparator produce `NaN`.

I left `sort.ts` and `useConcurrentSearch.ts` alone on purpose. With the producers fixed there is no `NaN` to defend against, and adding a second guard there would be a parallel way to do what the parse site now does.

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes (45 files, 314 tests)
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [x] OS-touching code works on Windows, macOS, and Linux — n/a, pure logic
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
