### PR TITLE
fix: merge duplicate rows instead of dropping the losers' trackers

### DIFF
--- a/src/sources/magnet.test.ts
+++ b/src/sources/magnet.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { parseMagnet, parseInput, isInfoHash, normalizeInfoHash, buildMagnet } from "./magnet";
+import {
+  parseMagnet,
+  parseInput,
+  isInfoHash,
+  normalizeInfoHash,
+  buildMagnet,
+  mergeMagnetTrackers,
+} from "./magnet";
 
 describe("parseMagnet", () => {
   it("keeps a full 40-char hex info hash", () => {
@@ -109,5 +116,44 @@ describe("parseInput", () => {
     expect(parseInput("g".repeat(40))).toBeNull(); // 40 chars but not hex
     expect(parseInput("magnet:?xt=urn:btih:tooshort")).toBeNull();
     expect(parseInput("")).toBeNull();
+  });
+});
+
+describe("mergeMagnetTrackers", () => {
+  const hash = "abcdef0123456789abcdef0123456789abcdef01";
+  const own = "udp://private.example:6969/announce/passkey";
+
+  it("appends only the trackers the primary is missing", () => {
+    const primary = buildMagnet(hash, "X");
+    const merged = mergeMagnetTrackers(primary, [buildMagnet(hash, "X", [own])]);
+    const tr = new URL(merged).searchParams.getAll("tr");
+    expect(tr).toContain(own);
+    expect(new Set(tr).size).toBe(tr.length);
+    expect(merged.startsWith(primary)).toBe(true);
+  });
+
+  it("returns the primary untouched when the others add nothing", () => {
+    const primary = buildMagnet(hash, "X");
+    expect(mergeMagnetTrackers(primary, [buildMagnet(hash, "X")])).toBe(primary);
+    expect(mergeMagnetTrackers(primary, [])).toBe(primary);
+  });
+
+  it("keeps parameters buildMagnet does not write", () => {
+    const primary = `magnet:?xt=urn:btih:${hash}&dn=X&xl=1234`;
+    const merged = mergeMagnetTrackers(primary, [buildMagnet(hash, "X", [own])]);
+    expect(new URL(merged).searchParams.get("xl")).toBe("1234");
+    expect(new URL(merged).searchParams.getAll("tr")).toContain(own);
+  });
+
+  it("leaves anything that is not a magnet exactly as it came", () => {
+    expect(mergeMagnetTrackers("not a magnet", [buildMagnet(hash, "X", [own])])).toBe(
+      "not a magnet",
+    );
+    expect(mergeMagnetTrackers("", [])).toBe("");
+  });
+
+  it("ignores others that are not magnets", () => {
+    const primary = buildMagnet(hash, "X");
+    expect(mergeMagnetTrackers(primary, ["nonsense", ""])).toBe(primary);
   });
 });

--- a/src/sources/magnet.ts
+++ b/src/sources/magnet.ts
@@ -96,3 +96,36 @@ export function parseInput(input: string): ParsedMagnet | null {
   const infoHash = normalizeInfoHash(s);
   return { infoHash, name: infoHash, magnet: buildMagnet(infoHash, infoHash) };
 }
+
+function trackersOf(magnet: string): string[] | null {
+  const s = magnet.trim();
+  if (!/^magnet:\?/i.test(s)) return null;
+  try {
+    return new URL(s).searchParams.getAll("tr").map((t) => t.trim()).filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+// A magnet's announce list is part of what a source knows about the torrent, so
+// when the same infohash arrives from several sources their lists get folded
+// together rather than the extras thrown away. `primary` is returned byte for
+// byte with only the trackers it is missing appended, which keeps every other
+// parameter it carries (xl, ws, so) intact — unlike rebuilding through
+// buildMagnet(). Order does not matter to a client: every tr in a magnet ends up
+// in one announce list and all of them are contacted.
+export function mergeMagnetTrackers(primary: string, others: string[]): string {
+  const own = trackersOf(primary);
+  if (!own) return primary;
+  const seen = new Set(own);
+  const extra: string[] = [];
+  for (const other of others) {
+    for (const url of trackersOf(other) ?? []) {
+      if (seen.has(url)) continue;
+      seen.add(url);
+      extra.push(url);
+    }
+  }
+  if (extra.length === 0) return primary;
+  return primary.trim() + extra.map((t) => `&tr=${encodeURIComponent(t)}`).join("");
+}

--- a/src/ui/dedupe.test.ts
+++ b/src/ui/dedupe.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { dedupeResults } from "./dedupe";
+import { buildMagnet } from "../sources/magnet";
+import type { SourceId, TorrentResult } from "../sources/types";
+
+const HASH = "abcdef0123456789abcdef0123456789abcdef01";
+
+function row(over: Partial<TorrentResult> & { source: SourceId }): TorrentResult {
+  return {
+    infoHash: HASH,
+    name: "Some Release 1080p",
+    sizeBytes: 1_000_000,
+    seeders: 0,
+    leechers: 0,
+    magnet: buildMagnet(HASH, "Some Release 1080p"),
+    ...over,
+  };
+}
+
+function trackers(magnet: string): string[] {
+  return new URL(magnet).searchParams.getAll("tr");
+}
+
+describe("dedupeResults", () => {
+  it("leaves distinct hashes alone", () => {
+    const other = "0123456789abcdef0123456789abcdef01234567";
+    const out = dedupeResults([row({ source: "nyaa" }), row({ source: "yts", infoHash: other })]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("keeps the healthiest row's own fields", () => {
+    const out = dedupeResults([
+      row({ source: "tpb-movies", seeders: 3, name: "TPB name" }),
+      row({ source: "x1337-movies", seeders: 90, name: "1337x name" }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.seeders).toBe(90);
+    expect(out[0]!.source).toBe("x1337-movies");
+    expect(out[0]!.name).toBe("1337x name");
+  });
+
+  it("carries the losing row's trackers into the surviving magnet", () => {
+    // The row 1337x returns carries the torrent's own announce list; the row
+    // buildMagnet() writes carries only torlink's public defaults. Whichever
+    // wins on seeders, both lists have to survive.
+    const own = "udp://private.example:6969/announce/passkey";
+    const out = dedupeResults([
+      row({ source: "tpb-movies", seeders: 90 }),
+      row({ source: "x1337-movies", seeders: 3, magnet: buildMagnet(HASH, "x", [own]) }),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]!.seeders).toBe(90);
+    expect(trackers(out[0]!.magnet)).toContain(own);
+    expect(trackers(out[0]!.magnet)).toContain("udp://tracker.opentrackr.org:1337/announce");
+  });
+
+  it("adds no duplicate trackers and no duplicate rows for three sources", () => {
+    const a = "udp://a.example:6969/announce";
+    const b = "udp://b.example:6969/announce";
+    const out = dedupeResults([
+      row({ source: "tpb-movies", seeders: 1, magnet: buildMagnet(HASH, "x", [a]) }),
+      row({ source: "yts", seeders: 5, magnet: buildMagnet(HASH, "x", [b]) }),
+      row({ source: "x1337-movies", seeders: 2, magnet: buildMagnet(HASH, "x", [a]) }),
+    ]);
+    expect(out).toHaveLength(1);
+    const tr = trackers(out[0]!.magnet);
+    expect(tr).toContain(a);
+    expect(tr).toContain(b);
+    expect(new Set(tr).size).toBe(tr.length);
+  });
+
+  it("backfills numFiles and added only where the winner has none", () => {
+    const out = dedupeResults([
+      row({ source: "yts", seeders: 90, added: 1_700_000_000 }),
+      row({ source: "eztv", seeders: 3, numFiles: 7, added: 1_600_000_000 }),
+    ]);
+    expect(out[0]!.numFiles).toBe(7);
+    expect(out[0]!.added).toBe(1_700_000_000);
+  });
+
+  it("keeps the first row when seeders tie", () => {
+    const out = dedupeResults([
+      row({ source: "nyaa", seeders: 10 }),
+      row({ source: "subsplease", seeders: 10 }),
+    ]);
+    expect(out[0]!.source).toBe("nyaa");
+  });
+});

--- a/src/ui/dedupe.ts
+++ b/src/ui/dedupe.ts
@@ -1,0 +1,35 @@
+import { mergeMagnetTrackers } from "../sources/magnet";
+import type { TorrentResult } from "../sources/types";
+
+// The same torrent reaches the list from several sources at once, and only one
+// row should survive. The healthiest row still wins — its seeder count is the
+// one worth showing — but the rows it beats are folded into it instead of being
+// dropped:
+//
+//   - their announce lists. 1337x and EZTV hand back the torrent's own
+//     trackers, while rows built by buildMagnet() carry only torlink's public
+//     defaults, so keeping the higher-seeder row alone can trade a working
+//     announce list for a generic one. Same loss #146 fixed for a .torrent
+//     file's own trackers.
+//   - numFiles and added, but only where the winner has none. A field the
+//     winner never reported is a gap, not a decision.
+//
+// Everything else stays the winner's, including its magnet URI byte for byte.
+function merge(a: TorrentResult, b: TorrentResult): TorrentResult {
+  const [win, lost] = b.seeders > a.seeders ? [b, a] : [a, b];
+  return {
+    ...win,
+    magnet: mergeMagnetTrackers(win.magnet, [lost.magnet]),
+    numFiles: win.numFiles ?? lost.numFiles,
+    added: win.added ?? lost.added,
+  };
+}
+
+export function dedupeResults(list: TorrentResult[]): TorrentResult[] {
+  const byHash = new Map<string, TorrentResult>();
+  for (const r of list) {
+    const existing = byHash.get(r.infoHash);
+    byHash.set(r.infoHash, existing ? merge(existing, r) : r);
+  }
+  return [...byHash.values()];
+}

--- a/src/ui/hooks/useConcurrentSearch.ts
+++ b/src/ui/hooks/useConcurrentSearch.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { SOURCES } from "../../sources/registry";
 import { cachedSearch } from "../../sources/cache";
+import { dedupeResults } from "../dedupe";
 import { HttpError } from "../../util/net";
 import type { SourceId, TorrentResult } from "../../sources/types";
 
@@ -28,15 +29,6 @@ function blankPerSource(loading: boolean): Record<SourceId, SourceState> {
   const out = {} as Record<SourceId, SourceState>;
   for (const s of SOURCES) out[s.id] = { loading, error: null, code: null, count: 0 };
   return out;
-}
-
-function dedupe(list: TorrentResult[]): TorrentResult[] {
-  const byHash = new Map<string, TorrentResult>();
-  for (const r of list) {
-    const existing = byHash.get(r.infoHash);
-    if (!existing || r.seeders > existing.seeders) byHash.set(r.infoHash, r);
-  }
-  return [...byHash.values()];
 }
 
 // torlink's default ordering: healthiest first. The results view can re-sort
@@ -78,7 +70,7 @@ export function useConcurrentSearch(query: string): ConcurrentSearchState {
 
     const flush = (): void => {
       setState({
-        results: defaultOrder(dedupe(collected.slice())),
+        results: defaultOrder(dedupeResults(collected.slice())),
         perSource: { ...per },
         loading: done < SOURCES.length,
         done,


### PR DESCRIPTION
## What and why

`dedupe()` in `useConcurrentSearch.ts` kept the row with the most seeders and dropped the rest:

```ts
const existing = byHash.get(r.infoHash);
if (!existing || r.seeders > existing.seeders) byHash.set(r.infoHash, r);
```

Dropping the row also drops its magnet, and a magnet's announce list is part of what that source knew about the torrent:

- **1337x** takes its magnet straight off the detail page (`x1337.ts:74`) and **EZTV** uses the API's `magnet_url` (`eztv.ts:36`) — both carry the torrent's *own* trackers.
- **TPB, YTS, Nyaa** rows are assembled by `buildMagnet()`, which writes only torlink's eleven public defaults.

So whenever those overlap — and TV and Movies overlap constantly, that is what dedupe is for — the higher-seeder row wins and can trade a working announce list for a generic one. `buildMagnet` already states the principle this breaks:

```ts
// extraTrackers come first and win on duplicates: a torrent that carries its own
// announce list means that list, and the public defaults are only a fallback.
```

It is the same loss #146 fixed for a `.torrent` file's own trackers, arriving by a different route. Two rows for one infohash is exactly the case where torlink has *more* information than either source alone, and the old code was the only place that spent it.

`numFiles` and `added` go the same way — EZTV reports `date_released_unix` and 1337x parses an upload date, so a YTS row with neither can win and leave the Added column blank for a torrent whose date was right there.

### What changed

The winner is chosen exactly as before, and still supplies every visible field. The rows it beats are folded into it rather than discarded:

```ts
function merge(a: TorrentResult, b: TorrentResult): TorrentResult {
  const [win, lost] = b.seeders > a.seeders ? [b, a] : [a, b];
  return {
    ...win,
    magnet: mergeMagnetTrackers(win.magnet, [lost.magnet]),
    numFiles: win.numFiles ?? lost.numFiles,
    added: win.added ?? lost.added,
  };
}
```

`??`, so a backfill only fills a genuine gap — a field the winner never reported is missing information, not a decision to overrule.

`mergeMagnetTrackers` lives in `src/sources/magnet.ts` next to `buildMagnet`, and **appends** the missing `tr` values rather than rebuilding the URI. That keeps the winning magnet byte for byte, so parameters torlink does not write itself survive — SubsPlease magnets carry `xl`, and rebuilding through `buildMagnet()` would have silently dropped it. Order is not a concern: every `tr` in a magnet lands in one announce list and the client contacts all of them.

Anything that is not a magnet is returned untouched, so a malformed URI from a source can never be corrupted further.

### Why dedupe moved file

`dedupe` was a private function inside a React hook, which is why it had no test. It is a pure result-list transform, so it now sits in `src/ui/dedupe.ts` beside `src/ui/sort.ts` and `src/ui/filter.ts` — the two functions of exactly the same shape — and the hook keeps one import. No behaviour rides on the move.

### Tests

`src/ui/dedupe.test.ts` (new): distinct hashes are untouched; the healthiest row still supplies name/source/seeders; a losing 1337x row's private-tracker URL survives into the winning magnet; three sources on one hash produce one row and no repeated tracker; `numFiles`/`added` backfill only into gaps; a seeder tie keeps the first row, as before.

`src/sources/magnet.test.ts`: `mergeMagnetTrackers` appends only what is missing, returns the primary unchanged when there is nothing to add, preserves `xl`, and leaves non-magnets alone.

```
npm run typecheck   clean
npm test            46 files, 322 tests, all passing
```

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a, no new key
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a, no new Store field
- [x] OS-touching code works on Windows, macOS, and Linux — n/a, pure logic
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
