### PR TITLE
fix: fall back to OSC 52 when no clipboard helper can be reached

### DIFF
--- a/src/util/clipboard.test.ts
+++ b/src/util/clipboard.test.ts
@@ -165,7 +165,7 @@ describe("writeClipboard OSC 52 fallback", () => {
       await onPlatform("linux", async () => {
         vi.stubEnv("SSH_TTY", "");
         vi.stubEnv("SSH_CONNECTION", "");
-        vi.stubEnv("TMUX", "/tmp/tmux-1000/default,1234,0");
+        vi.stubEnv("TMUX", "/run/user/1000/tmux-1000/default,1234,0");
         mockSpawn(1);
         const { writeClipboard } = await import("./clipboard");
 

--- a/src/util/clipboard.test.ts
+++ b/src/util/clipboard.test.ts
@@ -40,3 +40,158 @@ describe("writeClipboard", () => {
     }
   });
 });
+
+type FakeProc = EventEmitter & {
+  stdin: { end: (value: string) => void };
+  stdout: EventEmitter;
+  kill: () => void;
+};
+
+// Same shape as the mock above: every spawned command exits with `code`.
+function mockSpawn(code: number): void {
+  spawn.mockImplementation(() => {
+    const proc = new EventEmitter() as FakeProc;
+    proc.stdout = new EventEmitter();
+    proc.kill = vi.fn();
+    proc.stdin = { end: vi.fn(() => queueMicrotask(() => proc.emit("exit", code))) };
+    return proc;
+  });
+}
+
+// OSC 52 goes to the terminal, not to a child process, so the test watches the
+// tty rather than node:child_process.
+function captureTty(isTTY: boolean): { written: string[]; restore: () => void } {
+  const written: string[] = [];
+  const err = process.stderr as unknown as { isTTY?: boolean; write: unknown };
+  const out = process.stdout as unknown as { isTTY?: boolean };
+  const prev = { errIsTTY: err.isTTY, errWrite: err.write, outIsTTY: out.isTTY };
+  err.isTTY = isTTY;
+  out.isTTY = isTTY;
+  err.write = (chunk: unknown) => {
+    written.push(String(chunk));
+    return true;
+  };
+  return {
+    written,
+    restore: () => {
+      err.isTTY = prev.errIsTTY;
+      err.write = prev.errWrite;
+      out.isTTY = prev.outIsTTY;
+    },
+  };
+}
+
+async function onPlatform<T>(platform: string, run: () => Promise<T>): Promise<T> {
+  const original = process.platform;
+  Object.defineProperty(process, "platform", { value: platform });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(process, "platform", { value: original });
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    spawn.mockReset();
+  }
+}
+
+function decodeOsc52(seq: string): string {
+  const body = seq.slice(seq.indexOf(";c;") + 3, seq.lastIndexOf("\u0007"));
+  return Buffer.from(body, "base64").toString("utf8");
+}
+
+describe("writeClipboard OSC 52 fallback", () => {
+  it("asks the terminal when no Linux clipboard command works", async () => {
+    const tty = captureTty(true);
+    try {
+      await onPlatform("linux", async () => {
+        vi.stubEnv("SSH_TTY", "");
+        vi.stubEnv("SSH_CONNECTION", "");
+        vi.stubEnv("TMUX", "");
+        mockSpawn(1);
+        const { writeClipboard } = await import("./clipboard");
+
+        await expect(writeClipboard("magnet:?xt=urn:btih:abc")).resolves.toBe(true);
+        // wl-copy, xclip and xsel were all tried first.
+        expect(spawn).toHaveBeenCalledTimes(3);
+        expect(tty.written.join("")).toBe(
+          "\u001b]52;c;bWFnbmV0Oj94dD11cm46YnRpaDphYmM=\u0007",
+        );
+        expect(decodeOsc52(tty.written.join(""))).toBe("magnet:?xt=urn:btih:abc");
+      });
+    } finally {
+      tty.restore();
+    }
+  });
+
+  it("stays quiet when the platform command already worked", async () => {
+    const tty = captureTty(true);
+    try {
+      await onPlatform("darwin", async () => {
+        vi.stubEnv("SSH_TTY", "");
+        vi.stubEnv("SSH_CONNECTION", "");
+        mockSpawn(0);
+        const { writeClipboard } = await import("./clipboard");
+
+        await expect(writeClipboard("magnet:?xt=urn:btih:abc")).resolves.toBe(true);
+        expect(spawn).toHaveBeenCalledWith("pbcopy", [], { windowsHide: true });
+        expect(tty.written).toEqual([]);
+      });
+    } finally {
+      tty.restore();
+    }
+  });
+
+  it("prefers the terminal over the remote clipboard inside an SSH session", async () => {
+    const tty = captureTty(true);
+    try {
+      await onPlatform("linux", async () => {
+        vi.stubEnv("SSH_TTY", "/dev/pts/0");
+        vi.stubEnv("TMUX", "");
+        mockSpawn(0); // wl-copy would have "worked" -- on the wrong machine
+        const { writeClipboard } = await import("./clipboard");
+
+        await expect(writeClipboard("magnet:?xt=urn:btih:abc")).resolves.toBe(true);
+        expect(spawn).not.toHaveBeenCalled();
+        expect(decodeOsc52(tty.written.join(""))).toBe("magnet:?xt=urn:btih:abc");
+      });
+    } finally {
+      tty.restore();
+    }
+  });
+
+  it("wraps the sequence in a DCS passthrough inside tmux", async () => {
+    const tty = captureTty(true);
+    try {
+      await onPlatform("linux", async () => {
+        vi.stubEnv("SSH_TTY", "");
+        vi.stubEnv("SSH_CONNECTION", "");
+        vi.stubEnv("TMUX", "/tmp/tmux-1000/default,1234,0");
+        mockSpawn(1);
+        const { writeClipboard } = await import("./clipboard");
+
+        await expect(writeClipboard("hi")).resolves.toBe(true);
+        expect(tty.written.join("")).toBe("\u001bPtmux;\u001b\u001b]52;c;aGk=\u0007\u001b\\");
+      });
+    } finally {
+      tty.restore();
+    }
+  });
+
+  it("still reports failure when there is no terminal to ask", async () => {
+    const tty = captureTty(false);
+    try {
+      await onPlatform("linux", async () => {
+        vi.stubEnv("SSH_TTY", "");
+        vi.stubEnv("SSH_CONNECTION", "");
+        vi.stubEnv("TMUX", "");
+        mockSpawn(1);
+        const { writeClipboard } = await import("./clipboard");
+
+        await expect(writeClipboard("magnet:?xt=urn:btih:abc")).resolves.toBe(false);
+        expect(tty.written).toEqual([]);
+      });
+    } finally {
+      tty.restore();
+    }
+  });
+});

--- a/src/util/clipboard.ts
+++ b/src/util/clipboard.ts
@@ -83,7 +83,7 @@ export async function readClipboard(): Promise<string> {
   return "";
 }
 
-export async function writeClipboard(text: string): Promise<boolean> {
+async function writeNative(text: string): Promise<boolean> {
   if (process.platform === "win32") {
     return write(
       "powershell",
@@ -98,4 +98,60 @@ export async function writeClipboard(text: string): Promise<boolean> {
     if (await write(cmd, args, text)) return true;
   }
   return false;
+}
+
+// OSC 52 asks the terminal emulator itself to set the clipboard:
+// ESC ] 52 ; c ; <base64> BEL. It needs no helper binary, which is the whole
+// point — it is the one mechanism that still works when wl-copy, xclip and xsel
+// are all absent, and the only one that reaches the clipboard of the machine the
+// user is actually sitting at when torlink runs over SSH. torlink already knows
+// this sequence from the other direction: stripControl() in util/format.ts
+// exists so a hijacked source cannot smuggle one in through a name or a magnet.
+//
+// A terminal never acknowledges OSC 52, so `true` here means the request
+// reached the terminal, not that the clipboard now holds the text. That is the
+// honest limit of the mechanism, and it beats telling someone the copy failed
+// when it almost certainly did not.
+
+// Terminals cap the payload they will accept. A silently truncated paste is
+// worse than no paste, so anything past the cap is left to the helper binaries.
+// A magnet with every default tracker is well under 2 KB.
+const OSC52_MAX_BASE64 = 100_000;
+
+function ttyStream(): NodeJS.WriteStream | null {
+  if (process.stderr.isTTY) return process.stderr;
+  if (process.stdout.isTTY) return process.stdout;
+  return null;
+}
+
+function writeOsc52(text: string): boolean {
+  const stream = ttyStream();
+  if (!stream) return false;
+  const payload = Buffer.from(text, "utf8").toString("base64");
+  if (payload.length > OSC52_MAX_BASE64) return false;
+  const seq = `\u001b]52;c;${payload}\u0007`;
+  try {
+    // tmux drops an application's OSC 52 unless set-clipboard is `on`, and its
+    // default is `external`. Wrapping it in a DCS passthrough hands the sequence
+    // to the outer terminal whatever that setting is. TMUX is set by tmux itself,
+    // so this never fires anywhere else.
+    stream.write(process.env.TMUX ? `\u001bPtmux;\u001b${seq}\u001b\\` : seq);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Over SSH the helper binaries set the clipboard of the machine torlink is
+// running on, not the one in front of the user, so the magnet lands somewhere
+// they can never paste from — a success that is really a failure. Where that is
+// the situation, ask the terminal first.
+function isRemoteSession(): boolean {
+  return Boolean(process.env.SSH_TTY || process.env.SSH_CONNECTION);
+}
+
+export async function writeClipboard(text: string): Promise<boolean> {
+  if (isRemoteSession() && writeOsc52(text)) return true;
+  if (await writeNative(text)) return true;
+  return writeOsc52(text);
 }


### PR DESCRIPTION
## What and why

`writeClipboard` has no last resort. When the platform helper is missing or fails it returns `false`, `y` prints *"Couldn't copy magnet for …"* (#167), and the magnet is simply out of reach — the whole reason the key exists is gone, with no way to recover it from the TUI.

There is a second, quieter version of the same problem. Over SSH the helpers that *do* exist are worse than none:

```ts
// src/util/clipboard.ts
if (process.platform === "darwin") return write("pbcopy", [], text);
for (const [cmd, args] of LINUX_WRITE) { ... }   // wl-copy, xclip, xsel
```

Every one of those sets the clipboard of the machine **torlink is running on**, not the machine the user is sitting at. The copy reports success, and the magnet lands somewhere they can never paste from.

### OSC 52

Writing `ESC ] 52 ; c ; <base64> BEL` to the tty asks the terminal emulator itself to set the clipboard. No helper binary, and no dependence on which machine the process runs on — the terminal is always the user's.

torlink already knows this sequence, from the other direction. `stripControl()` in `src/util/format.ts` exists precisely so a hijacked source cannot smuggle one in through a name or a magnet:

```ts
// ...so a malicious or hijacked source can't smuggle e.g. an OSC-52
// clipboard-write sequence to the terminal through them.
```

This PR uses it deliberately, on torlink's own text, in the one place a user asked for it.

### What actually changed

```ts
export async function writeClipboard(text: string): Promise<boolean> {
  if (isRemoteSession() && writeOsc52(text)) return true;
  if (await writeNative(text)) return true;
  return writeOsc52(text);
}
```

- **On a desktop nothing changes.** The helpers are tried first and still win when they work — the existing test still asserts `wl-copy` gets the text, and a new one asserts no escape sequence is emitted when `pbcopy` succeeds.
- **In an SSH session the terminal is asked first**, because there the helper's "success" *is* the failure. Detected with `SSH_TTY` / `SSH_CONNECTION`.
- **Inside tmux the sequence goes through a DCS passthrough** (`ESC P tmux ; ESC <seq> ESC \`). tmux drops an application's OSC 52 unless `set-clipboard` is `on`, and its default is `external`; the passthrough hands it to the outer terminal regardless. Gated on `TMUX`, which only tmux sets.
- **With no tty, `false` exactly as before.** Payloads over 100 KB are left to the helpers too — a silently truncated paste is worse than none. A magnet with every default tracker is well under 2 KB.
- `readClipboard` is untouched. OSC 52 *reads* are a different thing entirely and most terminals disable them for good reason.

### One honest limitation

A terminal never acknowledges OSC 52, so `true` on that path means *the request reached the terminal*, not *the clipboard now holds the text*. I would rather state that plainly than hide it. The alternative is what happens today: telling someone the copy failed when it almost certainly worked.

### On #167

I could not reproduce it. The screenshot is Windows Terminal, and here `powershell -NoProfile -Command "Set-Clipboard …"` completes in ~350 ms with the magnet intact, so I do not know which of the Windows failure modes that reporter hit (`powershell.exe` off `PATH`, constrained-language mode blocking `[Console]::In.ReadToEnd()`, an AV blocking the spawn, or a cold start past the 4 s timeout). I am not claiming this PR diagnoses it. What it does is make every one of those endings recoverable instead of terminal, on a terminal that supports OSC 52 — which Windows Terminal does.

### Tests

`src/util/clipboard.test.ts`, following #6's pattern of mocking `node:child_process`, plus a small tty capture for the escape sequence: fallback after all three Linux helpers fail (asserting the exact bytes and the decoded payload), silence when `pbcopy` succeeds, terminal-first under SSH with `spawn` never called, the tmux DCS wrapper, and `false` when there is no tty.

```
npm run typecheck   clean
npm test            45 files, 316 tests, all passing
```

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a, `y` already exists and is unchanged
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [x] OS-touching code works on Windows, macOS, and Linux — the fallback is platform-independent and the platform branches are untouched
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
