### PR TITLE
fix: make EZTV answer a search instead of returning nothing

### DIFF
--- a/src/sources/eztv.test.ts
+++ b/src/sources/eztv.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetch = vi.fn();
+
+vi.mock("../util/net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../util/net")>();
+  return { ...actual, fetchResilient: mockFetch };
+});
+
+const ok = (torrents: unknown[]): Response =>
+  ({ ok: true, status: 200, json: async () => ({ torrents }) }) as unknown as Response;
+
+function row(title: string, hash: string, extra: Record<string, unknown> = {}) {
+  return {
+    title,
+    hash,
+    magnet_url: `magnet:?xt=urn:btih:${hash}&dn=${encodeURIComponent(title)}`,
+    imdb_id: "111",
+    seeds: 10,
+    peers: 1,
+    size_bytes: "1000",
+    date_released_unix: 1_700_000_000,
+    ...extra,
+  };
+}
+
+// Every request the source makes goes through this, keyed on what the API
+// actually reads: the page number and the imdb_id.
+function respond(reply: (page: number, imdbId: string | null) => unknown[] | number): void {
+  mockFetch.mockImplementation(async (url: string) => {
+    const params = new URL(String(url)).searchParams;
+    const out = reply(Number(params.get("page")), params.get("imdb_id"));
+    // A number stands for an HTTP status the source has to deal with itself.
+    if (typeof out === "number") return { ok: false, status: out } as unknown as Response;
+    return ok(out);
+  });
+}
+
+const urls = (): string[] => mockFetch.mock.calls.map((c) => String(c[0]));
+
+// The recent-feed index is shared across queries, so each test starts from a
+// fresh module rather than a leftover one.
+async function freshEztv(): Promise<typeof import("./eztv").eztv> {
+  vi.resetModules();
+  return (await import("./eztv")).eztv;
+}
+
+const JUDY = row("Judy Justice S04E79 1080p WEB h264", "a".repeat(40));
+const JUDY_OLD = row("Judy Justice S01E01 720p WEB h264", "b".repeat(40));
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("eztv search", () => {
+  it("asks for one page and nothing else when the query is empty", async () => {
+    respond(() => [JUDY]);
+    const eztv = await freshEztv();
+
+    const res = await eztv.search("");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(urls()[0]).toContain("page=1");
+    expect(urls()[0]).not.toContain("imdb_id");
+    expect(res).toHaveLength(1);
+    expect(res[0]!.source).toBe("eztv");
+  });
+
+  it("finds the show in the recent feed, then asks for its whole catalogue", async () => {
+    // The feed only reaches back a couple of days; S01E01 is only ever going to
+    // come back from the imdb_id query.
+    respond((page, imdbId) => {
+      if (imdbId === "111") return [JUDY, JUDY_OLD];
+      return page === 1 ? [JUDY] : [];
+    });
+    const eztv = await freshEztv();
+
+    const res = await eztv.search("judy justice");
+
+    expect(urls().some((u) => u.includes("imdb_id=111"))).toBe(true);
+    expect(res.map((r) => r.infoHash).sort()).toEqual(["a".repeat(40), "b".repeat(40)]);
+    expect(res.map((r) => r.name)).toContain("Judy Justice S01E01 720p WEB h264");
+  });
+
+  it("never asks for a catalogue when nothing in the feed matches", async () => {
+    respond(() => [JUDY]);
+    const eztv = await freshEztv();
+
+    await expect(eztv.search("south park")).resolves.toEqual([]);
+    expect(urls().every((u) => !u.includes("imdb_id"))).toBe(true);
+  });
+
+  it("narrows rather than fails when a deeper page is unavailable", async () => {
+    respond((page, imdbId) => {
+      if (imdbId === "111") return [JUDY, JUDY_OLD];
+      if (page === 1) return [JUDY];
+      if (page === 4) return 503;
+      return [];
+    });
+    const eztv = await freshEztv();
+
+    const res = await eztv.search("judy justice");
+
+    expect(res.length).toBeGreaterThan(0);
+  });
+
+  it("still surfaces the error when the first page is unavailable", async () => {
+    respond((page) => (page === 1 ? 503 : []));
+    const eztv = await freshEztv();
+
+    await expect(eztv.search("judy justice")).rejects.toThrow(/503/);
+  });
+
+  it("reuses the recent feed across queries instead of refetching it", async () => {
+    respond((page, imdbId) => {
+      if (imdbId === "111") return [JUDY, JUDY_OLD];
+      return page === 1 ? [JUDY] : [];
+    });
+    const eztv = await freshEztv();
+
+    await eztv.search("judy justice");
+    const afterFirst = mockFetch.mock.calls.length;
+    await eztv.search("judy justice 1080p");
+
+    // Only the catalogue request, never the ten index pages again.
+    expect(mockFetch.mock.calls.length - afterFirst).toBe(1);
+  });
+});

--- a/src/sources/eztv.ts
+++ b/src/sources/eztv.ts
@@ -4,11 +4,33 @@ import type { SearchOptions, Source, TorrentResult } from "./types";
 
 const API = "https://eztvx.to/api/get-torrents";
 
+// EZTV's API takes no text query. limit, page and imdb_id are the only inputs
+// it reads -- keywords, q, search and title are accepted and ignored, every one
+// of them answering with the same unfiltered latest page -- and the HTML search
+// route is behind Cloudflare on every mirror (eztvx.to, eztv.re, eztv.wf,
+// eztv.tf, eztv.yt, eztv1.xyz all answer /search/ with 403 "Just a moment").
+// So a show name has to become an imdb_id before EZTV can answer it, and the
+// only place to get that mapping without reaching for another service is EZTV's
+// own feed: every row carries its show's imdb_id. Match the query against the
+// recent feed, then ask for the shows it matched by id, which returns the whole
+// catalogue rather than the couple of days the feed itself spans.
+const PAGE_LIMIT = 100; // above 100 the API quietly answers with 30
+const INDEX_PAGES = 10; // ~1000 rows, ~250 distinct shows, ~2.5 days of releases
+const MAX_SHOWS = 2;
+const MAX_RESULTS = 100; // one API page's worth, like every other query here
+
+// The recent feed is the same for every query, so it is fetched once and shared
+// instead of per query, on the same five-minute life the per-query cache in
+// cache.ts uses.
+const INDEX_TTL_MS = 5 * 60 * 1000;
+let index: { at: number; rows: EztvTorrent[] } | null = null;
+
 interface EztvTorrent {
   title?: string;
   filename?: string;
   hash?: string;
   magnet_url?: string;
+  imdb_id?: string;
   seeds?: number;
   peers?: number;
   size_bytes?: string | number;
@@ -18,35 +40,107 @@ interface EztvResponse {
   torrents?: EztvTorrent[];
 }
 
-async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
-  if (query.trim()) return [];
-
-  const res = await fetchResilient(`${API}?limit=100&page=1`, {
+async function fetchPage(
+  params: Record<string, string>,
+  opts: SearchOptions,
+  retries: number,
+): Promise<EztvTorrent[]> {
+  const qs = new URLSearchParams({ limit: String(PAGE_LIMIT), ...params });
+  const res = await fetchResilient(`${API}?${qs.toString()}`, {
     headers: { "User-Agent": USER_AGENT },
     signal: opts.signal,
-    retries: 1,
+    retries,
   });
   if (!res.ok) throw new HttpError(res.status, `EZTV returned ${res.status}`);
-
   const json = (await res.json()) as EztvResponse;
-  const out: TorrentResult[] = [];
-  for (const t of json.torrents ?? []) {
-    const hash = (t.hash ?? "").toLowerCase();
-    const name = t.title || t.filename || hash;
-    const magnet = t.magnet_url || (hash ? buildMagnet(hash, name) : "");
-    if (!magnet || !hash) continue;
-    out.push({
-      infoHash: hash,
-      name,
-      sizeBytes: Number(t.size_bytes ?? 0) || 0,
-      seeders: t.seeds ?? 0,
-      leechers: t.peers ?? 0,
-      source: "eztv",
-      magnet,
-      added: t.date_released_unix,
-    });
+  return json.torrents ?? [];
+}
+
+async function recentIndex(opts: SearchOptions): Promise<EztvTorrent[]> {
+  const now = Date.now();
+  if (index && now - index.at < INDEX_TTL_MS) return index.rows;
+
+  // Page 1 is the request EZTV has always made here, and it still decides
+  // whether the source is reachable at all. The deeper pages only widen the
+  // window, so one of them failing narrows the search instead of breaking it.
+  const pages = Array.from({ length: INDEX_PAGES }, (_, i) =>
+    fetchPage({ page: String(i + 1) }, opts, i === 0 ? 1 : 0),
+  );
+  const guarded = pages.map((p, i) => (i === 0 ? p : p.catch(() => [] as EztvTorrent[])));
+  const rows = (await Promise.all(guarded)).flat();
+  index = { at: now, rows };
+  return rows;
+}
+
+function haystack(t: EztvTorrent): string {
+  return `${t.title ?? ""} ${t.filename ?? ""}`.toLowerCase();
+}
+
+function matches(t: EztvTorrent, tokens: string[]): boolean {
+  const name = haystack(t);
+  return tokens.every((token) => name.includes(token));
+}
+
+function toResult(t: EztvTorrent): TorrentResult | null {
+  const hash = (t.hash ?? "").toLowerCase();
+  const name = t.title || t.filename || hash;
+  const magnet = t.magnet_url || (hash ? buildMagnet(hash, name) : "");
+  if (!magnet || !hash) return null;
+  return {
+    infoHash: hash,
+    name,
+    sizeBytes: Number(t.size_bytes ?? 0) || 0,
+    seeders: t.seeds ?? 0,
+    leechers: t.peers ?? 0,
+    source: "eztv",
+    magnet,
+    added: t.date_released_unix,
+  };
+}
+
+// A show's own catalogue overlaps the recent feed by definition, so the same
+// hash arrives twice; keep the first and stop there.
+function toResults(rows: EztvTorrent[]): TorrentResult[] {
+  const byHash = new Map<string, TorrentResult>();
+  for (const row of rows) {
+    const r = toResult(row);
+    if (r && !byHash.has(r.infoHash)) byHash.set(r.infoHash, r);
   }
-  return out;
+  return [...byHash.values()];
+}
+
+function showIdsOf(hits: EztvTorrent[]): string[] {
+  const ids: string[] = [];
+  for (const t of hits) {
+    const id = (t.imdb_id ?? "").trim();
+    if (!id || id === "0" || ids.includes(id)) continue;
+    ids.push(id);
+    if (ids.length === MAX_SHOWS) break;
+  }
+  return ids;
+}
+
+async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
+  const q = query.trim();
+  // The empty query is the popular list, and one page is what it has always
+  // been. Widening the index there would make every startup ten times heavier
+  // for a view that does not need it.
+  if (!q) return toResults(await fetchPage({ page: "1" }, opts, 1));
+
+  const tokens = q.toLowerCase().split(/\s+/).filter(Boolean);
+  const recent = await recentIndex(opts);
+  const hits = recent.filter((t) => matches(t, tokens));
+
+  const catalogues = await Promise.all(
+    showIdsOf(hits).map((imdb_id) =>
+      fetchPage({ page: "1", imdb_id }, opts, 0).catch(() => [] as EztvTorrent[]),
+    ),
+  );
+
+  const rows = [...hits, ...catalogues.flat().filter((t) => matches(t, tokens))];
+  return toResults(rows)
+    .sort((a, b) => b.seeders - a.seeders)
+    .slice(0, MAX_RESULTS);
 }
 
 export const eztv: Source = {


### PR DESCRIPTION
## What and why

`src/sources/eztv.ts` opens with:

```ts
async function search(query: string, opts: SearchOptions = {}): Promise<TorrentResult[]> {
  if (query.trim()) return [];
```

So one of the four TV sources returns nothing for every real query. In the UI that reads as *"EZTV has nothing for this"*, when what actually happened is that EZTV was never asked. It has been that way since the first commit.

### Why it was never asked

Because the obvious ways do not work, and I checked both:

**The API takes no text query.** `limit`, `page` and `imdb_id` are the only inputs it reads. Every text parameter is accepted and silently ignored — each of these returns the same unfiltered latest page:

```
?limit=10&page=1&keywords=daredevil  -> "Motorway Cops Catching Britains Speeders S10E05…"
?limit=10&page=1&q=daredevil         -> "Motorway Cops Catching Britains Speeders S10E05…"
?limit=10&page=1&search=daredevil    -> "Motorway Cops Catching Britains Speeders S10E05…"
?limit=10&page=1&title=daredevil     -> "Motorway Cops Catching Britains Speeders S10E05…"
```

**The HTML search route is behind Cloudflare on every mirror.** `GET /search/daredevil-born-again`:

| host | status |
| --- | --- |
| eztvx.to, eztv.re, eztv.it, eztv.ch, eztv.ag | 403 `Just a moment…` |
| eztv.wf, eztv.tf, eztv.yt, eztv1.xyz | 403 `Just a moment…` |

(`/showlist/`, `/shows/` and `/home/` are 403 too. Only `/` and `/api/` answer.)

### What the API does have

`imdb_id`, and it is not a filter over the recent feed — it returns the show's **whole catalogue**:

```
?imdb_id=0121955  ->  torrents_count: 658   (South Park, back years)
?imdb_id=15521024 ->  torrents_count: 304   (2025-07-14 … 2026-08-28)
```

And the missing half of that lookup is already in the response torlink throws away today — **every row in the feed carries its show's `imdb_id`** (93 of the 100 rows on page 1).

So a name *can* become an id without reaching for another service: match the query against the recent feed, take the `imdb_id` of what it matched, and ask for those shows in full.

```
query -> tokens
      -> match against the recent feed (10 pages, ~1000 rows, ~250 shows)
      -> imdb_id of the matches (max 2 shows)
      -> ?imdb_id=… , the show's whole catalogue
      -> token-filter, dedupe by hash, seeders desc
```

### Live results, against eztvx.to today

| query | before | after | top row |
| --- | --- | --- | --- |
| `judy justice` | 0 | 100 | `Judy Justice S04E79 1080p WEB h264-EDITH` · 55 seeders |
| `big brother` | 0 | 100 | `Big Brother US S28E25 1080p HEVC x265-MeGusta` · 448 seeders |
| `the amazing race` | 0 | 100 | `The Amazing Race Canada S12E07 1080p HDTV x264` · 128 seeders |
| `south park` | 0 | 0 | — |

`south park` is the honest ceiling: the feed spans about two and a half days, so a show that has not aired recently is not in it and cannot be turned into an id. That is as far as this API goes without a third-party metadata lookup, and it covers the currently-airing TV EZTV is actually used for. I would rather ship that and say so than claim a general search.

### Cost

- The ten index pages are **fetched once and shared across queries**, on the same five-minute life the per-query cache in `cache.ts` uses. First search: 10 requests + 1. Every search after that, until the index ages out: **1 request**. Over a session that is fewer requests than 1337x makes for a single query.
- Measured at ~500 ms cold for the ten pages in parallel, ~250 ms warm.
- **The empty query is untouched** — still exactly one page, so startup and the popular list cost what they always did. Widening the index there would make every launch ten times heavier for a view that does not need it.
- A deeper index page failing narrows the window instead of breaking the search. Only page one failing still surfaces as an error, exactly as before.

### Tests

`src/sources/eztv.test.ts` (new), mocking `fetchResilient` the way `piratebay.test.ts` does: the empty query still makes one request and never sends `imdb_id`; a matching query reaches the catalogue and returns an episode the feed never held; a non-matching query never asks for a catalogue; a failed deeper page narrows rather than fails; a failed first page still throws; and a second query reuses the index instead of refetching it.

```
npm run typecheck   clean
npm test            46 files, 317 tests, all passing
```

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [x] OS-touching code works on Windows, macOS, and Linux — n/a, network only
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`) — a fix to a source already here, not a new one
