### PR TITLE
feat: add TORLINK_NO_WEBRTC to turn the WebRTC stack off per machine

### DIFF
--- a/scripts/cli-entry.cjs
+++ b/scripts/cli-entry.cjs
@@ -12,47 +12,71 @@ if (major < 22) {
   process.exit(1);
 }
 
-// The WebRTC stack (webtorrent -> simple-peer -> webrtc-polyfill) eagerly
-// requires node-datachannel's native binary, which only install scripts
-// download; npm 12 skips those scripts by default, so the binary is often
-// absent and the eager import would kill startup. When it cannot load,
-// resolve webrtc-polyfill to an inert stub instead: simple-peer then reports
+// Resolve webrtc-polyfill to an inert stub: simple-peer then reports
 // WEBRTC_SUPPORT = false and downloads run on TCP/uTP and DHT peers alone.
-try {
-  require('node-datachannel');
-} catch (err) {
+// Returns false on Node 22.0 to 22.14, which has no module.registerHooks and
+// so cannot redirect the eager import at all.
+function useWebrtcStub() {
   var Module = require('node:module');
-  if (typeof Module.registerHooks === 'function') {
-    var stubUrl = require('node:url')
-      .pathToFileURL(require('node:path').join(__dirname, 'webrtc-stub.mjs'))
-      .href;
-    Module.registerHooks({
-      resolve: function (specifier, context, nextResolve) {
-        if (specifier === 'webrtc-polyfill') {
-          return { url: stubUrl, shortCircuit: true };
-        }
-        return nextResolve(specifier, context);
-      },
-    });
-    process.stderr.write(
-      'torlnk: WebRTC peers unavailable (native module not installed); ' +
-        'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
-    );
+  if (typeof Module.registerHooks !== 'function') return false;
+  var stubUrl = require('node:url')
+    .pathToFileURL(require('node:path').join(__dirname, 'webrtc-stub.mjs'))
+    .href;
+  Module.registerHooks({
+    resolve: function (specifier, context, nextResolve) {
+      if (specifier === 'webrtc-polyfill') {
+        return { url: stubUrl, shortCircuit: true };
+      }
+      return nextResolve(specifier, context);
+    },
+  });
+  return true;
+}
+
+// The same switch, thrown on purpose. On some machines node-datachannel's
+// native event loop burns a core for as long as torlink is open, idle or not
+// (issue #119), and nothing inside it can be turned down at runtime. Rather
+// than decide for a whole platform, let the person watching their fan spin opt
+// out on their own machine: TCP/uTP and DHT peers are where torlink's swarms
+// are anyway. Presence is the switch, like TORLINK_NO_UPDATE_CHECK.
+if (process.env.TORLINK_NO_WEBRTC) {
+  if (useWebrtcStub()) {
+    process.stderr.write('torlnk: WebRTC peers disabled by TORLINK_NO_WEBRTC.\n');
   } else {
-    // Node 22.0 to 22.14 has no module.registerHooks, so the eager import
-    // cannot be redirected; a clear explanation beats the raw module error.
     process.stderr.write(
-      '\ntorlnk needs the WebRTC native module (node-datachannel), and it is\n' +
-        'not installed. Either upgrade to Node 22.15+ (torlnk then runs\n' +
-        'without WebRTC peers), or install the build tools and reinstall:\n' +
-        '  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static\n' +
-        '  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev\n' +
-        '  macOS:   xcode-select --install\n' +
-        '  Windows: install CMake and Visual Studio Build Tools\n' +
-        'On npm 12, also allow install scripts: npm approve-scripts\n\n' +
-        'https://github.com/baairon/torlink/issues/60\n\n'
+      'torlnk: TORLINK_NO_WEBRTC needs Node 22.15 or later to take effect; ' +
+        'WebRTC peers stay enabled on v' + process.versions.node + '.\n'
     );
-    process.exit(1);
+  }
+} else {
+  // The WebRTC stack (webtorrent -> simple-peer -> webrtc-polyfill) eagerly
+  // requires node-datachannel's native binary, which only install scripts
+  // download; npm 12 skips those scripts by default, so the binary is often
+  // absent and the eager import would kill startup.
+  try {
+    require('node-datachannel');
+  } catch (err) {
+    if (useWebrtcStub()) {
+      process.stderr.write(
+        'torlnk: WebRTC peers unavailable (native module not installed); ' +
+          'TCP/UDP peers still work. https://github.com/baairon/torlink/issues/60\n'
+      );
+    } else {
+      // Node 22.0 to 22.14 has no module.registerHooks, so the eager import
+      // cannot be redirected; a clear explanation beats the raw module error.
+      process.stderr.write(
+        '\ntorlnk needs the WebRTC native module (node-datachannel), and it is\n' +
+          'not installed. Either upgrade to Node 22.15+ (torlnk then runs\n' +
+          'without WebRTC peers), or install the build tools and reinstall:\n' +
+          '  Fedora:  sudo dnf install cmake gcc-c++ openssl-devel libstdc++-static\n' +
+          '  Debian / Ubuntu:  sudo apt install cmake g++ libssl-dev\n' +
+          '  macOS:   xcode-select --install\n' +
+          '  Windows: install CMake and Visual Studio Build Tools\n' +
+          'On npm 12, also allow install scripts: npm approve-scripts\n\n' +
+          'https://github.com/baairon/torlink/issues/60\n\n'
+      );
+      process.exit(1);
+    }
   }
 }
 

--- a/scripts/cli-entry.test.mjs
+++ b/scripts/cli-entry.test.mjs
@@ -1,0 +1,30 @@
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const entry = fileURLToPath(new URL("./cli-entry.cjs", import.meta.url));
+
+// cli-entry settles the WebRTC question and only then imports ./index.js,
+// which exists in dist/ and not in scripts/. Run from here that import fails
+// and the process exits, which leaves exactly the part under test on stderr.
+function runEntry(env) {
+  const res = spawnSync(process.execPath, [entry], {
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+  return res.stderr ?? "";
+}
+
+describe("TORLINK_NO_WEBRTC", () => {
+  it("turns WebRTC off when it is set", () => {
+    // The second branch is Node 22.0-22.14, where module.registerHooks does not
+    // exist and the opt-out says so rather than pretending to work.
+    expect(runEntry({ TORLINK_NO_WEBRTC: "1" })).toMatch(
+      /WebRTC peers disabled by TORLINK_NO_WEBRTC|TORLINK_NO_WEBRTC needs Node 22\.15/,
+    );
+  });
+
+  it("says nothing about the flag when it is unset", () => {
+    expect(runEntry({ TORLINK_NO_WEBRTC: "" })).not.toMatch(/TORLINK_NO_WEBRTC/);
+  });
+});


### PR DESCRIPTION
## What and why

#119 has been open since June and still has no fix. On some machines `node-datachannel`'s native event loop burns a core for as long as torlink is open, idle or not, and there is no runtime setting inside it to turn that down.

torlink already has the switch that stops it. `scripts/cli-entry.cjs` pulls it whenever the native module is missing:

```js
Module.registerHooks({
  resolve: function (specifier, context, nextResolve) {
    if (specifier === 'webrtc-polyfill') return { url: stubUrl, shortCircuit: true };
    ...
```

simple-peer then computes `WEBRTC_SUPPORT = false` and downloads run on TCP/uTP and DHT peers — which is where torlink's swarms are anyway. Thousands of users are already running exactly that configuration today, because the binary failed to install.

This PR exposes that switch to the person who needs it:

```sh
TORLINK_NO_WEBRTC=1 torlnk
# torlnk: WebRTC peers disabled by TORLINK_NO_WEBRTC.
```

### On maintenance mode

This is the one change in the set that is feature-shaped, so I want to be straight about it rather than dress it up as a fix. Three reasons I think it still fits:

- It is the **smaller shape of a change you already turned down**. #121 answered the same issue by detecting `darwin` and disabling WebRTC for every macOS user. This decides nothing for anybody — it costs nothing to a user who never sets it, and it does not guess whose fan is spinning.
- It is **the escape hatch you have offered twice**: a headless env-var flag, the same shape as `TORLINK_MAX_DOWNLOADS` in #102.
- It is **the only answer available**. The CPU cost is inside a native event loop; there is no per-instance flag to pass and no constructor option to set.

If it is still a no, close it — no argument from me. #119 is open with people asking "no fix yet?", and this is the smallest honest thing I could hand them.

### The change

`scripts/cli-entry.cjs` only. The redirect is unchanged; it is lifted into `useWebrtcStub()` so both callers share it instead of one inlining it:

```js
if (process.env.TORLINK_NO_WEBRTC) {
  // opted out
} else {
  try { require('node-datachannel'); } catch (err) { /* existing fallback */ }
}
```

Presence is the switch, matching `TORLINK_NO_UPDATE_CHECK` in `App.tsx:177`. On Node 22.0–22.14 there is no `module.registerHooks`, so the flag says it cannot take effect rather than pretending it did.

### Verified

Built and run against `dist/cli.cjs`:

```
$ node dist/cli.cjs --version
torlink v1.7.0

$ TORLINK_NO_WEBRTC=1 node dist/cli.cjs --version
torlnk: WebRTC peers disabled by TORLINK_NO_WEBRTC.
torlink v1.7.0
```

and the redirect really lands — importing `webrtc-polyfill` under the same hook gives:

```
RTCPeerConnection is undefined -> simple-peer WEBRTC_SUPPORT = false
```

I could not reproduce the 100% CPU myself; #119 is reported on macOS and I am on Windows. So I am not claiming this diagnoses the spin, only that it hands the affected user the switch. Worth noting alongside this: `node-datachannel` 0.33 replaced the whole prebuilt/loader path, so the bump in my other PR may change the behaviour on its own — this flag is useful either way, and independent of it.

### Test

`scripts/cli-entry.test.mjs` (new) runs the real entry point in a child process. `cli-entry` settles the WebRTC question before importing `./index.js`, which does not exist under `scripts/`, so the process exits right after the part under test and leaves it on stderr: the flag set produces the opt-out line, and unset says nothing about the flag at all.

```
npm run typecheck   clean
npm test            46 files, 313 tests, all passing
npm run build       ok
```

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a, no key; this is headless-only by design
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [x] OS-touching code works on Windows, macOS, and Linux — the flag is platform-independent, which is the point
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
