### PR TITLE
fix: stop the search cache growing without a ceiling

### DIFF
--- a/src/sources/cache.test.ts
+++ b/src/sources/cache.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Source, SourceId, TorrentResult } from "./types";
+
+const MAX_ENTRIES = 100;
+
+function countingSource(id: SourceId = "nyaa"): Source & { calls: number } {
+  const source = {
+    id,
+    label: id,
+    homepage: "https://example.org",
+    reportsHealth: true,
+    calls: 0,
+    search: async (query: string): Promise<TorrentResult[]> => {
+      source.calls += 1;
+      return [
+        {
+          infoHash: "a".repeat(40),
+          name: query,
+          sizeBytes: 1,
+          seeders: 1,
+          leechers: 0,
+          source: id,
+          magnet: `magnet:?xt=urn:btih:${"a".repeat(40)}`,
+        },
+      ];
+    },
+  };
+  return source;
+}
+
+// The cache is module state, so each test starts from a fresh copy.
+async function freshCache(): Promise<typeof import("./cache").cachedSearch> {
+  vi.resetModules();
+  return (await import("./cache")).cachedSearch;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("cachedSearch", () => {
+  it("serves a repeat query from the cache", async () => {
+    const cachedSearch = await freshCache();
+    const source = countingSource();
+
+    await cachedSearch(source, "dune");
+    const again = await cachedSearch(source, "  DUNE ");
+
+    expect(source.calls).toBe(1);
+    expect(again[0]!.name).toBe("dune");
+  });
+
+  it("goes back to the source once the entry has aged out", async () => {
+    vi.useFakeTimers();
+    const cachedSearch = await freshCache();
+    const source = countingSource();
+
+    await cachedSearch(source, "dune");
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+    await cachedSearch(source, "dune");
+
+    expect(source.calls).toBe(2);
+  });
+
+  it("keeps only the most recent entries instead of growing forever", async () => {
+    const cachedSearch = await freshCache();
+    const source = countingSource();
+
+    for (let i = 0; i < MAX_ENTRIES + 10; i++) await cachedSearch(source, `query ${i}`);
+    const filled = source.calls;
+
+    // The newest is still there; the oldest was dropped to make room.
+    await cachedSearch(source, `query ${MAX_ENTRIES + 9}`);
+    expect(source.calls).toBe(filled);
+
+    await cachedSearch(source, "query 0");
+    expect(source.calls).toBe(filled + 1);
+  });
+
+  it("counts a refreshed entry as the newest, not the oldest", async () => {
+    vi.useFakeTimers();
+    const cachedSearch = await freshCache();
+    const source = countingSource();
+
+    for (let i = 0; i < MAX_ENTRIES; i++) await cachedSearch(source, `query ${i}`);
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    // Refetching the oldest query moves it to the back of the queue, so the
+    // entry evicted by the next insert is the one after it, not this one.
+    await cachedSearch(source, "query 0");
+    await cachedSearch(source, "brand new");
+    const filled = source.calls;
+
+    await cachedSearch(source, "query 0");
+    expect(source.calls).toBe(filled);
+
+    await cachedSearch(source, "query 1");
+    expect(source.calls).toBe(filled + 1);
+  });
+});

--- a/src/sources/cache.ts
+++ b/src/sources/cache.ts
@@ -2,6 +2,12 @@ import type { SearchOptions, Source, TorrentResult } from "./types";
 
 const TTL_MS = 5 * 60 * 1000;
 
+// A search fills one entry per source, so this is the last ten searches --
+// more history than a five-minute TTL can put to use. Nothing evicted anything
+// before, so the map only ever grew, holding result lists the UI had long since
+// replaced: 200 distinct searches across the ten sources retained about 80 MB.
+const MAX_ENTRIES = 100;
+
 interface Entry {
   at: number;
   results: TorrentResult[];
@@ -23,6 +29,14 @@ export async function cachedSearch(
   if (hit && Date.now() - hit.at < TTL_MS) return hit.results;
 
   const results = await source.search(query, opts);
+  // Re-inserting rather than overwriting keeps the map's iteration order equal
+  // to fetch order, so the entry that gives way below is always the oldest.
+  cache.delete(k);
   cache.set(k, { at: Date.now(), results });
+  while (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
   return results;
 }


### PR DESCRIPTION
## What and why

`src/sources/cache.ts` is a module-level `Map` that nothing ever removes from:

```ts
const cache = new Map<string, Entry>();

export async function cachedSearch(source, query, opts = {}) {
  const k = key(source.id, query);
  const hit = cache.get(k);
  if (hit && Date.now() - hit.at < TTL_MS) return hit.results;

  const results = await source.search(query, opts);
  cache.set(k, { at: Date.now(), results });
  return results;
}
```

An entry past its five-minute TTL is never read again — but it is never dropped either. The next fetch for that key overwrites it; a key nobody searches again just stays. So the map grows with every distinct query for the life of the process, holding result lists the UI replaced long ago. torlink is a program people leave open, and the daemon leaves it running longer still.

### Measured

100 results per source with a full magnet each, the shape TPB and EZTV actually return, heap read after a forced GC:

| | retained heap |
| --- | --- |
| 200 distinct searches × 10 sources, today | **79.8 MB** |
| the same, with this change | **4.0 MB** |

### The fix

A ceiling of 100 entries — one per source per search, so the last ten searches, which is more history than a five-minute TTL can put to use.

```ts
  // Re-inserting rather than overwriting keeps the map's iteration order equal
  // to fetch order, so the entry that gives way below is always the oldest.
  cache.delete(k);
  cache.set(k, { at: Date.now(), results });
  while (cache.size > MAX_ENTRIES) {
    const oldest = cache.keys().next().value;
    if (oldest === undefined) break;
    cache.delete(oldest);
  }
```

A `Map` iterates in insertion order, and `set` on an existing key leaves that key where it was. Deleting first is what makes iteration order equal to *fetch* order, so a refreshed entry counts as the newest rather than staying at the front and being evicted next.

Nothing else changes: the TTL, the key, and what a hit returns are all untouched.

### Tests

`src/sources/cache.test.ts` (new), against behaviour rather than the map itself — a source that counts its own calls: a repeat query (and a differently-cased, differently-spaced one) is served from the cache; an aged-out entry goes back to the source; past the ceiling the newest query is still cached while the oldest has been dropped; and a refreshed entry survives the next insert while the one after it does not.

```
npm run typecheck   clean
npm test            46 files, 315 tests, all passing
```

## Checklist

- [x] `npm run typecheck` is clean
- [x] `npm test` passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] If I added a key, I updated both `HELP_GROUPS` and `footerHints` in `src/ui/keymap.ts` — n/a
- [x] If I added a `Store` field, I updated `makeStore` in `scripts/render-previews-impl.tsx` — n/a
- [x] OS-touching code works on Windows, macOS, and Linux — n/a, pure logic
- [x] One concern, with a Conventional Commits title (`feat:` / `fix:` / `docs:` / `chore:`)
