### PR TITLE
fix: exit after headless server shutdown

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -69,7 +69,10 @@ if (cmd.kind === "update") {
     seedTimeMs: cmd.seedTimeMs,
     deleteFiles: cmd.deleteFiles,
   };
-  void import("./daemon/serve").then(({ runServe }) => runServe(options).catch(failHeadless));
+  void import("./daemon/serve")
+    .then(({ runServe }) => runServe(options))
+    .then(() => process.exit(0))
+    .catch(failHeadless);
 } else if (cmd.kind === "files") {
   if (cmd.daemon) daemonize("files");
   const options = {


### PR DESCRIPTION
## Summary

Hi! experimenting with this in automation and ran into a timeout scenario:

- exit the headless `serve` process after its shutdown promise resolves
- preserve the existing error path through `failHeadless`
- prevent WebTorrent handles from keeping the process alive after SIGINT/SIGTERM cleanup

## Why

`runServe()` handles SIGINT/SIGTERM by synchronously persisting queue state and suspending the runtime, then resolves. The CLI previously left the process running afterward when WebTorrent handles remained open. Under systemd this reached the 90-second stop timeout and the unit ended in `Result=timeout`.

After this change, a real systemd start/stop cycle completed in 111 ms and reported `inactive` instead of `failed`.

## Verification

- `npm run typecheck`
- `npm test` (355 passed)
- `npm run build`
- real systemd start/stop probe