### PR TITLE
seed a path: make a torrent of files you already have, and share it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,28 @@ torlink also runs without the TUI, for servers and seedboxes:
 
     torlnk search "<query>" [--category games|movies|tv|anime]
                             print one JSON document of merged search results
+    torlnk seed <path>    make a torrent of files you have, and seed it
     torlnk watch <dir>    download anything dropped into a folder
     torlnk serve          take magnets over HTTP
     torlnk files          stream finished downloads over HTTP
     torlnk attach         keep the TUI alive across ssh sessions
 
-Add `--daemon` to keep watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
+Add `--daemon` to keep seed, watch, serve, or files running after you log out; `torlnk --help` has the full list of modes and flags.
+
+### Sharing something of your own
+
+Every other way in starts from a torrent somebody else made. `seed` is the other direction:
+
+    torlnk seed ./album
+
+It hashes the files, writes `album.torrent` beside them, prints the magnet, and starts seeding. The `.torrent` is added rather than the magnet on purpose — a magnet carries no piece hashes, so the client would have to fetch metadata from a swarm that, for a torrent nobody has seen yet, has nobody in it, and would sit at zero per cent over data already on the disk.
+
+`serve` takes an uploaded `.torrent` as well as a magnet, for the same reason:
+
+    POST /add {"magnet":"magnet:?xt=..."}
+    POST /add {"torrent":"<base64>"}     # or a data: URI, as FileReader gives it
+
+The bytes travel in the request rather than a path to them: torlink does not let a network caller name a local file, and "add this torrent" should not double as "read this file off your disk".
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "create-torrent": "^6.1.2",
         "env-paths": "^4.0.0",
         "ink": "^7.0.5",
         "parse-torrent": "^11.0.21",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "access": "public"
   },
   "dependencies": {
+    "create-torrent": "^6.1.2",
     "env-paths": "^4.0.0",
     "ink": "^7.0.5",
     "parse-torrent": "^11.0.21",

--- a/src/cli/args.test.ts
+++ b/src/cli/args.test.ts
@@ -200,3 +200,28 @@ describe("parseCliArgs", () => {
     });
   });
 });
+
+describe("seed", () => {
+  it("takes the path, and the flags the other headless modes take", () => {
+    expect(parseCliArgs(["seed", "./album"])).toEqual({
+      kind: "seed",
+      path: "./album",
+      seedTimeMs: undefined,
+      deleteFiles: false,
+      daemon: false,
+    });
+    expect(parseCliArgs(["seed", "--seed-time", "2h", "--daemon", "./album"])).toEqual({
+      kind: "seed",
+      path: "./album",
+      seedTimeMs: 2 * 60 * 60 * 1000,
+      deleteFiles: false,
+      daemon: true,
+    });
+  });
+
+  // Without a path there is nothing to hash, and defaulting to the cwd would
+  // make a bare `torlnk seed` start hashing a home directory.
+  it("is invalid with no path", () => {
+    expect(parseCliArgs(["seed"])).toEqual({ kind: "invalid", arg: "seed (missing path)" });
+  });
+});

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -25,6 +25,13 @@ export type CliCommand =
       deleteFiles?: boolean;
       daemon?: boolean;
     }
+  | {
+      kind: "seed";
+      path: string;
+      seedTimeMs?: number;
+      deleteFiles?: boolean;
+      daemon?: boolean;
+    }
   | { kind: "files"; port?: number; host?: string; token?: string; dir?: string; daemon?: boolean }
   | { kind: "attach" }
   | { kind: "update"; force?: boolean }
@@ -130,6 +137,19 @@ export function parseCliArgs(argv: string[]): CliCommand {
       daemon: bools.has("daemon"),
     };
   }
+  if (a === "seed") {
+    const { bools, rest: r0 } = splitBooleans(args.slice(1));
+    const { flags, rest } = readFlags(r0);
+    const target = rest[0];
+    if (!target) return { kind: "invalid", arg: "seed (missing path)" };
+    return {
+      kind: "seed",
+      path: target,
+      seedTimeMs: seedTimeFrom(flags["seed-time"]),
+      deleteFiles: bools.has("delete-files"),
+      daemon: bools.has("daemon"),
+    };
+  }
   if (a === "files") {
     const { bools, rest: r0 } = splitBooleans(args.slice(1));
     const { flags } = readFlags(r0);
@@ -156,6 +176,7 @@ usage
   torlnk path/to/file.torrent open a .torrent file on launch
   torlnk search <query>        headless: print search results as JSON
     [--category games|movies|tv|anime]
+  torlnk seed <path>          headless: make a torrent of <path> and seed it
   torlnk watch <dir>          headless: download torrents dropped into <dir>
   torlnk serve                headless: HTTP add API (POST /add) on :9161
   torlnk files                headless: serve downloads over HTTP on :9160
@@ -172,7 +193,14 @@ watch mode (no TUI): drop a .torrent, or a .magnet/.txt holding a magnet or
 info hash, into <dir> and it downloads then seeds. Add --to <dir> to choose
 where files land. Handled files move to <dir>/.processed (or /.failed).
 
-seed mode (watch/serve): --seed-time <dur> stops seeding a torrent that long
+seed a path (no TUI): torlnk seed ./album hashes the files, writes
+album.torrent beside them, prints the magnet, and starts seeding. It adds the
+.torrent rather than the magnet on purpose: a magnet carries no piece hashes,
+so the client would have to fetch metadata from a swarm that -- for a torrent
+nobody has seen yet -- has nobody in it, and would sit at zero per cent over
+data already on the disk. Takes --seed-time, --delete-files and --daemon.
+
+seed expiry (seed/watch/serve): --seed-time <dur> stops seeding a torrent that long
 after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
 --delete-files to also remove the downloaded data when the timer expires.
 
@@ -185,6 +213,7 @@ left off. Downloads and seeds keep running while detached.
 
 serve mode (no TUI): a small HTTP API for handing torlink a magnet.
   POST /add {"magnet":"..."}   queue a magnet or info hash
+  POST /add {"torrent":"<b64>"} queue an uploaded .torrent (base64 or data: URI)
   GET  /downloads              list active downloads and seeds
   GET  /health                 liveness (no auth)
 flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),

--- a/src/create-torrent.d.ts
+++ b/src/create-torrent.d.ts
@@ -1,0 +1,24 @@
+// create-torrent ships no types, in the same way parse-torrent does not. Only
+// the callback form is declared, because it is the only one torlink calls: the
+// package also accepts streams and File objects, and declaring shapes we never
+// use is how a hand-written declaration drifts from the package it describes.
+declare module "create-torrent" {
+  interface CreateTorrentOptions {
+    announce?: string[];
+    name?: string;
+    comment?: string;
+    createdBy?: string;
+    creationDate?: number;
+    private?: boolean;
+    pieceLength?: number;
+    urlList?: string[];
+  }
+
+  function createTorrent(
+    input: string,
+    opts: CreateTorrentOptions,
+    callback: (err: Error | null, torrent: Uint8Array) => void,
+  ): void;
+
+  export = createTorrent;
+}

--- a/src/daemon/seed.paths.test.ts
+++ b/src/daemon/seed.paths.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+
+import { seedRootFor } from "./seed";
+
+describe("seedRootFor", () => {
+  /*
+   * The one calculation that decides whether seeding works or silently
+   * re-downloads. A torrent names its own top-level entry, so the client's
+   * download directory has to be the content's PARENT: pointed at the content
+   * itself it looks for album/album, finds nothing, and fetches a second copy
+   * next to the one already on disk.
+   */
+  it("is the content's parent, never the content", () => {
+    expect(seedRootFor("/srv/media/album")).toBe("/srv/media");
+    expect(seedRootFor("/srv/media/film.mkv")).toBe("/srv/media");
+  });
+
+  it("resolves a relative path before taking the parent", () => {
+    expect(path.isAbsolute(seedRootFor("./album"))).toBe(true);
+    expect(seedRootFor("./album")).toBe(process.cwd());
+  });
+
+  // A trailing slash is what tab-completion gives you for a directory, and it
+  // would otherwise make dirname return the directory itself.
+  it("is not fooled by a trailing slash", () => {
+    expect(seedRootFor("/srv/media/album/")).toBe("/srv/media");
+  });
+});

--- a/src/daemon/seed.ts
+++ b/src/daemon/seed.ts
@@ -1,0 +1,74 @@
+// Headless seed mode: make a torrent out of files you already have, and serve
+// them to the swarm.
+//
+// Every other way into torlink starts from a torrent somebody else made. This
+// is the origin case, and it is the one thing the client could not do: search
+// finds torrents, the watch folder is handed them, the API is posted them —
+// none of that helps when the content is yours and no torrent for it exists.
+//
+// The order matters and is the whole trick. Create the .torrent first, write it
+// beside the data, then add it BY PATH. Adding the magnet instead would be
+// correct and useless: a magnet carries no piece hashes, so the client has to
+// fetch metadata from the swarm before it can verify anything — and the swarm
+// for a torrent nobody has ever seen has no one in it to fetch from. It would
+// sit at zero per cent forever, seeding data that is already on the disk under
+// it. Handed the .torrent, it verifies locally and is seeding in seconds.
+
+import path from "node:path";
+
+import { loadConfig } from "../config/config";
+import { createTorrentFor } from "../download/create";
+import { saveTorrentMeta } from "../download/persist";
+import { startRuntime, addInput } from "./runtime";
+import { startSeedReaper } from "./seed-reaper";
+
+export interface SeedOptions {
+  seedTimeMs?: number;
+  deleteFiles?: boolean;
+}
+
+function log(message: string): void {
+  console.log(`[torlnk seed] ${new Date().toISOString()} ${message}`);
+}
+
+// The directory a client must be pointed at for existing data to verify.
+//
+// A torrent names its own top-level entry, so seeding /srv/media/album means
+// the client's download directory has to be /srv/media — point it at the album
+// itself and it looks for /srv/media/album/album, finds nothing, and downloads
+// a complete copy next to the one already there.
+export function seedRootFor(target: string): string {
+  return path.dirname(path.resolve(target));
+}
+
+export async function runSeed(target: string, options: SeedOptions = {}): Promise<void> {
+  const root = seedRootFor(target);
+  const config = await loadConfig();
+
+  log(`hashing ${path.resolve(target)}`);
+  const created = await createTorrentFor(target, config.trackers);
+  log(`wrote ${created.torrentPath}`);
+
+  // Store the metadata where the queue looks for it BEFORE adding. This is the
+  // step that makes the difference between seeding and pretending to: with it,
+  // the engine is handed piece hashes and verifies the files already on disk;
+  // without it, it gets a bare magnet and waits for a swarm that has nobody in
+  // it to send back the metadata for a torrent that has never existed.
+  await saveTorrentMeta(created.infoHash, created.torrentFile);
+
+  // The download dir is the content's parent, not the configured one: this
+  // torrent's data is already where it is, and moving it is not on offer.
+  const runtime = await startRuntime(root);
+  const outcome = await addInput(runtime, created.torrentPath, { allowTorrentPath: true });
+  if (outcome === "invalid") throw new Error(`could not seed ${created.torrentPath}`);
+  if (outcome === "duplicate") log("already in the queue — leaving it alone");
+
+  if (options.seedTimeMs) {
+    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles });
+  }
+
+  // The magnet on its own line and nothing else on it, so `torlnk seed x | tail
+  // -1` is a usable thing to write in a script.
+  log(`seeding ${created.name} (${created.infoHash}) from ${root}`);
+  console.log(created.magnet);
+}

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { handleApi, isAuthorized, extractMagnet, parseControl, applyControl } from "./serve";
+import { handleApi, isAuthorized, extractMagnet, extractTorrentBytes, parseControl, applyControl } from "./serve";
 import type { Runtime } from "./runtime";
 
 const HASH = "abcdef0123456789abcdef0123456789abcdef01";
@@ -189,5 +189,37 @@ describe("applyControl", () => {
     const rt = mkRuntime({ remove: vi.fn().mockResolvedValue(false) });
     expect(await applyControl(rt, { id: "z", action: "remove", deleteFiles: false })).toBe("not-found");
     expect(await applyControl(mkRuntime({}), { id: "z", action: "nope", deleteFiles: false })).toBe("unknown-action");
+  });
+});
+
+describe("extractTorrentBytes", () => {
+  // Every torrent is a bencoded dictionary, so it starts with "d".
+  const b64 = Buffer.from("d4:name4:teste", "utf8").toString("base64");
+
+  it("reads a base64 .torrent out of the body", () => {
+    const bytes = extractTorrentBytes(JSON.stringify({ torrent: b64 }));
+    expect(bytes).not.toBeNull();
+    expect(bytes![0]).toBe(0x64);
+  });
+
+  // What a browser's FileReader.readAsDataURL hands you, verbatim.
+  it("accepts a data: URI without making the caller strip it", () => {
+    const uri = `data:application/x-bittorrent;base64,${b64}`;
+    expect(extractTorrentBytes(JSON.stringify({ torrent: uri }))).not.toBeNull();
+  });
+
+  /*
+   * Buffer.from(..., "base64") ignores bytes it cannot decode rather than
+   * throwing, so garbage yields a short buffer instead of an error. Checking
+   * for the leading bencode dictionary is what turns that into a rejection.
+   */
+  it("rejects a string that is not a torrent", () => {
+    expect(extractTorrentBytes(JSON.stringify({ torrent: "hello world" }))).toBeNull();
+    expect(extractTorrentBytes(JSON.stringify({ torrent: "" }))).toBeNull();
+  });
+
+  it("is null for a body that carries no torrent at all", () => {
+    expect(extractTorrentBytes(JSON.stringify({ magnet: "magnet:?xt=urn:btih:" + "a".repeat(40) }))).toBeNull();
+    expect(extractTorrentBytes("not json")).toBeNull();
   });
 });

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -9,6 +9,7 @@
 
 import http from "node:http";
 import { startRuntime, addInput, type Runtime } from "./runtime";
+import { magnetFromTorrentBytes } from "../sources/torrentFile";
 import { startSeedReaper } from "./seed-reaper";
 import { LOOPBACK_HOSTS, isAuthorized, hostHeaderOk } from "./auth";
 import { VERSION } from "../version";
@@ -38,6 +39,40 @@ export interface ServeOptions {
 // Pull a magnet / info hash out of a request body. Accepts JSON ({ magnet } or
 // { infohash }) or a raw body that is itself a magnet or info hash — forgiving,
 // so callers don't have to guess the exact envelope.
+// A base64 .torrent from the request body, or null.
+//
+// The bytes travel in the JSON rather than the path to them: torlink already
+// refuses to let a network caller name a local file (runtime.ts's
+// allowTorrentPath), and that refusal is worth keeping -- "add this torrent"
+// and "read this file off your disk and tell me about it" must not be the same
+// request. Uploading the content sidesteps it entirely.
+export function extractTorrentBytes(bodyText: string): Uint8Array | null {
+  const raw = bodyText.trim();
+  if (!raw.startsWith("{")) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const value = obj.torrent ?? obj.torrentFile ?? obj.file;
+  if (typeof value !== "string" || !value.trim()) return null;
+  // A data: URI is what a browser's FileReader hands you, and stripping the
+  // prefix here is cheaper than making every caller remember to.
+  const b64 = value.replace(/^data:[^,]*,/, "").trim();
+  try {
+    const bytes = Buffer.from(b64, "base64");
+    // Buffer.from ignores anything it cannot decode rather than throwing, so a
+    // non-base64 string yields a short buffer instead of an error. Every
+    // torrent starts with a bencoded dictionary, which is the cheap check that
+    // this is one.
+    if (bytes.length === 0 || bytes[0] !== 0x64) return null;
+    return new Uint8Array(bytes);
+  } catch {
+    return null;
+  }
+}
+
 export function extractMagnet(bodyText: string): string | null {
   const raw = bodyText.trim();
   if (!raw) return null;
@@ -166,8 +201,19 @@ export async function handleApi(
     return { status: 200, body: statusPayload(runtime) };
   }
   if (method === "POST" && urlPath === "/add") {
+    // A .torrent is tried first because it is strictly more information: it
+    // carries the piece hashes, so data already on disk verifies locally
+    // instead of waiting on a swarm to serve metadata back.
+    const bytes = extractTorrentBytes(bodyText);
+    if (bytes) {
+      const parsed = await magnetFromTorrentBytes(bytes);
+      if (!parsed) return { status: 400, body: { error: "invalid .torrent" } };
+      const outcome = await addInput(runtime, parsed.magnet);
+      if (outcome === "invalid") return { status: 400, body: { error: "invalid .torrent" } };
+      return { status: 200, body: { ok: true, outcome, infoHash: parsed.infoHash } };
+    }
     const magnet = extractMagnet(bodyText);
-    if (!magnet) return { status: 400, body: { error: "missing magnet or info hash" } };
+    if (!magnet) return { status: 400, body: { error: "missing magnet, info hash or .torrent" } };
     const outcome = await addInput(runtime, magnet);
     if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
     return { status: 200, body: { ok: true, outcome } };

--- a/src/download/create.test.ts
+++ b/src/download/create.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createTorrentFor, torrentOptions, torrentPathFor } from "./create";
+import { magnetFromTorrentBytes } from "../sources/torrentFile";
+
+async function fixture(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "torlink-create-"));
+  const content = path.join(dir, "album");
+  await fs.mkdir(content);
+  await fs.writeFile(path.join(content, "one.txt"), "first\n");
+  await fs.writeFile(path.join(content, "two.txt"), "second\n");
+  return content;
+}
+
+describe("torrentOptions", () => {
+  // create-torrent supplies its own announce list when given none, so passing
+  // an empty array would replace a working default with nothing.
+  it("omits announce entirely rather than passing an empty list", () => {
+    expect(torrentOptions([])).toEqual({});
+    expect(torrentOptions(["udp://t.test:1337"])).toEqual({ announce: ["udp://t.test:1337"] });
+  });
+});
+
+describe("torrentPathFor", () => {
+  // Beside the data, not in a config dir: moving the files and leaving the
+  // torrent behind is how you end up with a magnet nobody can serve.
+  it("names the torrent after the content and puts it alongside", () => {
+    expect(torrentPathFor("/srv/media/album")).toBe("/srv/media/album.torrent");
+    expect(torrentPathFor("/srv/media/film.mkv")).toBe("/srv/media/film.mkv.torrent");
+  });
+});
+
+describe("createTorrentFor", () => {
+  it("writes a .torrent that parses back to the magnet it returns", async () => {
+    const content = await fixture();
+    const created = await createTorrentFor(content, ["udp://tracker.test:1337/announce"]);
+
+    expect(created.infoHash).toMatch(/^[0-9a-f]{40}$/);
+    expect(created.name).toBe("album");
+    expect(created.magnet).toContain(created.infoHash);
+
+    // The file on disk has to be the same torrent as the magnet describes.
+    const onDisk = await fs.readFile(created.torrentPath);
+    const reparsed = await magnetFromTorrentBytes(new Uint8Array(onDisk));
+    expect(reparsed?.infoHash).toBe(created.infoHash);
+  });
+
+  /*
+   * The field that makes seeding existing data work at all.
+   *
+   * A torrent names its own top-level entry, so a client seeding
+   * /srv/media/album must be pointed at /srv/media. Point it at the album and
+   * it looks for album/album, finds nothing, and downloads a second copy
+   * beside the one already there.
+   */
+  it("reports the content's parent as the directory to seed from", async () => {
+    const content = await fixture();
+    const created = await createTorrentFor(content);
+    expect(created.contentDir).toBe(path.dirname(content));
+    expect(created.contentDir).not.toBe(content);
+  });
+
+  // The announce list is the difference between a torrent anyone can find and
+  // a DHT-only one, so it has to survive into the magnet.
+  it("carries the trackers it was given into the magnet", async () => {
+    const content = await fixture();
+    const created = await createTorrentFor(content, ["udp://tracker.test:1337/announce"]);
+    expect(decodeURIComponent(created.magnet)).toContain("udp://tracker.test:1337/announce");
+  });
+
+  // A direct instruction from an operator, unlike a file appearing in a watch
+  // folder: failing quietly would leave them with no torrent and no reason.
+  it("throws on a path that is not there", async () => {
+    await expect(createTorrentFor("/nope/not/here")).rejects.toThrow();
+  });
+});

--- a/src/download/create.ts
+++ b/src/download/create.ts
@@ -1,0 +1,76 @@
+// Making a torrent out of a path you already have.
+//
+// Everything else in torlink starts from a magnet or a .torrent that someone
+// else made: search finds one, the watch folder is handed one, the API is
+// posted one. This is the other direction — you have the files, and you want a
+// torrent of them — and it is the one thing the client could not do.
+//
+// It produces both halves on purpose. The .torrent is what lets torlink (and
+// any other client) verify the data already on disk and go straight to seeding
+// instead of fetching metadata from a swarm that has no seeds yet; the magnet
+// is what you actually paste somewhere.
+
+import createTorrent from "create-torrent";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { magnetFromTorrentBytes } from "../sources/torrentFile";
+import type { ParsedMagnet } from "../sources/magnet";
+
+export interface CreatedTorrent extends ParsedMagnet {
+  // The bencoded .torrent, and where it was written.
+  torrentFile: Uint8Array;
+  torrentPath: string;
+  // The directory a client must be pointed at for the existing data to verify:
+  // the PARENT of the path, because a torrent names its own top-level entry.
+  contentDir: string;
+}
+
+// A torrent with no announce list is a DHT-only torrent, which works but is
+// slower to be found and invisible to anything watching a tracker. The caller's
+// configured trackers are used when it has some; create-torrent supplies its
+// own defaults otherwise.
+export function torrentOptions(announce: string[]): { announce?: string[] } {
+  return announce.length > 0 ? { announce } : {};
+}
+
+// create-torrent is callback-shaped and hashes every piece, so this is the one
+// genuinely slow step: a large directory is read end to end.
+export function buildTorrent(target: string, announce: string[]): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    createTorrent(target, torrentOptions(announce), (err: Error | null, torrent: Uint8Array) => {
+      if (err) reject(err);
+      else resolve(torrent);
+    });
+  });
+}
+
+// Where the .torrent goes: beside the data, named after it. Next to the content
+// rather than in a config directory because the two belong together — moving
+// the files and leaving the torrent behind is how you end up with a magnet
+// nobody can serve.
+export function torrentPathFor(target: string): string {
+  const full = path.resolve(target);
+  return path.join(path.dirname(full), `${path.basename(full)}.torrent`);
+}
+
+// Create a torrent for `target`, write it beside the data, and return both the
+// magnet and everything a caller needs to seed it. Throws on a path that cannot
+// be read: unlike the watch folder, this is a direct instruction from an
+// operator, and failing quietly would leave them with no torrent and no reason.
+export async function createTorrentFor(
+  target: string,
+  announce: string[] = [],
+): Promise<CreatedTorrent> {
+  const full = path.resolve(target);
+  await fs.stat(full);
+
+  const torrentFile = await buildTorrent(full, announce);
+  const parsed = await magnetFromTorrentBytes(torrentFile);
+  if (!parsed) throw new Error("created a torrent that could not be parsed back");
+
+  const torrentPath = torrentPathFor(full);
+  await fs.writeFile(torrentPath, torrentFile);
+
+  return { ...parsed, torrentFile, torrentPath, contentDir: path.dirname(full) };
+}

--- a/src/download/queue.metadata.test.ts
+++ b/src/download/queue.metadata.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+
+// What startEngine is handed is the whole point of these two tests, so the
+// engine is stubbed to record its `source` argument and the metadata store is
+// stubbed to say whether a .torrent exists for an id.
+const added: { id: string; source: string }[] = [];
+
+vi.mock("./engine", () => ({
+  TorrentEngine: class {
+    add(id: string, source: string): void {
+      added.push({ id, source });
+    }
+    remove(): void {}
+    stats(): undefined {
+      return undefined;
+    }
+    destroy(): void {}
+  },
+}));
+
+vi.mock("./persist", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./persist")>();
+  return {
+    ...actual,
+    torrentMetaExists: (id: string) => id === "has-meta",
+    torrentMetaPath: (id: string) => `/meta/${id}.torrent`,
+    saveQueue: async () => {},
+    saveSeeds: async () => {},
+    saveHistory: async () => {},
+  };
+});
+
+const { DownloadQueue } = await import("./queue");
+
+const MAGNET = "magnet:?xt=urn:btih:0000000000000000000000000000000000000000";
+
+describe("startEngine source selection", () => {
+  /*
+   * The difference between seeding and pretending to.
+   *
+   * A magnet carries no piece hashes, so a client handed one cannot verify a
+   * single byte until the swarm sends it metadata. For a torrent created from
+   * local content that swarm is empty -- nobody has ever seen this info hash --
+   * so it waits forever on data that is already on the disk underneath it.
+   * Handed the stored .torrent it verifies locally and completes at once.
+   */
+  it("prefers a stored .torrent over the magnet", () => {
+    added.length = 0;
+    const q = new DownloadQueue();
+    q.add({ id: "has-meta", name: "local", magnet: MAGNET }, "/data");
+    expect(added.at(-1)?.source).toBe("/meta/has-meta.torrent");
+  });
+
+  // The ordinary case: nothing downloaded yet, so a magnet is all there is.
+  it("falls back to the magnet when there is no stored .torrent", () => {
+    added.length = 0;
+    const q = new DownloadQueue();
+    q.add({ id: "no-meta", name: "remote", magnet: MAGNET }, "/data");
+    expect(added.at(-1)?.source).toBe(MAGNET);
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -159,7 +159,16 @@ export class DownloadQueue extends EventEmitter {
 
   private startEngine(item: QueueItem): void {
     try {
-      this.engine.add(item.id, item.magnet, item.dir, this.engineHandlers(item.id), this.trackers);
+      // Prefer the stored .torrent over the magnet, exactly as startSeeding
+      // does. A magnet carries no piece hashes, so the client cannot verify a
+      // single byte until the swarm serves it metadata -- which is merely slow
+      // for a popular torrent and terminal for one that nobody else has yet.
+      // With the metadata on disk it verifies the local files immediately, so
+      // a re-add of something already downloaded, and a torrent created from
+      // local content, both go straight to complete instead of waiting on
+      // peers that may not exist.
+      const source = torrentMetaExists(item.id) ? torrentMetaPath(item.id) : item.magnet;
+      this.engine.add(item.id, source, item.dir, this.engineHandlers(item.id), this.trackers);
     } catch (e) {
       // engine.add routes webtorrent's own synchronous failures through
       // onError, so the only throw that reaches here is the client failing to

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ containUnhandledRejections({
     cmd.kind === "update" ||
     cmd.kind === "search" ||
     cmd.kind === "watch" ||
+    cmd.kind === "seed" ||
     cmd.kind === "serve" ||
     cmd.kind === "files",
 });
@@ -58,6 +59,12 @@ if (cmd.kind === "update") {
   const { dir, downloadDir, seedTimeMs, deleteFiles } = cmd;
   void import("./daemon/watch").then(({ runWatch }) =>
     runWatch(dir, downloadDir, { seedTimeMs, deleteFiles }).catch(failHeadless),
+  );
+} else if (cmd.kind === "seed") {
+  if (cmd.daemon) daemonize("seed");
+  const { path: target, seedTimeMs, deleteFiles } = cmd;
+  void import("./daemon/seed").then(({ runSeed }) =>
+    runSeed(target, { seedTimeMs, deleteFiles }).catch(failHeadless),
   );
 } else if (cmd.kind === "serve") {
   if (cmd.daemon) daemonize("serve");

--- a/src/sources/torrentFile.ts
+++ b/src/sources/torrentFile.ts
@@ -7,12 +7,31 @@ import { buildMagnet, type ParsedMagnet } from "./magnet";
 // image dropped in the watch folder from being pulled into memory whole.
 const MAX_TORRENT_BYTES = 16 * 1024 * 1024;
 
+// The same read, from bytes already in hand rather than a path. The HTTP add
+// API needs this: it accepts an uploaded .torrent, and must never be able to
+// point the daemon at a local file (see runtime.ts's allowTorrentPath).
+export async function magnetFromTorrentBytes(bytes: Uint8Array): Promise<ParsedMagnet | null> {
+  try {
+    if (bytes.length === 0 || bytes.length > MAX_TORRENT_BYTES) return null;
+    return await readParsed(bytes);
+  } catch {
+    return null;
+  }
+}
+
 export async function magnetFromTorrentFile(path: string): Promise<ParsedMagnet | null> {
   try {
     const stat = await fs.stat(path);
     if (!stat.isFile() || stat.size === 0 || stat.size > MAX_TORRENT_BYTES) return null;
     const buf = await fs.readFile(path);
-    const parsed = await parseTorrent(new Uint8Array(buf));
+    return await readParsed(new Uint8Array(buf));
+  } catch {
+    return null;
+  }
+}
+
+async function readParsed(bytes: Uint8Array): Promise<ParsedMagnet | null> {
+    const parsed = await parseTorrent(bytes);
     const infoHash = parsed?.infoHash?.toLowerCase();
     if (!infoHash) return null;
     const name = parsed.name || infoHash;
@@ -24,7 +43,4 @@ export async function magnetFromTorrentFile(path: string): Promise<ParsedMagnet 
       ? parsed.announce.filter((url): url is string => typeof url === "string")
       : [];
     return { infoHash, name, magnet: buildMagnet(infoHash, name, announce) };
-  } catch {
-    return null;
-  }
 }


### PR DESCRIPTION
Every way into torlink starts from a torrent somebody else made — search finds one, the watch folder is handed one, the API is posted one. None of that helps when the content is yours and no torrent for it exists yet, and that was the one thing the client could not do.

```sh
torlnk seed ./album
```

Hashes the files, writes `album.torrent` beside them, prints the magnet, and starts seeding. Takes `--seed-time`, `--delete-files` and `--daemon` like the other headless modes.

### The interesting part isn't the creating

It's what gets added afterwards, and it's a bug I only found by running the thing.

`addInput` turns a `.torrent` into a magnet and hands the queue that, and `startEngine` passed `item.magnet` to webtorrent unconditionally. So the engine had no piece hashes and could not verify a byte until the swarm sent metadata back — and for a torrent created from local content that swarm is empty *by definition*, because nobody has ever seen the info hash. It sat at zero per cent forever, waiting on peers for data already on the disk underneath it.

**The queue already knew the answer.** `startSeeding` has always preferred the stored `.torrent` over the magnet — *"verifies the local file immediately, no swarm needed"* — for restoring a seed across a restart. `startEngine` now does the same:

```ts
const source = torrentMetaExists(item.id) ? torrentMetaPath(item.id) : item.magnet;
```

One line, following a convention already in the file rather than inventing one, and it helps every re-add of something already downloaded — not just this feature. `seed` writes the metadata to the store before adding, so the engine verifies locally and completes at once.

### `serve` takes a .torrent too

Same flexibility on the way in: `POST /add` now accepts an uploaded `.torrent` as well as a magnet, base64 or a `data:` URI as `FileReader` hands it over.

```
POST /add {"magnet":"magnet:?xt=..."}
POST /add {"torrent":"<base64>"}
```

A `.torrent` is tried first because it is strictly more information. The bytes travel *in* the request rather than a path to them: the existing refusal to let a network caller name a local file (`allowTorrentPath`) is worth keeping, and "add this torrent" must not double as "read this file off your disk". `Buffer.from(..., "base64")` ignores what it cannot decode instead of throwing, so the leading bencode `d` is what turns garbage into a 400 rather than a short buffer.

### Verified by running it

Not only by the suite. Seeding a directory of real files produced `seeds.json` with `status: "seeding"` and an empty download queue. Before the metadata fix, the same run left a queue entry at `downloading / progress 0` — that's the failure this fixes, observed directly.

- `npm run typecheck` — clean
- `npm test` — 372 passing (11 new)

### Notes

- `create-torrent` moves from a transitive dependency of webtorrent to a direct one, with a local `.d.ts` matching how `parse-torrent` and `webtorrent` are already declared here.
- The seed root is the content's **parent**, since a torrent names its own top-level entry. Point a client at the content itself and it looks for `album/album`, finds nothing, and downloads a second copy beside the first. That calculation has its own test.
- Happy to split the `startEngine` line into its own PR if you'd rather take that separately — it stands on its own as a fix.