### PR TITLE
fix(download): disable uTP to prevent ENOBUFS socket exhaustion crashes

### DIFF
--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -108,4 +108,19 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     expect(result?.total).toBe(0);
     engine.destroy();
   });
+
+  it("passes utp:false so utp-native does not exhaust UDP buffers or crash on unhandled bind errors", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    engine.add(
+      "test-id",
+      "magnet:?xt=urn:btih:0000000000000000000000000000000000000000",
+      "/downloads",
+      {},
+    );
+    engine.destroy();
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]).toMatchObject({ utp: false });
+  });
 });
+

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -45,7 +45,21 @@ export class TorrentEngine {
       // the app the moment a download starts. NAT-PMP can never succeed
       // on macOS because the port is permanently taken, so disable it
       // and let UPnP handle NAT traversal instead.
-      const opts = process.platform === "darwin" ? { natPmp: false } : {};
+      //
+      // Disable uTP across all platforms:
+      // WebTorrent's uTP implementation relies on `utp-native`, which allocates
+      // an independent UDP socket for every outgoing connection attempt. Under
+      // peer discovery churn, this rapidly exhausts socket buffer space and
+      // ephemeral ports (leading to WSAENOBUFS / ENOBUFS: "no buffer space available").
+      // Furthermore, when `utp-native` fails to bind, it emits an unhandled 'error'
+      // on an internal EventEmitter with no listeners, crashing the process as an
+      // uncaught exception. Disabling uTP forces WebTorrent to use standard TCP
+      // connections, which are supported by 100% of BitTorrent clients and operate
+      // reliably without socket buffer exhaustion.
+      const opts = {
+        utp: false,
+        ...(process.platform === "darwin" ? { natPmp: false } : {}),
+      };
       this.client = new WebTorrent(opts);
       this.client.on("error", () => {});
     }


### PR DESCRIPTION
## What and why

WebTorrent's uTP transport implementation relies on the native \utp-native\ dependency. In \utp-native\, each outgoing peer connection attempts to bind a new, independent UDP socket on an ephemeral port (\
ew UTP()\ -> \uv_udp_bind(0, '0.0.0.0')\) rather than multiplexing traffic over a single shared UDP socket.

Under active swarm discovery and peer reconnection churn, rapidly opening dozens to hundreds of UDP sockets exhausts the OS socket buffer space and dynamic port pool—especially on Windows, which triggers Winsock error 10055 (\WSAENOBUFS\ / \code: 'ENOBUFS'\, 'no buffer space available').

Furthermore, when \inding.utp_napi_bind\ throws \ENOBUFS\, \utp-native\ schedules \process.nextTick(emitError, this, err)\ on the underlying \UTP\ socket instance. Because \UTP.connect\ only returns the connection stream (\conn\) without attaching an error listener to the orphaned \UTP\ socket instance, this error is emitted with 0 listeners, escalating into an unhandled \uncaughtException\ that immediately terminates the process:
\\\
Error: no buffer space available
    at UTP.bind (node_modules/utp-native/index.js:198:13)
    at UTP.connect (node_modules/utp-native/index.js:165:27)
    at UTP.connect (node_modules/utp-native/index.js:46:14)
    at Torrent._drain (node_modules/webtorrent/lib/torrent.js:2110:23)
\\\

This fix passes \utp: false\ to the \WebTorrent\ constructor options in \ensureClient()\, forcing peer traffic over standard TCP (alongside the existing macOS NAT-PMP fix #22). Standard BitTorrent TCP (BEP 3) is supported by 100% of BitTorrent clients, fully error-handled, pooled, and immune to ephemeral UDP socket buffer exhaustion.

## Checklist

- [x] \
pm run typecheck\ is clean
- [x] \
pm test\ passes
- [x] New logic has a test (vitest; mock node built-ins for platform code)
- [x] OS-touching code works on Windows, macOS, and Linux
- [x] One concern, with a Conventional Commits title (\eat:\ / \ix:\ / \docs:\ / \chore:\)