### PR TITLE
feat(serve): per-torrent seed time over the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ It turns the folder into a torrent, saves `album.torrent` next to it, prints the
     POST /add {"magnet":"magnet:?xt=..."}
     POST /add {"torrent":"<base64>"}
 
+Either can carry a `seedTime` for that one torrent, in the same grammar as `--seed-time` (`"30d"`, `"2h"`; `0` means never stop). It wins over the daemon-wide flag, so a box that normally drops seeds after a couple of hours can keep one release alive for a month. Change it later, or on something already downloading, through the control endpoint:
+
+    POST /control {"id":"<info hash>","action":"seed-time","seedTime":"30d"}
+
+`GET /downloads` reports the limit and when it falls due (`seedUntil`) on every torrent that has one.
+
 ## Contributing
 
 To run or work on torlink locally:

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -201,6 +201,9 @@ anyone the magnet and they pull the files from you. Takes --seed-time,
 seed expiry (seed/watch/serve): --seed-time <dur> stops seeding a torrent that long
 after it finishes (e.g. 1h, 30m, 90s, 2d); files are kept by default. Add
 --delete-files to also remove the downloaded data when the timer expires.
+One torrent can carry its own limit over the serve API (seedTime on /add, or
+the seed-time control action); that wins over --seed-time, and 0 keeps it
+seeding for good.
 
 --daemon (watch/serve/files): background the process (own session, logs to a
 file), so you can log out and it keeps running. Prints the pid and log path.
@@ -211,7 +214,13 @@ left off. Downloads and seeds keep running while detached.
 
 serve mode (no TUI): a small HTTP API for handing torlink a magnet.
   POST /add {"magnet":"..."}   queue a magnet or info hash
+       ... "seedTime":"30d"      optional: this torrent's own seed limit
+                                (0 = never stop); overrides --seed-time
   POST /add {"torrent":"<b64>"} queue an uploaded .torrent (base64 or data: URI)
+  POST /control {"id":"...","action":"seed-time","seedTime":"30d"}
+                               change a torrent's seed limit ("" = inherit);
+                               other actions: pause, resume, start-seed,
+                               stop-seed, remove, delete
   GET  /downloads              list active downloads and seeds
   GET  /health                 liveness (no auth)
 flags: --port <n> (default 9161), --host <addr> (default 127.0.0.1),

--- a/src/daemon/runtime.ts
+++ b/src/daemon/runtime.ts
@@ -61,6 +61,9 @@ export interface AddInputOptions {
   // the watch folder opts in; a network caller (the HTTP add API) must never
   // be able to point the daemon at the local filesystem.
   allowTorrentPath?: boolean;
+  // Per-torrent seed limit (ms after completion; 0 = never stop). Unset
+  // inherits the daemon-wide --seed-time.
+  seedTimeMs?: number;
 }
 
 export async function addInput(
@@ -80,7 +83,12 @@ export async function addInput(
   if (runtime.queue.has(parsed.infoHash)) return "duplicate";
   await fs.mkdir(runtime.downloadDir, { recursive: true }).catch(() => {});
   runtime.queue.add(
-    { id: parsed.infoHash, name: parsed.name, magnet: parsed.magnet },
+    {
+      id: parsed.infoHash,
+      name: parsed.name,
+      magnet: parsed.magnet,
+      ...(options.seedTimeMs !== undefined ? { seedTimeMs: options.seedTimeMs } : {}),
+    },
     runtime.downloadDir,
   );
   return "added";

--- a/src/daemon/seed-reaper.test.ts
+++ b/src/daemon/seed-reaper.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { dueSeeds, type ReapableQueue } from "./seed-reaper";
+import { dueSeeds, seedLimitFor, type ReapableQueue } from "./seed-reaper";
 
 const HOUR = 3_600_000;
 
 function queue(
   seeds: { id: string; name: string; dir: string; status: string }[],
-  history: { id: string; completedAt: number }[],
+  history: { id: string; completedAt: number; seedTimeMs?: number }[],
 ): ReapableQueue {
   return {
     getSeeds: () => seeds,
@@ -50,5 +50,52 @@ describe("dueSeeds", () => {
       [{ id: "a", completedAt: now - 5 * HOUR }],
     );
     expect(dueSeeds(q, HOUR, now)).toEqual([{ id: "a", name: "Movie", dir: "/downloads" }]);
+  });
+});
+
+describe("dueSeeds with per-torrent limits", () => {
+  const now = 100 * HOUR;
+  const seeding = (id: string) => ({ id, name: id, dir: "/d", status: "seeding" });
+
+  it("a torrent's own limit wins over the daemon-wide one, in both directions", () => {
+    const q = queue(
+      [seeding("longer"), seeding("shorter"), seeding("inherits")],
+      [
+        { id: "longer", completedAt: now - 5 * HOUR, seedTimeMs: 24 * HOUR },
+        { id: "shorter", completedAt: now - 5 * HOUR, seedTimeMs: HOUR },
+        { id: "inherits", completedAt: now - 5 * HOUR },
+      ],
+    );
+    // Daemon says 2h: "longer" (24h) is kept, "shorter" (1h) and the
+    // inheriting one (2h) are due.
+    expect(dueSeeds(q, 2 * HOUR, now).map((s) => s.id)).toEqual(["shorter", "inherits"]);
+  });
+
+  it("acts on a torrent's own limit even when the daemon has none", () => {
+    const q = queue(
+      [seeding("capped"), seeding("free")],
+      [
+        { id: "capped", completedAt: now - 3 * HOUR, seedTimeMs: HOUR },
+        { id: "free", completedAt: 0 },
+      ],
+    );
+    expect(dueSeeds(q, 0, now).map((s) => s.id)).toEqual(["capped"]);
+  });
+
+  it("0 on the torrent means never stop it, whatever the daemon says", () => {
+    const q = queue([seeding("forever")], [{ id: "forever", completedAt: 0, seedTimeMs: 0 }]);
+    expect(dueSeeds(q, HOUR, now)).toEqual([]);
+  });
+
+  it("with no limit anywhere nothing is ever due", () => {
+    const q = queue([seeding("a")], [{ id: "a", completedAt: 0 }]);
+    expect(dueSeeds(q, 0, now)).toEqual([]);
+  });
+
+  it("seedLimitFor prefers the torrent's own value, including 0", () => {
+    expect(seedLimitFor(undefined, HOUR)).toBe(HOUR);
+    expect(seedLimitFor(2 * HOUR, HOUR)).toBe(2 * HOUR);
+    expect(seedLimitFor(0, HOUR)).toBe(0);
+    expect(seedLimitFor(undefined, 0)).toBe(0);
   });
 });

--- a/src/daemon/seed-reaper.ts
+++ b/src/daemon/seed-reaper.ts
@@ -6,6 +6,11 @@
 //
 // The clock is the download's completion time (history.completedAt), not when
 // this process started, so a restart doesn't reset every torrent's timer.
+//
+// A torrent can carry its own limit (history.seedTimeMs, set over the headless
+// API): that wins over the daemon-wide value, and 0 there means "never stop
+// this one". With neither set the seed is left alone, so the reaper is safe to
+// run even when the daemon has no --seed-time.
 
 import type { DownloadQueue } from "../download/queue";
 import { deleteSeedData } from "../download/delete-data";
@@ -18,7 +23,7 @@ const DEFAULT_CHECK_MS = 30_000;
 // The slice of DownloadQueue the reaper needs — keeps it trivially testable.
 export interface ReapableQueue {
   getSeeds(): { id: string; name: string; dir: string; status: string }[];
-  getHistory(): { id: string; completedAt: number }[];
+  getHistory(): { id: string; completedAt: number; seedTimeMs?: number }[];
   stopSeeding(id: string): void;
 }
 
@@ -28,14 +33,25 @@ export interface DueSeed {
   dir: string;
 }
 
-// The actively-seeding torrents whose completion is older than the limit.
+// The effective limit for one torrent: its own if it has one, else the
+// daemon-wide value. 0 / undefined means no limit.
+export function seedLimitFor(own: number | undefined, daemonWide: number): number {
+  return own ?? daemonWide;
+}
+
+// The actively-seeding torrents whose completion is older than their limit.
+// `seedTimeMs` is the daemon-wide default (0 = none); a torrent's own
+// history.seedTimeMs overrides it.
 export function dueSeeds(queue: ReapableQueue, seedTimeMs: number, now: number): DueSeed[] {
-  const completedAt = new Map(queue.getHistory().map((h) => [h.id, h.completedAt]));
+  const history = new Map(queue.getHistory().map((h) => [h.id, h]));
   const out: DueSeed[] = [];
   for (const s of queue.getSeeds()) {
     if (s.status !== "seeding") continue;
-    const since = completedAt.get(s.id) ?? now; // unknown completion → treat as just finished
-    if (now - since >= seedTimeMs) out.push({ id: s.id, name: s.name, dir: s.dir });
+    const h = history.get(s.id);
+    const limit = seedLimitFor(h?.seedTimeMs, seedTimeMs);
+    if (!(limit > 0)) continue;
+    const since = h?.completedAt ?? now; // unknown completion → treat as just finished
+    if (now - since >= limit) out.push({ id: s.id, name: s.name, dir: s.dir });
   }
   return out;
 }

--- a/src/daemon/serve.test.ts
+++ b/src/daemon/serve.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import os from "node:os";
 import path from "node:path";
 import { promises as fs } from "node:fs";
-import { handleApi, isAuthorized, extractMagnet, extractTorrentBytes, parseControl, applyControl } from "./serve";
+import {
+  handleApi,
+  isAuthorized,
+  extractMagnet,
+  extractTorrentBytes,
+  extractSeedTime,
+  parseControl,
+  applyControl,
+} from "./serve";
 import type { Runtime } from "./runtime";
 
 const HASH = "abcdef0123456789abcdef0123456789abcdef01";
@@ -53,6 +61,7 @@ describe("handleApi", () => {
         add,
         getItems: () => [],
         getSeeds: () => [],
+        getHistory: () => [],
       } as unknown as Runtime["queue"],
       downloadDir: dir,
     };
@@ -119,6 +128,79 @@ describe("handleApi", () => {
     expect(res.status).toBe(404);
   });
 
+  it("forwards a per-torrent seedTime from POST /add", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, `{"magnet":"${MAGNET}","seedTime":"30d"}`);
+    expect(res.status).toBe(200);
+    expect(add).toHaveBeenCalledWith(
+      { id: HASH, name: "Example", magnet: MAGNET, seedTimeMs: 30 * 86_400_000 },
+      dir,
+    );
+  });
+
+  it("adds without a seedTime when the field is absent (daemon default applies)", async () => {
+    await handleApi(runtime, null, "POST", "/add", undefined, `{"magnet":"${MAGNET}"}`);
+    const [input] = add.mock.calls[0]!;
+    expect("seedTimeMs" in (input as object)).toBe(false);
+  });
+
+  it("400s an unusable seedTime on POST /add without adding anything", async () => {
+    const res = await handleApi(runtime, null, "POST", "/add", undefined, `{"magnet":"${MAGNET}","seedTime":"soon"}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "invalid seedTime" });
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it("sets a seed limit on a known torrent through POST /control", async () => {
+    const setSeedTime = vi.fn().mockReturnValue(true);
+    runtime.queue = { setSeedTime } as unknown as Runtime["queue"];
+    const res = await handleApi(
+      runtime,
+      null,
+      "POST",
+      "/control",
+      undefined,
+      `{"id":"${HASH}","action":"seed-time","seedTime":"2h"}`,
+    );
+    expect(res.status).toBe(200);
+    expect(setSeedTime).toHaveBeenCalledWith(HASH, 2 * 3_600_000);
+  });
+
+  it("400s a seed-time control with an unusable value, 404s an unknown torrent", async () => {
+    const setSeedTime = vi.fn().mockReturnValue(false);
+    runtime.queue = { setSeedTime } as unknown as Runtime["queue"];
+    const bad = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"seed-time","seedTime":"eventually"}`);
+    expect(bad.status).toBe(400);
+    expect(bad.body).toEqual({ error: "invalid seedTime" });
+    expect(setSeedTime).not.toHaveBeenCalled();
+    const missing = await handleApi(runtime, null, "POST", "/control", undefined, `{"id":"${HASH}","action":"seed-time","seedTime":"1d"}`);
+    expect(missing.status).toBe(404);
+  });
+
+  it("reports a torrent's own limit and its due time on GET /downloads", async () => {
+    const completedAt = 1_700_000_000_000;
+    runtime.queue = {
+      getItems: () => [
+        { id: "dl", name: "In flight", status: "downloading", progress: 0.5, peers: 1, speed: 0, seedTimeMs: 60_000 },
+      ],
+      getSeeds: () => [
+        { id: "own", name: "Own", status: "seeding", peers: 0, uploaded: 0 },
+        { id: "forever", name: "Forever", status: "seeding", peers: 0, uploaded: 0 },
+        { id: "plain", name: "Plain", status: "seeding", peers: 0, uploaded: 0 },
+      ],
+      getHistory: () => [
+        { id: "own", completedAt, seedTimeMs: 3_600_000 },
+        { id: "forever", completedAt, seedTimeMs: 0 },
+        { id: "plain", completedAt },
+      ],
+    } as unknown as Runtime["queue"];
+    const res = await handleApi(runtime, null, "GET", "/downloads", undefined, "");
+    const body = res.body as { downloads: Record<string, unknown>[]; seeds: Record<string, unknown>[] };
+    expect(body.downloads[0]).toMatchObject({ id: "dl", seedTimeMs: 60_000 });
+    expect(body.seeds[0]).toMatchObject({ id: "own", seedTimeMs: 3_600_000, seedUntil: completedAt + 3_600_000 });
+    expect(body.seeds[1]).toMatchObject({ id: "forever", seedTimeMs: 0, seedUntil: null });
+    expect("seedTimeMs" in body.seeds[2]!).toBe(false);
+  });
+
   it("pauses a known download on POST /control", async () => {
     const pause = vi.fn();
     runtime.queue = { has: (id: string) => id === HASH, pause } as unknown as Runtime["queue"];
@@ -139,6 +221,12 @@ describe("parseControl", () => {
       action: "delete",
       deleteFiles: true,
     });
+  });
+  it("parses seedTime into ms, blank clears, garbage is null", () => {
+    expect(parseControl(`{"id":"abc","action":"seed-time","seedTime":"1d"}`)?.seedTimeMs).toBe(86_400_000);
+    expect(parseControl(`{"id":"abc","action":"seed-time","seedTime":""}`)?.seedTimeMs).toBeUndefined();
+    expect(parseControl(`{"id":"abc","action":"seed-time"}`)?.seedTimeMs).toBeUndefined();
+    expect(parseControl(`{"id":"abc","action":"seed-time","seedTime":"1 week"}`)?.seedTimeMs).toBeNull();
   });
   it("returns null when id or action is missing/blank or the body isn't JSON", () => {
     expect(parseControl(`{"id":"abc"}`)).toBeNull();
@@ -185,6 +273,21 @@ describe("applyControl", () => {
     expect(remove).toHaveBeenCalledWith("z", { deleteFiles: false });
   });
 
+  it("seed-time sets, clears, and refuses an unusable value", async () => {
+    const setSeedTime = vi.fn().mockReturnValue(true);
+    const rt = mkRuntime({ setSeedTime });
+    expect(await applyControl(rt, { id: "s", action: "seed-time", deleteFiles: false, seedTimeMs: 5000 })).toBe("ok");
+    expect(setSeedTime).toHaveBeenCalledWith("s", 5000);
+    expect(await applyControl(rt, { id: "s", action: "seed-time", deleteFiles: false, seedTimeMs: undefined })).toBe("ok");
+    expect(setSeedTime).toHaveBeenLastCalledWith("s", undefined);
+    expect(await applyControl(rt, { id: "s", action: "seed-time", deleteFiles: false, seedTimeMs: null })).toBe(
+      "invalid-seed-time",
+    );
+    expect(setSeedTime).toHaveBeenCalledTimes(2);
+    setSeedTime.mockReturnValue(false);
+    expect(await applyControl(rt, { id: "?", action: "seed-time", deleteFiles: false, seedTimeMs: 1 })).toBe("not-found");
+  });
+
   it("reports not-found when remove finds nothing and unknown-action otherwise", async () => {
     const rt = mkRuntime({ remove: vi.fn().mockResolvedValue(false) });
     expect(await applyControl(rt, { id: "z", action: "remove", deleteFiles: false })).toBe("not-found");
@@ -221,5 +324,32 @@ describe("extractTorrentBytes", () => {
   it("is null for a body that carries no torrent at all", () => {
     expect(extractTorrentBytes(JSON.stringify({ magnet: "magnet:?xt=urn:btih:" + "a".repeat(40) }))).toBeNull();
     expect(extractTorrentBytes("not json")).toBeNull();
+  });
+});
+
+describe("extractSeedTime", () => {
+  it("is undefined when the field is absent, blank, or the body is not JSON", () => {
+    expect(extractSeedTime(`{"magnet":"m"}`)).toBeUndefined();
+    expect(extractSeedTime(`{"magnet":"m","seedTime":""}`)).toBeUndefined();
+    expect(extractSeedTime(`{"magnet":"m","seedTime":null}`)).toBeUndefined();
+    expect(extractSeedTime("magnet:?xt=urn:btih:abc")).toBeUndefined();
+    expect(extractSeedTime("{not json")).toBeUndefined();
+  });
+
+  it("reads the --seed-time grammar, a bare number as seconds, and 0 as never", () => {
+    expect(extractSeedTime(`{"seedTime":"30d"}`)).toBe(30 * 86_400_000);
+    expect(extractSeedTime(`{"seedTime":"90m"}`)).toBe(90 * 60_000);
+    expect(extractSeedTime(`{"seedTime":"45"}`)).toBe(45_000);
+    expect(extractSeedTime(`{"seedTime":3600}`)).toBe(3_600_000);
+    expect(extractSeedTime(`{"seedTime":0}`)).toBe(0);
+    expect(extractSeedTime(`{"seedTime":"0"}`)).toBe(0);
+  });
+
+  it("is null for anything it cannot read, so the caller can 400", () => {
+    expect(extractSeedTime(`{"seedTime":"a month"}`)).toBeNull();
+    expect(extractSeedTime(`{"seedTime":"1w"}`)).toBeNull();
+    expect(extractSeedTime(`{"seedTime":-5}`)).toBeNull();
+    expect(extractSeedTime(`{"seedTime":true}`)).toBeNull();
+    expect(extractSeedTime(`{"seedTime":{}}`)).toBeNull();
   });
 });

--- a/src/daemon/serve.ts
+++ b/src/daemon/serve.ts
@@ -12,6 +12,7 @@ import { startRuntime, addInput, type Runtime } from "./runtime";
 import { magnetFromTorrentBytes } from "../sources/torrentFile";
 import { startSeedReaper } from "./seed-reaper";
 import { LOOPBACK_HOSTS, isAuthorized, hostHeaderOk } from "./auth";
+import { parseDuration } from "../util/duration";
 import { VERSION } from "../version";
 
 export { isAuthorized } from "./auth";
@@ -92,6 +93,37 @@ export function extractMagnet(bodyText: string): string | null {
   return raw;
 }
 
+// The optional per-torrent seed limit on /add and /control: a `seedTime` field
+// holding a duration in the --seed-time grammar ("30d", "2h", "90m"; a bare
+// number is seconds), or 0 to never stop seeding that torrent. Three answers:
+//   undefined  the field is absent (inherit the daemon-wide --seed-time)
+//   null       it is there but unusable (the caller gets a 400)
+//   number     milliseconds
+// A raw (non-JSON) body carries no seedTime.
+export function extractSeedTime(bodyText: string): number | null | undefined {
+  const raw = bodyText.trim();
+  if (!raw.startsWith("{")) return undefined;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+  return seedTimeField(obj.seedTime);
+}
+
+function seedTimeField(value: unknown): number | null | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? Math.floor(value) * 1000 : null;
+  }
+  if (typeof value === "string") {
+    if (!value.trim()) return undefined;
+    return parseDuration(value);
+  }
+  return null;
+}
+
 // Control actions the headless API accepts (POST /control). A seedbox web app
 // drives per-torrent buttons through these instead of the interactive keymap.
 export const CONTROL_ACTIONS = [
@@ -101,6 +133,7 @@ export const CONTROL_ACTIONS = [
   "stop-seed", // stop seeding but keep the files
   "remove", // forget the torrent, keep files on disk
   "delete", // forget the torrent AND delete its files
+  "seed-time", // set this torrent's own seed limit ({ seedTime }); "" clears it
 ] as const;
 export type ControlAction = (typeof CONTROL_ACTIONS)[number];
 
@@ -108,11 +141,14 @@ export interface ControlRequest {
   id: string;
   action: string;
   deleteFiles: boolean;
+  // Parsed `seedTime` for the seed-time action: ms, undefined when absent or
+  // blank (clear the override), null when present but unusable.
+  seedTimeMs?: number | null;
 }
 
-// Parse a control request body: JSON { id, action, deleteFiles? }. Returns null
-// for anything missing the two required string fields; the action string itself
-// is validated later so an unknown action gets a precise error.
+// Parse a control request body: JSON { id, action, deleteFiles?, seedTime? }.
+// Returns null for anything missing the two required string fields; the action
+// string itself is validated later so an unknown action gets a precise error.
 export function parseControl(bodyText: string): ControlRequest | null {
   const raw = bodyText.trim();
   if (!raw.startsWith("{")) return null;
@@ -125,10 +161,10 @@ export function parseControl(bodyText: string): ControlRequest | null {
   const id = typeof obj.id === "string" ? obj.id.trim() : "";
   const action = typeof obj.action === "string" ? obj.action.trim() : "";
   if (!id || !action) return null;
-  return { id, action, deleteFiles: obj.deleteFiles === true };
+  return { id, action, deleteFiles: obj.deleteFiles === true, seedTimeMs: seedTimeField(obj.seedTime) };
 }
 
-export type ControlOutcome = "ok" | "not-found" | "unknown-action";
+export type ControlOutcome = "ok" | "not-found" | "unknown-action" | "invalid-seed-time";
 
 // Apply a parsed control request to the queue. Pure over the runtime so it's
 // unit-testable with a fake queue.
@@ -137,7 +173,7 @@ export async function applyControl(
   req: ControlRequest,
 ): Promise<ControlOutcome> {
   const q = runtime.queue;
-  const { id, action, deleteFiles } = req;
+  const { id, action, deleteFiles, seedTimeMs } = req;
   switch (action as ControlAction) {
     case "pause":
       if (!q.has(id)) return "not-found";
@@ -162,6 +198,10 @@ export async function applyControl(
       const found = await q.remove(id, { deleteFiles: action === "delete" || deleteFiles });
       return found ? "ok" : "not-found";
     }
+    case "seed-time": {
+      if (seedTimeMs === null) return "invalid-seed-time";
+      return q.setSeedTime(id, seedTimeMs) ? "ok" : "not-found";
+    }
     default:
       return "unknown-action";
   }
@@ -175,14 +215,27 @@ function statusPayload(runtime: Runtime): Record<string, unknown> {
     progress: it.progress,
     peers: it.peers,
     speed: it.speed,
+    ...(it.seedTimeMs !== undefined ? { seedTimeMs: it.seedTimeMs } : {}),
   }));
-  const seeds = runtime.queue.getSeeds().map((s) => ({
-    id: s.id,
-    name: s.name,
-    status: s.status,
-    peers: s.peers,
-    uploaded: s.uploaded,
-  }));
+  const history = new Map(runtime.queue.getHistory().map((h) => [h.id, h]));
+  const seeds = runtime.queue.getSeeds().map((s) => {
+    const h = history.get(s.id);
+    return {
+      id: s.id,
+      name: s.name,
+      status: s.status,
+      peers: s.peers,
+      uploaded: s.uploaded,
+      // Only a torrent's own limit is reported; a daemon-wide --seed-time is
+      // the caller's to know. seedUntil is when that own limit falls due.
+      ...(h?.seedTimeMs !== undefined
+        ? {
+            seedTimeMs: h.seedTimeMs,
+            seedUntil: h.seedTimeMs > 0 ? h.completedAt + h.seedTimeMs : null,
+          }
+        : {}),
+    };
+  });
   return { downloads, seeds };
 }
 
@@ -208,17 +261,20 @@ export async function handleApi(
     // A .torrent is tried first because it is strictly more information: it
     // carries the piece hashes, so data already on disk verifies locally
     // instead of waiting on a swarm to serve metadata back.
+    const seedTimeMs = extractSeedTime(bodyText);
+    if (seedTimeMs === null) return { status: 400, body: { error: "invalid seedTime" } };
+    const addOptions = seedTimeMs !== undefined ? { seedTimeMs } : {};
     const bytes = extractTorrentBytes(bodyText);
     if (bytes) {
       const parsed = await magnetFromTorrentBytes(bytes);
       if (!parsed) return { status: 400, body: { error: "invalid .torrent" } };
-      const outcome = await addInput(runtime, parsed.magnet);
+      const outcome = await addInput(runtime, parsed.magnet, addOptions);
       if (outcome === "invalid") return { status: 400, body: { error: "invalid .torrent" } };
       return { status: 200, body: { ok: true, outcome, infoHash: parsed.infoHash } };
     }
     const magnet = extractMagnet(bodyText);
     if (!magnet) return { status: 400, body: { error: "missing magnet, info hash or .torrent" } };
-    const outcome = await addInput(runtime, magnet);
+    const outcome = await addInput(runtime, magnet, addOptions);
     if (outcome === "invalid") return { status: 400, body: { error: "invalid magnet or info hash" } };
     return { status: 200, body: { ok: true, outcome } };
   }
@@ -229,6 +285,7 @@ export async function handleApi(
     if (outcome === "unknown-action") {
       return { status: 400, body: { error: `unknown action: ${req.action}` } };
     }
+    if (outcome === "invalid-seed-time") return { status: 400, body: { error: "invalid seedTime" } };
     if (outcome === "not-found") return { status: 404, body: { error: "no such torrent" } };
     return { status: 200, body: { ok: true, id: req.id, action: req.action } };
   }
@@ -287,9 +344,9 @@ export async function runServe(options: ServeOptions = {}): Promise<void> {
 
   const runtime = await startRuntime(options.downloadDir);
 
-  if (options.seedTimeMs && options.seedTimeMs > 0) {
-    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
-  }
+  // Always on: with no --seed-time it only acts on torrents that carry their
+  // own limit (set over the API), and does nothing at all otherwise.
+  startSeedReaper(runtime.queue, options.seedTimeMs ?? 0, { deleteFiles: options.deleteFiles, log });
 
   const server = http.createServer((req, res) => {
     void (async () => {

--- a/src/daemon/watch.ts
+++ b/src/daemon/watch.ts
@@ -100,9 +100,9 @@ export async function runWatch(
   const runtime = await startRuntime(downloadDir);
   runtime.queue.on("completed", (name: string) => log(`done, now seeding: ${name}`));
 
-  if (options.seedTimeMs && options.seedTimeMs > 0) {
-    startSeedReaper(runtime.queue, options.seedTimeMs, { deleteFiles: options.deleteFiles, log });
-  }
+  // Always on: with no --seed-time it only acts on torrents that carry their
+  // own limit (set over the API), and does nothing at all otherwise.
+  startSeedReaper(runtime.queue, options.seedTimeMs ?? 0, { deleteFiles: options.deleteFiles, log });
 
   log(`watching ${dir}`);
   log(`downloads -> ${runtime.downloadDir}`);

--- a/src/download/history.ts
+++ b/src/download/history.ts
@@ -14,6 +14,10 @@ export interface HistoryItem {
   magnet: string;
   dir: string;
   completedAt: number;
+  // Per-torrent seed limit (ms after completedAt), set through the headless
+  // API. Overrides the daemon-wide --seed-time; 0 means never stop seeding
+  // this one. Absent = inherit whatever the daemon was started with.
+  seedTimeMs?: number;
 }
 
 const write = serializeWrites();

--- a/src/download/queue.test.ts
+++ b/src/download/queue.test.ts
@@ -297,3 +297,45 @@ describe("DownloadQueue error resilience on boot", () => {
     q.suspend();
   });
 });
+
+describe("DownloadQueue per-torrent seed time", () => {
+  it("setSeedTime updates a history entry and clears it again with undefined", () => {
+    const q = new DownloadQueue();
+    q.restoreHistory([h({ id: "st1" })]);
+    expect(q.setSeedTime("st1", 86_400_000)).toBe(true);
+    expect(q.getHistory()[0]?.seedTimeMs).toBe(86_400_000);
+    expect(q.setSeedTime("st1", undefined)).toBe(true);
+    expect("seedTimeMs" in q.getHistory()[0]!).toBe(false);
+  });
+
+  it("setSeedTime reaches a download that has not finished yet", () => {
+    const q = new DownloadQueue();
+    // Safe mode brings the item back paused without starting an engine.
+    q.restore(
+      [
+        {
+          id: "st2",
+          name: "Still going",
+          magnet: "magnet:?xt=urn:btih:st2",
+          dir: "/d",
+          status: "downloading",
+          progress: 0.2,
+          totalBytes: 10,
+          downloadedBytes: 2,
+          speed: 0,
+          peers: 0,
+          addedAt: 1,
+        },
+      ],
+      { safe: true },
+    );
+    expect(q.setSeedTime("st2", 0)).toBe(true);
+    expect(q.getItems().find((it) => it.id === "st2")?.seedTimeMs).toBe(0);
+    q.suspend();
+  });
+
+  it("setSeedTime reports an id it has never seen", () => {
+    const q = new DownloadQueue();
+    expect(q.setSeedTime("nope", 1000)).toBe(false);
+  });
+});

--- a/src/download/queue.ts
+++ b/src/download/queue.ts
@@ -59,6 +59,9 @@ export interface AddInput {
   magnet: string;
   source?: SourceId;
   sizeBytes?: number;
+  // Stop seeding this long (ms) after it finishes; 0 = never. Undefined leaves
+  // the daemon-wide --seed-time in charge.
+  seedTimeMs?: number;
 }
 
 export interface RestoreOptions {
@@ -127,6 +130,7 @@ export class DownloadQueue extends EventEmitter {
           status: "downloading",
           error: undefined,
           speed: 0,
+          ...(input.seedTimeMs !== undefined ? { seedTimeMs: input.seedTimeMs } : {}),
           ...(existing.dir === dir
             ? {}
             : { progress: 0, downloadedBytes: 0, eta: undefined }),
@@ -144,6 +148,7 @@ export class DownloadQueue extends EventEmitter {
           speed: 0,
           peers: 0,
           addedAt: Date.now(),
+          ...(input.seedTimeMs !== undefined ? { seedTimeMs: input.seedTimeMs } : {}),
         };
     // Respect the concurrent-download cap: start now if a slot is free, else
     // hold the torrent as "queued" until one frees (see promote()).
@@ -713,6 +718,30 @@ export class DownloadQueue extends EventEmitter {
     return this.history;
   }
 
+  // Set (or with undefined, clear) the per-torrent seed limit on a download
+  // still in flight or on a finished one. Returns false when the id is unknown
+  // to both, so a caller can answer not-found without a second lookup. The
+  // seed reaper reads the value from history, so a finished torrent's timer
+  // changes on its next tick; an in-flight one carries the value into history
+  // when it completes.
+  setSeedTime(id: string, seedTimeMs: number | undefined): boolean {
+    const it = this.items.get(id);
+    if (it) {
+      if (seedTimeMs === undefined) delete it.seedTimeMs;
+      else it.seedTimeMs = seedTimeMs;
+      void this.persist();
+    }
+    const h = this.history.find((x) => x.id === id);
+    if (h) {
+      if (seedTimeMs === undefined) delete h.seedTimeMs;
+      else h.seedTimeMs = seedTimeMs;
+      void saveHistory(this.history).catch(() => {});
+    }
+    if (!it && !h) return false;
+    this.changed();
+    return true;
+  }
+
   private recordHistory(it: QueueItem): void {
     const rec: HistoryItem = {
       id: it.id,
@@ -722,6 +751,7 @@ export class DownloadQueue extends EventEmitter {
       magnet: it.magnet,
       dir: it.dir,
       completedAt: Date.now(),
+      ...(it.seedTimeMs !== undefined ? { seedTimeMs: it.seedTimeMs } : {}),
     };
     this.history = [rec, ...this.history.filter((h) => h.id !== it.id)].slice(0, HISTORY_MAX);
     void saveHistory(this.history).catch(() => {});

--- a/src/download/types.ts
+++ b/src/download/types.ts
@@ -36,4 +36,6 @@ export interface QueueItem {
   files?: number;
   error?: string;
   addedAt: number;
+  // Carried from add() into the history entry on completion (see HistoryItem).
+  seedTimeMs?: number;
 }


### PR DESCRIPTION
## Why

`--seed-time` is one policy for the whole daemon. A seedbox that drops seeds after a couple of hours has no way to keep one release alive for a month short of restarting the daemon with a different flag or running a second one. The headless API grew per-torrent buttons in #105; this gives it a per-torrent seed limit to match.

## What

- `POST /add` takes an optional `seedTime` in the `--seed-time` grammar (`"30d"`, `"2h"`, a bare number is seconds; `0` = never stop this one). It belongs to that torrent alone and wins over the daemon-wide flag. An unusable value is a 400 and nothing is added.
- New `seed-time` control action sets or clears it later (`seedTime: ""` clears), including on a download still in flight.
- The value rides on the queue item into its history entry, so it survives restarts the same way `completedAt` does.
- The reaper now runs in `serve` and `watch` even without `--seed-time`; with no daemon-wide limit it only acts on torrents carrying their own, and with neither it does nothing. `seed` (the one-shot local seeder) is unchanged.
- `GET /downloads` reports `seedTimeMs` on downloads and `seedTimeMs` + `seedUntil` on seeds that have their own limit, so a caller can verify the setting took. Torrents inheriting the daemon default report nothing new, since that default is the caller's to know.

Watch mode is deliberately untouched: a `.magnet` file has nowhere to carry a limit, and the API is where a seedbox sets one anyway.

## Tests

`npm run typecheck` clean, `npm test` 392 passing (373 before). New coverage: reaper precedence (own limit over daemon-wide in both directions, 0 = never, per-torrent with no daemon limit, nothing with no limit at all), `extractSeedTime` on every input shape, `/add` forwarding and rejecting, the `seed-time` control action end to end, the status payload, and `setSeedTime` on both a history entry and an in-flight download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SKAohrRkqLKVQL2cGCAkR5
