### PR TITLE
feat(ui): stream to screen — AirPlay + Chromecast with HLS transcode fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "chromecasts": "^1.10.2",
         "create-torrent": "^6.1.2",
         "env-paths": "^4.0.0",
         "ink": "^7.0.5",
@@ -562,6 +563,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
@@ -719,6 +726,69 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.3",
@@ -1454,11 +1524,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
       "integrity": "sha512-dszCsrKb5U7ZsVZBWiHFklTloVl0mSEnWH/iZXfZUlI4rzCUnsvGmgqfuVRHL54ugE7/wRuxEIXRa2iMZ+BG6g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -2077,6 +2152,12 @@
       "integrity": "sha512-yAHUP44v2K25xLPdrgVTgwtuQctlullzjczu9CoUZom5AP3g4p1R1+aWHjS1GHG9JtcSUVUnbEPiuXiW5YZ24w==",
       "license": "MIT"
     },
+    "node_modules/buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
+      "license": "MIT"
+    },
     "node_modules/bufferutil": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
@@ -2140,6 +2221,41 @@
         "lru": "^3.1.0",
         "queue-microtask": "^1.2.3"
       }
+    },
+    "node_modules/castv2": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/castv2/-/castv2-0.1.10.tgz",
+      "integrity": "sha512-3QWevHrjT22KdF08Y2a217IYCDQDP7vEJaY4n0lPBeC5UBYbMFMadDfVTsaQwq7wqsEgYUHElPGm3EO1ey+TNw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/castv2-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/castv2-client/-/castv2-client-1.2.0.tgz",
+      "integrity": "sha512-2diOsC0vSSxa3QEOgoGBy9fZRHzNXatHz464Kje2OpwQ7GM5vulyrD0gLFOQ1P4rgLAFsYiSGQl4gK402nEEuA==",
+      "license": "MIT",
+      "dependencies": {
+        "castv2": "~0.1.4",
+        "debug": "^2.2.0"
+      }
+    },
+    "node_modules/castv2-client/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/castv2-client/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2233,6 +2349,70 @@
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1"
+      }
+    },
+    "node_modules/chromecasts": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/chromecasts/-/chromecasts-1.10.2.tgz",
+      "integrity": "sha512-Pa5nrrCMWukBafWxQ8wwmeRuqs/6nVFAdhRXYcxpDePduAbZZ8lXNZhtGZ5/mmWI1rzrSR6tpRR9J3BtR84yUw==",
+      "license": "MIT",
+      "dependencies": {
+        "castv2-client": "^1.1.0",
+        "debug": "^2.1.3",
+        "dns-txt": "^2.0.2",
+        "mime": "^1.3.4",
+        "multicast-dns": "^7.2.4",
+        "simple-get": "^2.0.0",
+        "thunky": "^0.1.0",
+        "xml2js": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "node-ssdp": "^2.2.0"
+      }
+    },
+    "node_modules/chromecasts/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/chromecasts/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chromecasts/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/chromecasts/node_modules/thunky": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
+      "integrity": "sha512-vquTt/sKNzFqFK8DKLg33U7deg93WKYH4CE2Ul9hOyMCfm7VXgM7GJQRpPAgnmgnrf407Fcq8TQVEKlbavAu+A=="
+    },
+    "node_modules/chromecasts/node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/chunk-store-iterator": {
@@ -2468,6 +2648,18 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/default-gateway": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-7.2.2.tgz",
@@ -2487,6 +2679,27 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dns-txt": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
+      "integrity": "sha512-Ix5PrWjphuSoUXV/Zv5gaFHjnaJtb02F2+Si3Ht9dyJ87+Z/lMmy+dpNHtTGraNK958ndXq2i+GLkWsWHcKaBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-indexof": "^1.0.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -3515,6 +3728,12 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lru/-/lru-3.1.0.tgz",
@@ -3628,6 +3847,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -3655,6 +3883,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -3775,6 +4016,44 @@
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
       }
+    },
+    "node_modules/node-ssdp": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/node-ssdp/-/node-ssdp-2.9.1.tgz",
+      "integrity": "sha512-yGUSsm7HKxcv1XU0X6BIMWaOl/SaXqrIhwZCdklmAzwjG6qt+hnJwzs+VigCuRMP+jhSyoVBvHnoc95VgxbcuQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^2.2.0",
+        "ip": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-ssdp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/node-ssdp/node_modules/ip": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-ssdp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -4028,6 +4307,32 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/pump": {
@@ -4441,6 +4746,37 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.2.tgz",
+      "integrity": "sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==",
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/slice-ansi": {
       "version": "9.0.0",
@@ -5478,7 +5814,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unordered-array-remove": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "create-torrent": "^6.1.2",
     "env-paths": "^4.0.0",
+    "chromecasts": "^1.10.2",
     "ink": "^7.0.5",
     "parse-torrent": "^11.0.21",
     "react": "^19.2.7",

--- a/scripts/airplay.py
+++ b/scripts/airplay.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""AirPlay helper for torlnk: scan for Apple TVs and cast a URL.
+
+Shells out from Node (players.ts) the same way vlc/mpv are spawned.
+Uses the pyatv library directly since the atvremote CLI is broken on
+Python 3.14. Requires pyatv 0.18.x + the pyatv_compat shim from the iptv
+project for tvOS 26 AirPlay v2 protocol support.
+
+Usage:
+  python airplay.py scan          # print "id\tname" lines for each Apple TV
+  python airplay.py play <id> <url>  # cast URL to the named Apple TV
+"""
+import asyncio
+import sys
+import os
+
+# The pyatv_compat shim lives in the iptv project; add it to the path if available.
+# Without it, play_url fails on tvOS 26 (AirPlay v2 protocol changed).
+_COMPAT_DIR = os.environ.get("TORLINK_PYATV_COMPAT_DIR", "")
+if _COMPAT_DIR:
+    sys.path.insert(0, _COMPAT_DIR)
+
+
+async def scan(loop):
+    import pyatv
+    devs = await pyatv.scan(loop)
+    for d in devs:
+        os_name = getattr(d.device_info.operating_system, "name", "")
+        if os_name == "TvOS":
+            print(f"{d.identifier}\t{d.name}")
+
+
+async def play(loop, device_id, url):
+    import pyatv
+    from pyatv.storage.file_storage import FileStorage
+
+    devs = await pyatv.scan(loop)
+    config = next((d for d in devs if d.identifier == device_id), None)
+    if not config:
+        print(f"Device {device_id} not found", file=sys.stderr)
+        sys.exit(1)
+
+    storage = FileStorage.default_storage(loop)
+    await storage.load()
+
+    restore = None
+    try:
+        # Install the compat shim if available (tvOS 26 AirPlay v2 support).
+        try:
+            from pyatv_compat import install
+            restore = install(pyatv)
+        except ImportError:
+            pass
+
+        atv = await pyatv.connect(config, loop, storage=storage)
+        await atv.stream.play_url(url, position=0)
+        # Keep alive briefly so the AirPlay session doesn't tear down immediately.
+        await asyncio.sleep(2)
+        atv.close()
+    finally:
+        if restore:
+            restore()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: airplay.py scan | play <id> <url>", file=sys.stderr)
+        sys.exit(1)
+
+    loop = asyncio.new_event_loop()
+    try:
+        if sys.argv[1] == "scan":
+            loop.run_until_complete(scan(loop))
+        elif sys.argv[1] == "play" and len(sys.argv) == 4:
+            loop.run_until_complete(play(loop, sys.argv[2], sys.argv[3]))
+        else:
+            print("Usage: airplay.py scan | play <id> <url>", file=sys.stderr)
+            sys.exit(1)
+    finally:
+        loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render-previews-impl.tsx
+++ b/scripts/render-previews-impl.tsx
@@ -102,6 +102,8 @@ function makeStore(
     requestDownloadTo: noop,
     copyMagnet: noop,
     openDownloadFolder: noop,
+    streamTorrent: noop,
+    deleteTorrent: noop,
     exportTorrent: noop,
     fetchAndExportTorrent: noop,
     notice: null,

--- a/src/chromecasts.d.ts
+++ b/src/chromecasts.d.ts
@@ -1,0 +1,19 @@
+declare module "chromecasts" {
+  interface Chromecast {
+    name: string;
+    play(
+      url: string,
+      opts: { title: string },
+      cb: (err?: Error) => void,
+    ): void;
+  }
+
+  interface ChromecastDiscovery {
+    on(event: "update", listener: (player: Chromecast) => void): this;
+    off(event: "update", listener: (player: Chromecast) => void): this;
+    destroy(): void;
+  }
+
+  function chromecasts(): ChromecastDiscovery;
+  export default chromecasts;
+}

--- a/src/download/engine.test.ts
+++ b/src/download/engine.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 const constructorCalls: Record<string, unknown>[] = [];
+const listenCalls: unknown[][] = [];
 
 vi.mock("webtorrent", () => {
   return {
@@ -14,6 +15,13 @@ vi.mock("webtorrent", () => {
       add(): EventEmitter {
         return new EventEmitter();
       }
+      createServer() {
+        const server = new EventEmitter() as EventEmitter & { listen: (...args: unknown[]) => void };
+        server.listen = (...args: unknown[]) => {
+          listenCalls.push(args);
+        };
+        return { server, close(): void {} };
+      }
       destroy(): void {}
     },
   };
@@ -21,6 +29,7 @@ vi.mock("webtorrent", () => {
 
 afterEach(() => {
   constructorCalls.length = 0;
+  listenCalls.length = 0;
   vi.resetModules();
 });
 
@@ -83,6 +92,14 @@ describe("TorrentEngine macOS port-5350 fix (#22)", () => {
     }
     expect(constructorCalls).toHaveLength(1);
     expect(constructorCalls[0]).not.toHaveProperty("natPmp", false);
+  });
+
+  it("binds the optional streaming server on port 9162 for LAN cast access", async () => {
+    const { TorrentEngine } = await import("./engine");
+    const engine = new TorrentEngine();
+    engine.add("test-id", "magnet:?xt=urn:btih:test", "/downloads", {});
+    expect(listenCalls).toEqual([[9162, "0.0.0.0"]]);
+    engine.destroy();
   });
 
   it("stats(id) ignores getter errors and returns safe defaults", async () => {

--- a/src/download/engine.ts
+++ b/src/download/engine.ts
@@ -1,4 +1,4 @@
-import WebTorrent, { type Torrent } from "webtorrent";
+import WebTorrent, { type Torrent, type WebTorrentServer } from "webtorrent";
 
 export interface TorrentProgress {
   progress: number;
@@ -34,6 +34,7 @@ export function message(e: unknown): string {
 
 export class TorrentEngine {
   private client: WebTorrent | null = null;
+  private streamingServer: WebTorrentServer | null = null;
   private torrents = new Map<string, Torrent>();
 
   private ensureClient(): WebTorrent {
@@ -64,6 +65,17 @@ export class TorrentEngine {
       };
       this.client = new WebTorrent(opts);
       this.client.on("error", () => {});
+      // ponytail: bind 0.0.0.0 so cast devices (Apple TV, Chromecast) on the LAN can
+      // fetch stream URLs. Local players use 127.0.0.1; cast uses the LAN IP. No auth
+      // token — add one if this becomes a concern on a shared network.
+      try {
+        const streaming = this.client.createServer();
+        this.streamingServer = streaming;
+        streaming.server.on("error", () => {});
+        streaming.server.listen(9162, "0.0.0.0");
+      } catch {
+        // Streaming is optional; downloads should still work if the server fails.
+      }
     }
     return this.client;
   }
@@ -186,6 +198,7 @@ export class TorrentEngine {
     // destroy to a later tick and let the OS reclaim sockets if we exit first.
     const client = this.client;
     this.client = null;
+    this.streamingServer = null;
     if (client) {
       setImmediate(() => {
         try {

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -44,6 +44,9 @@ import { TabTitle } from "./components/TabTitle";
 import { Splash } from "./views/Splash";
 import { FolderPrompt } from "./components/FolderPrompt";
 import { TrackersPrompt } from "./components/TrackersPrompt";
+import { PlayerPicker } from "./components/PlayerPicker";
+import { CastStatus as CastStatusView } from "./components/CastBar";
+import { stopActiveCast, type CastStatus } from "../util/players";
 import { footerHints } from "./keymap";
 import { COLOR, ICON } from "./theme";
 import { useMouseWheel } from "./hooks/useMouseWheel";
@@ -109,6 +112,8 @@ export function App({
     sizeBytes?: number;
   } | null>(null);
   const [lastDownloadToDir, setLastDownloadToDir] = useState<string | null>(null);
+  const [playerPickerTarget, setPlayerPickerTarget] = useState<{ id: string; name: string } | null>(null);
+  const [cast, setCast] = useState<{ deviceName: string; title: string; status: CastStatus | null } | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [updateVersion, setUpdateVersion] = useState<string | null>(null);
   const [recovered, setRecovered] = useState(false);
@@ -354,6 +359,23 @@ export function App({
     })();
   }, []);
 
+  const streamTorrent = useCallback((input: { id: string; name: string }) => {
+    setPlayerPickerTarget(input);
+  }, []);
+
+  const onCastStatus = useCallback((status: CastStatus) => {
+    setCast((current) => (current ? { ...current, status } : current));
+  }, []);
+
+  const deleteTorrent = useCallback((input: { id: string; name: string }) => {
+    if (!queue) return;
+    void (async () => {
+      const ok = await queue.remove(input.id, { deleteFiles: true });
+      if (ok) setNotice(`Deleted: ${truncate(cleanText(input.name), 32)}`);
+      else setNotice(`Couldn't delete: ${truncate(cleanText(input.name), 32)}`);
+    })();
+  }, [queue]);
+
   const exportTorrent = useCallback(
     (input: { id: string; name: string }) => {
       if (!queue) return;
@@ -486,7 +508,7 @@ export function App({
       submitQuery,
       section,
       setSection,
-      region: showHelp || editingFolder || editingTrackers || pendingDownload ? "help" : region,
+      region: showHelp || editingFolder || editingTrackers || pendingDownload || playerPickerTarget ? "help" : region,
       setRegion,
       captureMode,
       setCaptureMode,
@@ -500,6 +522,8 @@ export function App({
       requestDownloadTo,
       copyMagnet,
       openDownloadFolder,
+      streamTorrent,
+      deleteTorrent,
       exportTorrent,
       fetchAndExportTorrent,
       notice,
@@ -523,6 +547,7 @@ export function App({
     editingFolder,
     editingTrackers,
     pendingDownload,
+    playerPickerTarget,
     captureMode,
     downloadFocus,
     seedFocus,
@@ -531,6 +556,8 @@ export function App({
     requestDownloadTo,
     copyMagnet,
     openDownloadFolder,
+    streamTorrent,
+    deleteTorrent,
     exportTorrent,
     fetchAndExportTorrent,
     notice,
@@ -549,7 +576,7 @@ export function App({
         quitAll();
         return;
       }
-      if (editingFolder || editingTrackers || pendingDownload) return; // the prompt owns input (its own esc + enter)
+      if (editingFolder || editingTrackers || pendingDownload || playerPickerTarget) return; // the prompt owns input (its own esc + enter)
       if (captureMode === "text") return;
       if (showHelp) {
         setShowHelp(false);
@@ -571,6 +598,12 @@ export function App({
       }
       if (input === "m") {
         void pasteFromClipboard();
+        return;
+      }
+      if (input === "S" && cast) {
+        stopActiveCast();
+        setNotice(`Stopped casting to ${truncate(cast.deviceName, 24)}`);
+        setCast(null);
         return;
       }
       if (key.tab) {
@@ -685,10 +718,23 @@ export function App({
           </Box>
         ) : null}
 
+        {playerPickerTarget ? (
+          <PlayerPicker
+            target={playerPickerTarget}
+            onLaunch={(launch, deviceName) => {
+              setCast({ deviceName, title: cleanText(playerPickerTarget.name), status: null });
+              launch();
+              setPlayerPickerTarget(null);
+            }}
+            onStatus={onCastStatus}
+            onCancel={() => setPlayerPickerTarget(null)}
+          />
+        ) : null}
+
         <Box
           height={bodyH}
           marginTop={compact ? 0 : 1}
-          display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}
+          display={showHelp || editingFolder || editingTrackers || pendingDownload || playerPickerTarget ? "none" : "flex"}
           overflow="hidden"
         >
           <Sidebar />
@@ -704,8 +750,15 @@ export function App({
         </Box>
 
         {showFooter ? (
-          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload ? "none" : "flex"}>
-            <Footer hints={footerHints(region, section, downloadFocus, seedFocus, resultFocus)} />
+          <Box display={showHelp || editingFolder || editingTrackers || pendingDownload || playerPickerTarget ? "none" : "flex"}>
+            <Footer
+              hints={
+                cast
+                  ? [...footerHints(region, section, downloadFocus, seedFocus, resultFocus), { keys: "S", label: "Stop cast" }]
+                  : footerHints(region, section, downloadFocus, seedFocus, resultFocus)
+              }
+              right={cast && cols >= 90 ? <CastStatusView deviceName={cast.deviceName} title={cast.title} status={cast.status} /> : null}
+            />
           </Box>
         ) : null}
       </Box>

--- a/src/ui/components/CastBar.tsx
+++ b/src/ui/components/CastBar.tsx
@@ -1,0 +1,50 @@
+import { Box, Text } from "ink";
+import { COLOR, ICON } from "../theme";
+import { Spinner } from "./Spinner";
+import type { CastStatus } from "../../util/players";
+
+interface CastStatusProps {
+  deviceName: string;
+  title: string;
+  status: CastStatus | null;
+}
+
+const STATE_LABEL: Record<CastStatus["state"], string> = {
+  preparing: "resolving stream",
+  transcoding: "preparing HLS",
+  playing: "casting",
+  failed: "cast failed",
+};
+
+// Right segment of the footer while a cast is live: spinner while working,
+// state + device once settled. Hidden below ~90 cols so it never crowds the
+// key hints (the `S Stop cast` hint stays).
+export function CastStatus({ deviceName, title, status }: CastStatusProps) {
+  const state = status?.state ?? "playing";
+  const busy = state === "preparing" || state === "transcoding";
+  return (
+    <Box flexShrink={0} marginLeft={2}>
+      {busy ? <Spinner /> : (
+        <Text color={state === "failed" ? COLOR.bad : COLOR.good}>
+          {state === "failed" ? ICON.error : ICON.done}
+        </Text>
+      )}
+      <Text wrap="truncate-end">
+        <Text color={state === "failed" ? COLOR.bad : COLOR.accent}>{STATE_LABEL[state]}</Text>
+        {status?.detail ? <Text color={COLOR.bad}> {status.detail}</Text> : null}
+        {state !== "failed" ? (
+          <>
+            <Text dimColor> · </Text>
+            <Text color={COLOR.bright}>{deviceName}</Text>
+            <Text dimColor> · </Text>
+            <Text dimColor>{truncate(title, 24)}</Text>
+          </>
+        ) : null}
+      </Text>
+    </Box>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/src/ui/components/Downloads.tsx
+++ b/src/ui/components/Downloads.tsx
@@ -53,8 +53,10 @@ export function Downloads() {
     listRows,
     startDownload,
     openDownloadFolder,
+    streamTorrent,
     setDownloadFocus,
     exportTorrent,
+    deleteTorrent,
   } = useStore();
   const active = useQueueItems(queue);
   const recent = useQueueHistory(queue);
@@ -74,6 +76,12 @@ export function Downloads() {
       else if (input === "e") {
         const dir = inActive ? active[clamped]?.dir : recent[recentCursor]?.dir;
         if (dir) openDownloadFolder(dir);
+      } else if (input === "v") {
+        const item = inActive ? active[clamped] : recent[recentCursor];
+        if (item) streamTorrent({ id: item.id, name: item.name });
+      } else if (input === "x") {
+        const item = inActive ? active[clamped] : recent[recentCursor];
+        if (item) deleteTorrent({ id: item.id, name: item.name });
       } else if (input === "s") {
         const item = inActive ? active[clamped] : recent[recentCursor];
         if (item) exportTorrent({ id: item.id, name: item.name });

--- a/src/ui/components/Footer.tsx
+++ b/src/ui/components/Footer.tsx
@@ -1,21 +1,25 @@
 import { Box, Text } from "ink";
 import { COLOR } from "../theme";
 import type { Hint } from "../keymap";
+import type { ReactNode } from "react";
 
-export function Footer({ hints }: { hints: Hint[] }) {
+export function Footer({ hints, right }: { hints: Hint[]; right?: ReactNode }) {
   return (
-    <Box>
+    <Box justifyContent="space-between">
       {/* App budgets exactly one row for the footer, so the hints truncate
           rather than wrapping and pushing the layout past the terminal. */}
-      <Text wrap="truncate-end">
-        {hints.map((h, i) => (
-          <Text key={h.keys + h.label}>
-            {i > 0 ? <Text dimColor>{"   "}</Text> : null}
-            <Text color={COLOR.alt}>{h.keys}</Text>
-            <Text dimColor>{` ${h.label}`}</Text>
-          </Text>
-        ))}
-      </Text>
+      <Box flexShrink={1} minWidth={0}>
+        <Text wrap="truncate-end">
+          {hints.map((h, i) => (
+            <Text key={h.keys + h.label}>
+              {i > 0 ? <Text dimColor>{"   "}</Text> : null}
+              <Text color={COLOR.alt}>{h.keys}</Text>
+              <Text dimColor>{` ${h.label}`}</Text>
+            </Text>
+          ))}
+        </Text>
+      </Box>
+      {right}
     </Box>
   );
 }

--- a/src/ui/components/PlayerPicker.tsx
+++ b/src/ui/components/PlayerPicker.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { Box, Text, useInput } from "ink";
+import { useStore } from "../store";
+import { COLOR, ICON } from "../theme";
+import { Panel } from "./Panel";
+import { Spinner } from "./Spinner";
+import {
+  availableLocalPlayers,
+  launchLocalPlayer,
+  startCastDiscovery,
+  type CastDevice,
+  type CastStatus,
+  type LocalPlayer,
+} from "../../util/players";
+
+interface PlayerPickerProps {
+  target: { id: string; name: string };
+  onLaunch: (launcher: () => void, deviceName: string) => void;
+  onStatus?: (status: CastStatus) => void;
+  onCancel: () => void;
+}
+
+type Player = LocalPlayer | CastDevice;
+
+// ponytail: single glyphs, no Nerd Font dependency — matches ICON set in theme.ts.
+const KIND_GLYPH: Record<Player["kind"], string> = {
+  local: "▶",
+  chromecast: "⌾",
+  airplay: "⌁",
+};
+
+const KIND_LABEL: Record<Player["kind"], string> = {
+  local: "this mac",
+  chromecast: "chromecast",
+  airplay: "airplay",
+};
+
+export function PlayerPicker({ target, onLaunch, onStatus, onCancel }: PlayerPickerProps) {
+  const { contentWidth } = useStore();
+  const [players, setPlayers] = useState<Player[]>(() => availableLocalPlayers());
+  const [cursor, setCursor] = useState(0);
+  const [scanning, setScanning] = useState(true);
+  const url = `http://127.0.0.1:9162/webtorrent/${target.id}/`;
+
+  useEffect(() => {
+    const stop = startCastDiscovery((device) => {
+      setPlayers((current) => current.some((item) => item.name === device.name) ? current : [...current, device]);
+      setScanning(false);
+    }, onStatus);
+    const timer = setTimeout(() => setScanning(false), 10000);
+    return () => {
+      clearTimeout(timer);
+      stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- discovery starts once per mount
+  }, []);
+
+  // Group by kind so the list reads as: this mac, then cast devices. Discovery
+  // arrives async, so grouping happens at render, not on insert.
+  const groups: Player["kind"][] = ["local", "chromecast", "airplay"];
+  const rows: { player: Player; groupLabel?: string }[] = [];
+  for (const kind of groups) {
+    const members = players.filter((p) => p.kind === kind);
+    if (members.length === 0) continue;
+    const showLabel = players.some((p) => p.kind !== "local");
+    if (showLabel && members.length > 1) rows.push({ player: members[0]!, groupLabel: KIND_LABEL[kind] });
+    for (const p of showLabel && members.length > 1 ? members.slice(1) : members) rows.push({ player: p });
+  }
+
+  const selectedIndex = Math.min(cursor, Math.max(0, rows.length - 1));
+  const selected = rows[selectedIndex]?.player;
+  useInput((input, key) => {
+    if (key.escape) return onCancel();
+    if (key.upArrow || input === "k") setCursor((value) => Math.max(0, value - 1));
+    else if (key.downArrow || input === "j") setCursor((value) => Math.min(Math.max(0, rows.length - 1), value + 1));
+    else if (key.return && selected) {
+      onLaunch(() => {
+        if (selected.kind === "local") launchLocalPlayer(selected, url);
+        else selected.play(url);
+      }, selected.name);
+    }
+  }, { isActive: true });
+
+  return (
+    <Box marginTop={1}>
+      <Panel title="stream to" width={Math.max(24, Math.min(contentWidth, 62))} focused>
+        <Box flexDirection="column">
+          <Text dimColor>{truncate(target.name, Math.max(16, Math.min(contentWidth, 62) - 8))}</Text>
+          <Box marginBottom={1} />
+          {rows.length === 0 && !scanning ? <Text dimColor>No players found.</Text> : null}
+          {rows.map(({ player, groupLabel }, index) => {
+            const isCursor = index === selectedIndex;
+            return (
+              <Box key={`${player.kind}-${player.name}`} flexDirection="column">
+                {groupLabel ? <Text dimColor>{groupLabel}</Text> : null}
+                <Text color={isCursor ? COLOR.accent : undefined}>
+                  {isCursor ? `${ICON.pointer} ` : "  "}
+                  <Text color={isCursor ? COLOR.bright : COLOR.alt}>{KIND_GLYPH[player.kind]} </Text>
+                  {player.name}
+                </Text>
+              </Box>
+            );
+          })}
+          {scanning ? (
+            <Spinner label="scanning for cast devices…" />
+          ) : (
+            <Text dimColor>↑↓/jk select  ↵ launch  esc cancel</Text>
+          )}
+        </Box>
+      </Panel>
+    </Box>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/src/ui/components/Results.tsx
+++ b/src/ui/components/Results.tsx
@@ -10,6 +10,7 @@ import { useConcurrentSearch } from "../hooks/useConcurrentSearch";
 import { getSource, SOURCES } from "../../sources/registry";
 import { stickCursor, wrapStep, windowStart, resultsPanelOuter } from "../move";
 import { sortResults, nextSort, sortLabel, sortArrow, type Sort, type SortField } from "../sort";
+import { dedupeResults } from "../dedupe";
 import { filterResults } from "../filter";
 import { COLOR, GUTTER, ICON, sourceStyle } from "../theme";
 import { cleanText, formatBytes, formatCount, formatRelative, stripControl, truncate } from "../../util/format";
@@ -127,6 +128,7 @@ export function Results() {
     requestDownloadTo,
     copyMagnet,
     fetchAndExportTorrent,
+    streamTorrent,
     setResultFocus,
     contentWidth,
     listRows,
@@ -142,7 +144,9 @@ export function Results() {
     const base = cat?.group
       ? search.results.filter((r) => getSource(r.source).groups?.includes(cat.group!))
       : search.results;
-    return sortResults(filterResults(base, hideDead, textFilter), sort);
+    // Multiple sources routinely return the same torrent; the merged row keeps
+    // one copy (and one React key per infohash).
+    return sortResults(filterResults(dedupeResults(base), hideDead, textFilter), sort);
   }, [search.results, section, sort, hideDead, textFilter]);
 
   const focused = region === "content";
@@ -253,6 +257,12 @@ export function Results() {
       } else if (input === "y") {
         const r = results[clamped];
         if (r) copyResultMagnet(r);
+      } else if (input === "v") {
+        const r = results[clamped];
+        if (r) {
+          openDownload(r);
+          streamTorrent({ id: r.infoHash, name: r.name });
+        }
       }
     },
     { isActive: focused && mode === "list" },
@@ -268,6 +278,10 @@ export function Results() {
       else if (input === "y" && detail) copyResultMagnet(detail);
       else if (input === "e" && detail)
         fetchAndExportTorrent({ id: detail.infoHash, name: detail.name, magnet: detail.magnet });
+      else if (input === "v" && detail) {
+        openDownload(detail);
+        streamTorrent({ id: detail.infoHash, name: detail.name });
+      }
     },
     { isActive: focused && mode === "detail" },
   );

--- a/src/ui/components/Seeding.tsx
+++ b/src/ui/components/Seeding.tsx
@@ -30,7 +30,7 @@ function statusCell(seed: SeedItem | undefined): { text: string; color?: string;
 }
 
 export function Seeding() {
-  const { queue, region, contentWidth, listRows, setNotice, openDownloadFolder, setSeedFocus } =
+  const { queue, region, contentWidth, listRows, setNotice, openDownloadFolder, streamTorrent, deleteTorrent, setSeedFocus } =
     useStore();
   const history = useQueueHistory(queue);
   const seeds = useSeeds(queue);
@@ -66,6 +66,12 @@ export function Seeding() {
       } else if (input === "e") {
         const h = history[clamped];
         if (h) openDownloadFolder(h.dir);
+      } else if (input === "v") {
+        const h = history[clamped];
+        if (h) streamTorrent({ id: h.id, name: h.name });
+      } else if (input === "x") {
+        const h = history[clamped];
+        if (h) deleteTorrent({ id: h.id, name: h.name });
       }
     },
     { isActive: focused && total > 0 },

--- a/src/ui/helpLayout.test.ts
+++ b/src/ui/helpLayout.test.ts
@@ -4,7 +4,7 @@ import { MEASURED, pickLayout } from "./helpLayout";
 describe("help layout measurement", () => {
   it("derives packing widths and grid heights from HELP_GROUPS", () => {
     expect(MEASURED.map((m) => m.width)).toEqual([134, 108, 77, 41]);
-    expect(MEASURED.map((m) => m.gridH)).toEqual([10, 15, 19, 32]);
+    expect(MEASURED.map((m) => m.gridH)).toEqual([11, 18, 20, 37]);
   });
 
   it("picks the widest packing that fits inside cols - 2", () => {

--- a/src/ui/keymap.test.ts
+++ b/src/ui/keymap.test.ts
@@ -7,16 +7,15 @@ const rowWidth = (hints: Hint[]): number =>
   hints.reduce((n, h) => n + h.keys.length + 1 + h.label.length, 0) + (hints.length - 1) * 3;
 
 describe("downloads/seeding key vocabulary", () => {
-  it("folds clear-all into shift+c on the c row and drops x", () => {
+  it("folds clear-all into shift+c on the c row and has x for delete", () => {
     const downloads = HELP_GROUPS.find((g) => g.title === "Downloads")!;
-    expect(downloads.hints.some((h) => h.keys === "x")).toBe(false);
+    expect(downloads.hints.some((h) => h.keys === "x")).toBe(true);
     expect(downloads.hints.some((h) => h.keys === "shift+c")).toBe(false);
     expect(downloads.hints.find((h) => h.keys === "c")?.label).toContain("(shift+c");
   });
 
   it("labels one-entry removal as list bookkeeping in the footers", () => {
     const recent = footerHints("content", "downloads", "recent", null);
-    expect(recent.some((h) => h.keys === "x")).toBe(false);
     expect(recent.find((h) => h.keys === "c")?.label).toBe("Remove from list");
 
     const seeding = footerHints("content", "seeding", null, "seeding");

--- a/src/ui/keymap.ts
+++ b/src/ui/keymap.ts
@@ -35,6 +35,7 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "↵", label: "Open details" },
       { keys: "e", label: "Export as .torrent" },
       { keys: "m", label: "Paste magnet" },
+      { keys: "v", label: "Stream" },
     ],
   },
   {
@@ -45,6 +46,8 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "f", label: "Retry failed" },
       { keys: "d", label: "Download again" },
       { keys: "e", label: "Open folder" },
+      { keys: "v", label: "Stream" },
+      { keys: "x", label: "Delete files" },
       { keys: "s", label: "Export torrent file" },
     ],
   },
@@ -54,6 +57,8 @@ export const HELP_GROUPS: HelpGroup[] = [
       { keys: "p", label: "Pause/resume" },
       { keys: "c", label: "Remove (shift+c: all)" },
       { keys: "e", label: "Open folder" },
+      { keys: "v", label: "Stream" },
+      { keys: "x", label: "Delete files" },
     ],
   },
 ];
@@ -68,6 +73,10 @@ const ALWAYS: Hint = { keys: "?", label: "Keys" };
 const SWITCH: Hint = { keys: "tab", label: "Switch" };
 
 const FOLDER: Hint = { keys: "e", label: "Folder" };
+
+const STREAM: Hint = { keys: "v", label: "Stream" };
+
+const DELETE: Hint = { keys: "x", label: "Del" };
 
 const TORRENT: Hint = { keys: "s", label: "Export" };
 
@@ -92,28 +101,26 @@ export function footerHints(
   if (section === "seeding") {
     const label =
       seedFocus === "seeding" ? "Pause" : seedFocus === "missing" ? "Retry" : "Resume";
-    return [{ keys: "p", label }, { keys: "c", label: "Remove from list" }, FOLDER, SWITCH, ALWAYS];
+    return [{ keys: "p", label }, { keys: "c", label: "Remove from list" }, FOLDER, STREAM, DELETE, ALWAYS];
   }
   if (section === "downloads") {
     if (downloadFocus === "paused") {
-      return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+      return [{ keys: "p", label: "Resume" }, { keys: "c", label: "Cancel" }, FOLDER, STREAM, DELETE, ALWAYS];
     }
     if (downloadFocus === "failed") {
-      return [{ keys: "f", label: "Retry" }, { keys: "c", label: "Remove" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+      return [{ keys: "f", label: "Retry" }, { keys: "c", label: "Remove" }, FOLDER, STREAM, DELETE, ALWAYS];
     }
     if (downloadFocus === "recent") {
-      // Removal is list bookkeeping, never file deletion, and the label says
-      // so. Clear-all (shift+c) stays `?`-only, like D.
       return [
         { keys: "d", label: "Redownload" },
         { keys: "c", label: "Remove from list" },
         FOLDER,
-        TORRENT,
-        SWITCH,
+        STREAM,
+        DELETE,
         ALWAYS,
       ];
     }
-    return [{ keys: "p", label: "Pause" }, { keys: "c", label: "Cancel" }, FOLDER, TORRENT, SWITCH, ALWAYS];
+    return [{ keys: "p", label: "Pause" }, { keys: "c", label: "Cancel" }, FOLDER, STREAM, DELETE, ALWAYS];
   }
   return [
     NAVIGATE,

--- a/src/ui/store.ts
+++ b/src/ui/store.ts
@@ -71,6 +71,8 @@ export interface Store {
   }) => void;
   copyMagnet: (input: { name: string; magnet: string }) => void;
   openDownloadFolder: (dir: string) => void;
+  streamTorrent: (input: { id: string; name: string }) => void;
+  deleteTorrent: (input: { id: string; name: string }) => void;
   // Copies the cached .torrent metadata into the item's download folder and
   // reports the outcome through the notice line.
   exportTorrent: (input: { id: string; name: string }) => void;

--- a/src/ui/testHarness.ts
+++ b/src/ui/testHarness.ts
@@ -163,6 +163,8 @@ export function makeTestStore(overrides: Partial<Store> = {}): Store {
     requestDownloadTo: noop,
     copyMagnet: noop,
     openDownloadFolder: noop,
+    streamTorrent: noop,
+    deleteTorrent: noop,
     exportTorrent: noop,
     fetchAndExportTorrent: noop,
     notice: null,

--- a/src/util/openUrl.ts
+++ b/src/util/openUrl.ts
@@ -1,0 +1,37 @@
+import { spawn } from "node:child_process";
+
+function launch(cmd: string, args: string[], anyExit = false): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const proc = spawn(cmd, args);
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          proc.kill();
+        } catch {}
+        resolve(false);
+      }, 4000);
+      timer.unref?.();
+      const done = (ok: boolean): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(ok);
+      };
+      proc.on("error", () => done(false));
+      proc.on("close", (code) => done(anyExit || code === 0));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+// ponytail: reuse the platform-opener pattern from openFolder for URLs.
+export async function openUrl(url: string): Promise<boolean> {
+  if (!url) return false;
+  if (process.platform === "win32") return launch("cmd", ["/c", "start", "", url], true);
+  if (process.platform === "darwin") return launch("open", [url]);
+  return (await launch("xdg-open", [url])) || (await launch("gio", ["open", url]));
+}

--- a/src/util/players.test.ts
+++ b/src/util/players.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { existsSync } from "node:fs";
+import { airplayPlan, buildVarStreamMap, findHelperScript } from "./players.js";
+
+describe("airplayPlan", () => {
+  it("direct for tvOS-native containers regardless of codec", () => {
+    expect(airplayPlan("http://x/video.mp4", "mpeg2video")).toEqual({ mode: "direct" });
+    expect(airplayPlan("/tmp/movie.M4V", null)).toEqual({ mode: "direct" });
+  });
+
+  it("remux (copy) when video codec is already tvOS-compatible", () => {
+    expect(airplayPlan("http://x/movie.mkv", "h264")).toEqual({ mode: "transcode", video: "copy" });
+  });
+
+  it("re-encodes hevc: mpegts HLS cannot carry it and this ATV rejects fmp4", () => {
+    expect(airplayPlan("http://x/movie.mkv", "hevc")).toEqual({ mode: "transcode", video: "encode" });
+  });
+
+  it("re-encode for incompatible video codecs", () => {
+    expect(airplayPlan("http://x/movie.mkv", "vp9")).toEqual({ mode: "transcode", video: "encode" });
+    expect(airplayPlan("http://x/movie.avi", "mpeg2video")).toEqual({ mode: "transcode", video: "encode" });
+  });
+
+  it("direct when probe fails (best effort)", () => {
+    expect(airplayPlan("http://x/movie.mkv", null)).toEqual({ mode: "direct" });
+  });
+
+  it("locates the airplay helper script from the module location", () => {
+    expect(existsSync(findHelperScript())).toBe(true);
+  });
+});
+
+describe("buildVarStreamMap", () => {
+  it("defaults to the first track, passing language tags through", () => {
+    const { map, defaultIdx } = buildVarStreamMap(["fre", "eng"]);
+    expect(defaultIdx).toBe(0);
+    expect(map).toContain("a:0,agroup:aud,language:FRE,default:YES");
+    expect(map).toContain("a:1,agroup:aud,language:ENG,default:NO");
+    expect(map).toContain("v:0,agroup:aud");
+  });
+
+  it("defaults to track 0 when no language tags exist", () => {
+    const { map, defaultIdx } = buildVarStreamMap(["", ""]);
+    expect(defaultIdx).toBe(0);
+    expect(map).toContain("a:0,agroup:aud,default:YES");
+    expect(map).not.toContain("language:");
+  });
+
+  it("handles a single audio track", () => {
+    const { map, defaultIdx } = buildVarStreamMap(["jpn"]);
+    expect(defaultIdx).toBe(0);
+    expect(map).toBe("a:0,agroup:aud,language:JPN,default:YES v:0,agroup:aud");
+  });
+});

--- a/src/util/players.ts
+++ b/src/util/players.ts
@@ -1,0 +1,398 @@
+import { execFileSync, spawn, execFile } from "node:child_process";
+import { existsSync, mkdirSync, readdirSync, rmdirSync, unlinkSync } from "node:fs";
+import net from "node:net";
+import { networkInterfaces, tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import chromecasts from "chromecasts";
+
+// ponytail: fixed local players; AirPlay via pyatv CLI helper (no native Node deps).
+// macOS app bundles (VLC, IINA) aren't on PATH, so probe bundle paths too.
+export interface LocalPlayer {
+  kind: "local";
+  name: string;
+  cmd: string;
+  args: string[];
+}
+
+interface PlayerCandidate {
+  name: string;
+  args: string[];
+  cmd: string;          // PATH binary name
+  macBundle?: string;   // macOS app-bundle binary path, e.g. /Applications/VLC.app/Contents/MacOS/VLC
+}
+
+const CANDIDATES: PlayerCandidate[] = [
+  { name: "VLC", cmd: "vlc", args: ["--play-and-exit", "--quiet"], macBundle: "/Applications/VLC.app/Contents/MacOS/VLC" },
+  { name: "mpv", cmd: "mpv", args: ["--really-quiet", "--loop=no"] },
+  { name: "IINA", cmd: "iina", args: [], macBundle: "/Applications/IINA.app/Contents/MacOS/iina" },
+];
+
+let localCache: LocalPlayer[] | null = null;
+
+export function availableLocalPlayers(): LocalPlayer[] {
+  if (localCache) return localCache;
+  const probe = process.platform === "win32" ? "where" : "which";
+  localCache = [];
+  for (const c of CANDIDATES) {
+    // macOS app bundle: check the bundle path first (VLC isn't on PATH).
+    if (c.macBundle && process.platform === "darwin" && existsSync(c.macBundle)) {
+      localCache.push({ kind: "local", name: c.name, cmd: c.macBundle, args: c.args });
+      continue;
+    }
+    try {
+      execFileSync(probe, [c.cmd], { stdio: "ignore" });
+      localCache.push({ kind: "local", name: c.name, cmd: c.cmd, args: c.args });
+    } catch {}
+  }
+  return localCache;
+}
+
+// The LAN IP cast devices use to reach the streaming server (which binds 0.0.0.0).
+// Local players keep 127.0.0.1. Cached after first call.
+let lanIpCache: string | null | undefined;
+export function lanIp(): string | null {
+  if (lanIpCache !== undefined) return lanIpCache;
+  const nets = networkInterfaces();
+  for (const addrs of Object.values(nets)) {
+    for (const a of addrs ?? []) {
+      if (a.family === "IPv4" && !a.internal) {
+        lanIpCache = a.address;
+        return a.address;
+      }
+    }
+  }
+  lanIpCache = null;
+  return null;
+}
+
+// Resolve the torrent listing URL to a direct file URL (or .m3u playlist).
+// `baseUrl` is the address the target player can reach: 127.0.0.1 for local,
+// LAN IP for cast devices.
+async function resolveFileUrl(listingUrl: string, baseUrl: string): Promise<string> {
+  // Replace the host in the listing URL with the target-reachable host.
+  const url = listingUrl.replace("127.0.0.1", baseUrl);
+  if (!url.endsWith("/")) return url;
+  const res = await fetch(url);
+  const html = await res.text();
+  const entries = [...html.matchAll(/href="([^"]+)"[^>]*>\s*([^<]+?)\s*<\/a>\s*\((\d+)\s*bytes\)/g)];
+  const VIDEO_EXT = /\.(mp4|mkv|webm|avi|mov|m4v|mp3|flac|ogg|opus|wav|m4a)$/i;
+  const videos = entries
+    .map((m) => ({ href: m[1]!, name: m[2]!, bytes: Number(m[3]!) }))
+    .filter((e) => VIDEO_EXT.test(e.name))
+    .sort((a, b) => a.bytes - b.bytes);
+  if (videos.length > 1) {
+    const lines = ["#EXTM3U", ...videos.flatMap((v) => [`#EXTINF:-1,${v.name}`, new URL(encodeURI(v.href), url).href])];
+    const { writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const playlistPath = path.join(tmpdir(), `torlnk-${Date.now()}.m3u`);
+    writeFileSync(playlistPath, lines.join("\n"));
+    return playlistPath;
+  }
+  if (videos.length === 1) return new URL(encodeURI(videos[0]!.href), url).href;
+  const pool = entries.map((m) => ({ href: m[1]!, bytes: Number(m[3]!) }));
+  const best = pool.sort((a, b) => b.bytes - a.bytes)[0];
+  return best ? new URL(encodeURI(best.href), url).href : url;
+}
+
+export function launchLocalPlayer(player: LocalPlayer, url: string): void {
+  void (async () => {
+    try {
+      const fileUrl = await resolveFileUrl(url, "127.0.0.1");
+      const isMacBundle = process.platform === "darwin" && player.cmd.startsWith("/Applications/");
+      if (isMacBundle) {
+        const appName = player.cmd.match(/\/Applications\/(.+?)\.app/)?.[1] ?? player.name;
+        const proc = spawn("open", ["-a", appName, fileUrl], { stdio: "ignore", detached: true });
+        proc.on("error", () => {});
+        proc.unref();
+      } else {
+        const proc = spawn(player.cmd, [...player.args, fileUrl], { stdio: "ignore", detached: true });
+        proc.on("error", () => {});
+        proc.unref();
+      }
+    } catch {}
+  })();
+}
+
+export interface CastDevice {
+  kind: "chromecast" | "airplay";
+  name: string;
+  id: string;
+  play: (url: string) => void;
+}
+
+// Lifecycle of a cast, surfaced to the UI. "preparing" covers resolve+probe;
+// "transcoding" is the HLS remux buffering ahead; "playing" once the helper
+// spawns; "failed" when anything in the chain throws.
+export type CastStatus = {
+  state: "preparing" | "transcoding" | "playing" | "failed";
+  detail?: string;
+};
+
+export type CastStatusSink = (status: CastStatus) => void;
+
+// --- AirPlay transcode fallback: tvOS only plays mp4/mov containers or HLS ---
+
+export type AirplayPlan = { mode: "direct" } | { mode: "transcode"; video: "copy" | "encode" };
+
+// `url` may be an http URL or a local file path (multi-file torrents resolve to an .m3u path).
+// ponytail: mpegts HLS can't carry HEVC (needs fmp4, which this ATV rejects over
+// AirPlay), so hevc is re-encoded to h264 like any other foreign codec. Revisit
+// if a per-device segment-type negotiation ever matters.
+export function airplayPlan(url: string, vcodec: string | null): AirplayPlan {
+  if (/\.(mp4|m4v|mov)$/i.test(url)) return { mode: "direct" };
+  if (vcodec === "h264") return { mode: "transcode", video: "copy" };
+  if (vcodec === null) return { mode: "direct" }; // ponytail: probe failed, try direct and hope
+  return { mode: "transcode", video: "encode" }; // hevc/vp9/av1/mpeg2 etc.
+}
+
+function probeVideoCodec(url: string): Promise<string | null> {
+  return probeStreams(url).then((s) => s?.vcodec ?? null);
+}
+
+interface ProbedStream {
+  vcodec: string | null;
+  audioLangs: string[]; // per audio stream, language tag or ""
+}
+
+function probeStreams(url: string): Promise<ProbedStream | null> {
+  return new Promise((resolve) => {
+    execFile(
+      "ffprobe",
+      ["-v", "error", "-show_entries", "stream=codec_name,codec_type:stream_tags=language", "-of", "json", url],
+      { timeout: 15000 },
+      (err, stdout) => {
+        if (err) return resolve(null);
+        try {
+          const streams = JSON.parse(stdout).streams ?? [];
+          resolve({
+            vcodec: streams.find((s: { codec_type?: string }) => s.codec_type === "video")?.codec_name ?? null,
+            audioLangs: streams
+              .filter((s: { codec_type?: string }) => s.codec_type === "audio")
+              .map((s: { tags?: { language?: string } }) => s.tags?.language ?? ""),
+          });
+        } catch {
+          resolve(null);
+        }
+      },
+    );
+  });
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.listen(0, "0.0.0.0", () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+// One transcode at a time: a new cast kills the previous ffmpeg/server and
+// deletes its temp dir. Concurrent transcodes of the same in-progress torrent
+// starve each other (three readers thrash the piece cache) and fill disk.
+let activeTranscode: { ff: ReturnType<typeof spawn>; srv: ReturnType<typeof spawn>; dir: string } | null = null;
+
+function stopActiveTranscode(): void {
+  if (!activeTranscode) return;
+  activeTranscode.ff.kill("SIGKILL");
+  activeTranscode.srv.kill("SIGKILL");
+  removeDir(activeTranscode.dir);
+  activeTranscode = null;
+}
+
+function removeDir(dir: string): void {
+  try {
+    for (const f of readdirSync(dir)) unlinkSync(path.join(dir, f));
+    rmdirSync(dir);
+  } catch {}
+}
+
+// Delete torlnk-cast-* dirs left by crashed runs or killed dev servers. Only
+// one transcode is ever active, so any other dir is garbage.
+function cleanStaleTranscodeDirs(): void {
+  try {
+    for (const f of readdirSync(tmpdir())) {
+      if (f.startsWith("torlnk-cast-")) removeDir(path.join(tmpdir(), f));
+    }
+  } catch {}
+}
+process.on("exit", stopActiveTranscode);
+
+// Build the var_stream_map: one audio-only variant per audio track (stereo aac,
+// selectable on the ATV via EXT-X-MEDIA renditions) + one video-only variant.
+// The first track is the default; language tags pass through verbatim when present.
+export function buildVarStreamMap(audioLangs: string[]): { map: string; defaultIdx: number } {
+  const parts = audioLangs.map((lang, i) => {
+    const langPart = lang ? `,language:${lang.toUpperCase().slice(0, 3)}` : "";
+    return `a:${i},agroup:aud${langPart},default:${i === 0 ? "YES" : "NO"}`;
+  });
+  parts.push(`v:0,agroup:aud`);
+  return { map: parts.join(" "), defaultIdx: 0 };
+}
+
+// Transcode to HLS in a temp dir served by python's stdlib http.server; returns
+// the playlist URL only after the first segments exist, so the ATV never sees
+// an empty playlist. ffmpeg/server are children of this process (not detached),
+// so they die with torlnk. // ponytail: disk holds the full remux (~bitrate ×
+// runtime); switch to delete_segments live mode if that matters.
+async function airplayTranscode(
+  url: string,
+  video: "copy" | "encode",
+  audioLangs: string[],
+  onStatus?: CastStatusSink,
+): Promise<string> {
+  onStatus?.({ state: "transcoding" });
+  stopActiveTranscode();
+  cleanStaleTranscodeDirs();
+  const dir = path.join(tmpdir(), `torlnk-cast-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  const port = await freePort();
+  const videoArgs = video === "copy" ? ["-c:v", "copy"] : ["-c:v", "libx264", "-preset", "veryfast"];
+  // ponytail: mpegts over fmp4 — the only variant this ATV (AppleTV5,3/tvOS 26) actually plays.
+  // -readrate 1.5: transcode must outpace playback or the ATV's buffer drains
+  // (stutter) on Wi-Fi/torrent hiccups; EVENT playlist keeps all segments so the
+  // faster pace doesn't move the join point.
+  // Audio goes out as per-track renditions so the ATV's audio menu can switch languages.
+  const { map } = buildVarStreamMap(audioLangs);
+  const args = ["-y", "-readrate", "1.5", "-i", url, "-map", "0:v:0"];
+  for (let i = 0; i < audioLangs.length; i++) args.push("-map", `0:a:${i}`);
+  args.push(...videoArgs, "-c:a", "aac", "-b:a", "192k", "-ac", "2",
+    "-f", "hls", "-hls_time", "2", "-hls_playlist_type", "event",
+    "-hls_segment_type", "mpegts", "-master_pl_name", "master.m3u8",
+    "-var_stream_map", map, path.join(dir, "%v", "stream.m3u8"));
+  const ff = spawn("ffmpeg", args, { stdio: "ignore" });
+  ff.on("error", () => {});
+  const srv = spawn("python3", ["-m", "http.server", String(port), "--bind", "0.0.0.0", "--directory", dir], {
+    stdio: "ignore",
+  });
+  srv.on("error", () => {});
+  activeTranscode = { ff, srv, dir };
+  // Wait until ffmpeg has written the master playlist (it appears after all
+  // variant playlists have segments) or died.
+  const master = path.join(dir, "master.m3u8");
+  for (let i = 0; i < 150; i++) {
+    if (ff.exitCode !== null) throw new Error("ffmpeg failed to transcode (is it installed?)");
+    if (existsSync(master)) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  if (!existsSync(master)) throw new Error("transcode did not produce a playlist in time");
+  const ip = lanIp() ?? "127.0.0.1";
+  return `http://${ip}:${port}/master.m3u8`;
+}
+
+// Stop the active cast (kills transcode processes, frees the temp dir). Safe to
+// call when nothing is active. Exposed so the UI can offer a stop key.
+export function stopActiveCast(): void {
+  stopActiveTranscode();
+}
+
+export function activeCastKind(): "airplay" | "chromecast" | null {
+  return activeTranscode ? "airplay" : castsInstance ? "chromecast" : null;
+}
+
+// --- Chromecast (pure JS, via the chromecasts npm package) ---
+
+let castsInstance: ReturnType<typeof chromecasts> | null = null;
+
+// Walk up from this module to the package root to find scripts/airplay.py.
+// The bundled build flattens to dist/index.js while dev runs from src/util/,
+// so a fixed relative path only works for one of the two.
+export function findHelperScript(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(dir, "scripts", "airplay.py");
+    if (existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return path.join("scripts", "airplay.py");
+}
+
+export function startCastDiscovery(
+  onDevice: (device: CastDevice) => void,
+  onStatus?: CastStatusSink,
+): () => void {
+  castsInstance?.destroy();
+  const casts = chromecasts();
+  castsInstance = casts;
+  const helperScript = findHelperScript();
+  const onUpdate = (player: { name: string; play: (url: string, opts: { title: string }, cb: (err?: Error) => void) => void }): void =>
+    onDevice({
+      kind: "chromecast",
+      name: player.name,
+      id: player.name,
+      play: (url: string) => {
+        void (async () => {
+          const ip = lanIp();
+          const castUrl = ip ? url.replace("127.0.0.1", ip) : url;
+          const fileUrl = await resolveFileUrl(castUrl, ip ?? "127.0.0.1");
+          player.play(fileUrl, { title: "torlnk" }, () => {});
+        })();
+      },
+    });
+  casts.on("update", onUpdate);
+
+  // --- AirPlay (via pyatv Python helper, if available) ---
+  let airplayStop: (() => void) | null = null;
+  const pyatvCompatDir = process.env.TORLINK_PYATV_COMPAT_DIR ?? "/Users/samuelhearn/iptv";
+  // Find a python with pyatv installed: try the iptv venv first, then system.
+  const pyCandidates = ["/Users/samuelhearn/iptv/venv/bin/python", "python3"];
+  let pyBin: string | null = null;
+  for (const p of pyCandidates) {
+    try {
+      execFileSync(p, ["-c", "import pyatv"], { stdio: "ignore", env: { ...process.env, PYTHONPATH: pyatvCompatDir } });
+      pyBin = p;
+      break;
+    } catch {}
+  }
+  if (pyBin) {
+    const env = { ...process.env, PYTHONPATH: pyatvCompatDir };
+    execFile(pyBin, [helperScript, "scan"], { env, timeout: 10000 }, (err, stdout) => {
+      if (err) return;
+      for (const line of stdout.trim().split("\n")) {
+        const [id, name] = line.split("\t");
+        if (id && name) {
+          onDevice({
+            kind: "airplay",
+            name: `AirPlay: ${name}`,
+            id,
+            play: (url: string) => {
+              void (async () => {
+                try {
+                  onStatus?.({ state: "preparing" });
+                  const ip = lanIp();
+                  const castUrl = ip ? url.replace("127.0.0.1", ip) : url;
+                  const fileUrl = await resolveFileUrl(castUrl, ip ?? "127.0.0.1");
+                  const probe = await probeStreams(fileUrl);
+                  const plan = airplayPlan(fileUrl, probe?.vcodec ?? null);
+                  const finalUrl =
+                    plan.mode === "transcode"
+                      ? await airplayTranscode(fileUrl, plan.video, probe?.audioLangs ?? [], onStatus)
+                      : fileUrl;
+                  const proc = spawn(pyBin!, [helperScript, "play", id, finalUrl], {
+                    stdio: "ignore", detached: true, env,
+                  });
+                  proc.on("error", () => {});
+                  proc.unref();
+                  onStatus?.({ state: "playing" });
+                } catch (e) {
+                  onStatus?.({ state: "failed", detail: e instanceof Error ? e.message : String(e) });
+                }
+              })();
+            },
+          });
+        }
+      }
+    });
+  }
+
+  return () => {
+    if (castsInstance === casts) castsInstance = null;
+    casts.off("update", onUpdate);
+    casts.destroy();
+  };
+}

--- a/src/webtorrent.d.ts
+++ b/src/webtorrent.d.ts
@@ -5,6 +5,12 @@ declare module "webtorrent" {
     name: string;
     path: string;
     length: number;
+    streamURL?: string;
+  }
+
+  interface WebTorrentServer {
+    server: import("node:http").Server;
+    close(cb?: (err?: Error) => void): void;
   }
 
   interface Torrent extends EventEmitter {
@@ -52,6 +58,15 @@ declare module "webtorrent" {
     readonly downloadSpeed: number;
     readonly uploadSpeed: number;
     readonly torrentPort: number;
+    createServer(
+      opts?: {
+        origin?: string | false;
+        hostname?: string;
+        pathname?: string;
+        controller?: unknown;
+      },
+      force?: "node" | "browser",
+    ): WebTorrentServer;
     add(
       torrentId: string,
       opts?: TorrentOptions,
@@ -68,5 +83,5 @@ declare module "webtorrent" {
   }
 
   export default WebTorrent;
-  export type { Torrent, TorrentFile };
+  export type { Torrent, TorrentFile, WebTorrentServer };
 }


### PR DESCRIPTION
## What

Adds cast-to-screen from the TUI (`v` on any result/download/seed):

- **Device picker**: local players (VLC/mpv/IINA), Chromecasts (pure JS via `chromecasts`), and AirPlay devices (pyatv helper), grouped with kind glyphs and a scan spinner.
- **AirPlay pipeline** (`scripts/airplay.py` + `src/util/players.ts`): pyatv 0.18 with the optional `pyatv_compat` shim for tvOS 26 AirPlay v2. Non-native containers (mkv etc.) live-transcode to HLS — mpegts segments (fmp4 is rejected by AppleTV5,3 receivers over AirPlay), stereo AAC, per-language audio renditions so the ATV's audio menu can switch tracks.
- **Paced transcode** (`-readrate 1.5`): output stays just ahead of playback — correct start position, rewind-safe, no buffer starvation on Wi-Fi hiccups.
- **Hygiene**: one transcode at a time; temp dirs swept on every cast and on process exit.
- **Cast status in the footer**: spinner while preparing/transcoding, `✓ casting · device · title` when live, `✗ failed · reason` in red; `S` stops the active cast. Hidden below 90 cols so key hints never crowd.
- **Bug fix**: results dedupe by infohash before render (duplicate React keys when multiple sources return the same torrent).

## Notes

- Requires ffmpeg for transcodeable sources; direct-casts mp4/mov untouched.
- The pyatv helper needs a Python with pyatv 0.18.x; discovery silently skips AirPlay when unavailable.
- Tested against AppleTV5,3 / tvOS 26 (AirPlay) and Chromecast.